### PR TITLE
docs: fix drop transaction param type

### DIFF
--- a/site/docs/actions/test/dropTransaction.md
+++ b/site/docs/actions/test/dropTransaction.md
@@ -30,7 +30,7 @@ await testClient.dropTransaction({ // [!code focus:4]
 
 ### hash
 
-- **Type:** ``"0x${string}"``
+- **Type:** [`Hash`](/docs/glossary/types#hash)
 
 The hash of the transaction.
 


### PR DESCRIPTION
Prefer `Hash` over `$0x{string}` type in docs and link to the `Hash` glossary.