### PR TITLE
docs: fix home page

### DIFF
--- a/site/.vitepress/theme/components/HomeSponsors.vue
+++ b/site/.vitepress/theme/components/HomeSponsors.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { VPButton, VPIconHeart, VPSponsors } from 'vitepress/theme';
 import { sponsors } from '../sponsors'
 </script>
 
@@ -28,6 +27,7 @@ import { sponsors } from '../sponsors'
 
 <style scoped>
 .VPHomeSponsors {
+  margin-top: 0 !important;
   padding-top: 40px;
   background-color: var(--vp-c-bg);
 }

--- a/site/.vitepress/theme/components/HomeSponsors.vue
+++ b/site/.vitepress/theme/components/HomeSponsors.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { VPButton, VPIconHeart, VPSponsors } from 'vitepress/theme'
 import { sponsors } from '../sponsors'
 </script>
 

--- a/site/index.md
+++ b/site/index.md
@@ -4,12 +4,15 @@ editLink: false
 title: viem
 titleTemplate: :title · TypeScript Interface for Ethereum
 description: Build reliable Ethereum apps & libraries with lightweight, composable, & type-safe modules from viem.
+layout: home
 ---
 
 <script setup lang="ts">
 import { VPButton } from 'vitepress/theme'
 import HomeSponsors from './.vitepress/theme/components/HomeSponsors.vue'
 </script>
+
+<div class="max-w-[1120px] mx-auto vp-doc relative px-[24px] mb-[96px] mt-[32px] md:px-0 md:mb-[64px]">
 
 <div class="pt-[48px] max-sm:pt-0">
   <div class="absolute -left-28 right-0 -top-10 bottom-0 bg-[url('/colosseum-light.svg')] dark:bg-[url('/colosseum.svg')] bg-no-repeat z-[-1] max-sm:w-[200%] max-sm:-left-[200px] max-sm:hidden" />
@@ -136,17 +139,17 @@ yarn add viem
 
 ```ts
 // 1. Import modules.
-import { createPublicClient, http } from 'viem';
-import { mainnet } from 'viem/chains';
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
 
 // 2. Set up your client with desired chain & transport.
 const client = createPublicClient({
   chain: mainnet,
   transport: http(),
-});
+})
 
 // 3. Consume an action!
-const blockNumber = await client.getBlockNumber();
+const blockNumber = await client.getBlockNumber()
 ```
 
 <div class="h-8" />
@@ -189,18 +192,6 @@ Help support future development and make wagmi a sustainable open-source project
 
 <HomeSponsors />
 </div>
-
-<style>
-  .VPDoc .container {
-    max-width: 1120px !important;
-  }
-
-  .VPDoc .content {
-    max-width: 100% !important;
-    padding: 0px !important;
-    width: 100% !important;
-  }
-</style>
 
 <style scoped>
   html:not(.dark) img.dark {
@@ -264,3 +255,5 @@ Help support future development and make wagmi a sustainable open-source project
     justify-content: center;
   }
 </style>
+
+</div>


### PR DESCRIPTION
Hi, just noticed a weird bug where toc has no padding:

![CleanShot 2023-03-07 at 19 10 12@2x](https://user-images.githubusercontent.com/1091472/223405903-7608906c-354d-4241-b4fd-644c43cdf52b.png)

And it's caused by the global style defined in home page:

```
<style>
  .VPDoc .container {
    max-width: 1120px !important;
  }

  .VPDoc .content {
    max-width: 100% !important;
    padding: 0px !important;
    width: 100% !important;
  }
</style>
```

In this fix, I've removed that global styles and wrapped the whole content inside a `div` with tailwindcss classes.

And here's the toc after the fix:

![CleanShot 2023-03-07 at 19 13 25@2x](https://user-images.githubusercontent.com/1091472/223406546-ceed57fb-cc8d-4fce-b6c2-ddd3db232221.png)
