### PR TITLE
chore: ignore `@algolia/client-search` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
   "pnpm": {
     "patchedDependencies": {
       "vitepress@1.0.0-alpha.49": "patches/vitepress@1.0.0-alpha.49.patch"
+    },
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "@algolia/client-search"
+      ]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,6 +322,9 @@ packages:
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
+    peerDependenciesMeta:
+      '@algolia/client-search':
+        optional: true
     dependencies:
       '@algolia/autocomplete-shared': 1.7.4
       algoliasearch: 4.14.2


### PR DESCRIPTION
Hello there, peer dependency `@algolia/client-search` could be ignored as per VitePress [doc](https://vitepress.vuejs.org/guide/getting-started#step-2-install-vitepress)