### PR TITLE
Update Alchemy URLs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -87,7 +87,7 @@ After the install completes, pnpm links packages across the project for developm
 wagmi uses [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil) to execute tests against a local Ethereum node. First, install Anvil via [Foundry](https://book.getfoundry.sh/getting-started/installation). Next, add the following to your environment (recommended to use [`direnv`](https://github.com/direnv/direnv)):
 
 ```bash
-VITE_ANVIL_FORK_URL=https://eth-mainnet.alchemyapi.io/v2/<apiKey>
+VITE_ANVIL_FORK_URL=https://eth-mainnet.g.alchemy.com/v2/<apiKey>
 VITE_ANVIL_BLOCK_TIME=1
 VITE_ANVIL_BLOCK_NUMBER=16280770
 VITE_NETWORK_TRANSPORT_MODE=http

--- a/site/docs/actions/test/setRpcUrl.md
+++ b/site/docs/actions/test/setRpcUrl.md
@@ -23,7 +23,7 @@ Sets the backend RPC URL.
 ```ts [example.ts]
 import { testClient } from './client'
 
-await testClient.setRpcUrl('https://eth-mainnet.alchemyapi.io/v2') // [!code focus]
+await testClient.setRpcUrl('https://eth-mainnet.g.alchemy.com/v2') // [!code focus]
 ```
 
 ```ts [client.ts]

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -135,7 +135,7 @@ import { mainnet } from 'viem/chains'
 
 const client = createPublicClient({
   chain: mainnet,
-  transport: http('https://eth-mainnet.alchemyapi.io/v2/<apiKey>')
+  transport: http('https://eth-mainnet.g.alchemy.com/v2/<apiKey>')
 })
 ```
 
@@ -231,7 +231,7 @@ const provider = new providers.FallbackProvider([alchemy, infura])
 import { createPublicClient, http, fallback } from 'viem'
 import { mainnet } from 'viem/chains'
 
-const alchemy = http('https://eth-mainnet.alchemyapi.io/v2/<apiKey>')
+const alchemy = http('https://eth-mainnet.g.alchemy.com/v2/<apiKey>')
 const infura = http('https://mainnet.infura.io/v3/<apiKey>')
 
 const client = createPublicClient({
@@ -275,7 +275,7 @@ const client = createWalletClient({
 ```ts {3}
 import { providers } from 'ethers'
 
-const provider = new providers.WebSocketProvider('wss://eth-mainnet.alchemyapi.io/v2/<apiKey>')
+const provider = new providers.WebSocketProvider('wss://eth-mainnet.g.alchemy.com/v2/<apiKey>')
 ```
 
 #### viem
@@ -286,7 +286,7 @@ import { mainnet } from 'viem/chains'
 
 const client = createPublicClient({
   chain: mainnet,
-  transport: webSocket('wss://eth-mainnet.alchemyapi.io/v2/<apiKey>')
+  transport: webSocket('wss://eth-mainnet.g.alchemy.com/v2/<apiKey>')
 })
 ```
 


### PR DESCRIPTION
Hey team 👋 

Bastien from Alchemy - quick doc update to future proof the Alchemy endpoints.
We're moving to `g.alchemy.com` instead of `alchemyapi.io`.

Epic stuff you're building 🚀 
