### PR TITLE
fix: `transaction.to` property type for contract deployment transactions

### DIFF
--- a/src/utils/formatters/transaction.test.ts
+++ b/src/utils/formatters/transaction.test.ts
@@ -274,3 +274,45 @@ test('nullish values', () => {
     }
   `)
 })
+
+test('contract deployment transaction', () => {
+  expect(
+    formatTransaction({
+      accessList: undefined,
+      blockHash: '0x1',
+      blockNumber: '0x10f2c',
+      from: '0x1',
+      gas: '0x4234584',
+      gasPrice: '0x45',
+      hash: '0x1',
+      input: '0x1',
+      nonce: '0x1',
+      r: '0x1',
+      s: '0x1',
+      to: undefined,
+      transactionIndex: '0x1',
+      type: '0x0',
+      v: '0x1',
+      value: '0x1',
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "blockHash": "0x1",
+      "blockNumber": 69420n,
+      "chainId": undefined,
+      "from": "0x1",
+      "gas": 69420420n,
+      "gasPrice": 69n,
+      "hash": "0x1",
+      "input": "0x1",
+      "nonce": 1,
+      "r": "0x1",
+      "s": "0x1",
+      "to": null,
+      "transactionIndex": 1,
+      "type": "legacy",
+      "v": 1n,
+      "value": 1n,
+    }
+  `)
+})

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -41,6 +41,7 @@ export function formatTransaction(transaction: Partial<RpcTransaction>) {
       ? BigInt(transaction.maxPriorityFeePerGas)
       : undefined,
     nonce: transaction.nonce ? hexToNumber(transaction.nonce) : undefined,
+    to: transaction.to ? transaction.to : null,
     transactionIndex: transaction.transactionIndex
       ? Number(transaction.transactionIndex)
       : null,


### PR DESCRIPTION
Should fix #151 