### PR TITLE
fix: decoding event logs if constructor in abi

### DIFF
--- a/.changeset/polite-wasps-protect.md
+++ b/.changeset/polite-wasps-protect.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed issue where decoding error logs would break if constructor was in ABI.

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -7,6 +7,11 @@ test('Transfer()', () => {
     abi: [
       {
         inputs: [],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+      },
+      {
+        inputs: [],
         name: 'Transfer',
         type: 'event',
       },

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -49,7 +49,9 @@ export function decodeEventLog<
 >): DecodeEventLogReturnType<TAbi, TEventName, TTopics, TData> {
   const [signature, ...argTopics] = topics
   const abiItem = (abi as Abi).find(
-    (x) => signature === getEventSelector(formatAbiItem(x) as EventDefinition),
+    (x) =>
+      x.type === 'event' &&
+      signature === getEventSelector(formatAbiItem(x) as EventDefinition),
   )
   if (!(abiItem && 'name' in abiItem))
     throw new AbiEventSignatureNotFoundError(signature, {


### PR DESCRIPTION
Fixes #157