### PR TITLE
feat: infer `multicallAddress` from client chain for `multicall`

### DIFF
--- a/.changeset/spotty-llamas-think.md
+++ b/.changeset/spotty-llamas-think.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Infer multicall address from client chain
+Added inference for multicall address from client chain.

--- a/.changeset/spotty-llamas-think.md
+++ b/.changeset/spotty-llamas-think.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Infer multicall address from client chain

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -220,3 +220,24 @@ const results = await publicClient.multicall({
   account: getAccount('0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b') // [!code focus]
 })
 ```
+
+### multicallAddress (optional)
+
+- **Type:** [`Address`](/docs/glossary/types#address)
+- **Default:** `client.chain.contracts.multicall3.address`
+
+Address of Multicall Contract.
+
+```ts
+const results = await publicClient.multicall({
+  contracts: [
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: wagmiAbi,
+      functionName: 'totalSupply',
+    },
+    ...
+  ],
+  multicallAddress: '0xca11bde05977b3631167028862be2a173976ca11' // [!code focus]
+})
+```

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -1,7 +1,11 @@
 import { PublicClient } from '../../clients'
-import { ChainDoesNotSupportContract } from '../../errors'
 import type { Address, Prettify } from '../../types'
-import { decodeFunctionResult, encodeFunctionData, toHex } from '../../utils'
+import {
+  decodeFunctionResult,
+  encodeFunctionData,
+  getChainContractAddress,
+  toHex,
+} from '../../utils'
 import { namehash, packetToBytes } from '../../utils/ens'
 import { readContract, ReadContractParameters } from '../public'
 
@@ -46,28 +50,11 @@ export async function getEnsAddress(
         'client chain not configured. universalResolverAddress is required.',
       )
 
-    const contract = client.chain?.contracts?.ensUniversalResolver
-    if (!contract)
-      throw new ChainDoesNotSupportContract({
-        chain: client.chain,
-        contract: { name: 'ensUniversalResolver' },
-      })
-
-    if (
-      blockNumber &&
-      contract.blockCreated &&
-      contract.blockCreated > blockNumber
-    )
-      throw new ChainDoesNotSupportContract({
-        blockNumber,
-        chain: client.chain,
-        contract: {
-          name: 'ensUniversalResolver',
-          blockCreated: contract.blockCreated,
-        },
-      })
-
-    universalResolverAddress = contract.address
+    universalResolverAddress = getChainContractAddress({
+      blockNumber,
+      chain: client.chain,
+      contract: 'ensUniversalResolver',
+    })
   }
 
   const res = await readContract(client, {

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -1,12 +1,11 @@
 import { PublicClient } from '../../clients'
 import { panicReasons } from '../../constants'
 import {
-  ChainDoesNotSupportContract,
   ContractFunctionExecutionError,
   ContractFunctionRevertedError,
 } from '../../errors'
 import type { Address, Prettify } from '../../types'
-import { toHex } from '../../utils'
+import { getChainContractAddress, toHex } from '../../utils'
 import { packetToBytes } from '../../utils/ens'
 import { readContract, ReadContractParameters } from '../public'
 
@@ -48,28 +47,11 @@ export async function getEnsName(
         'client chain not configured. universalResolverAddress is required.',
       )
 
-    const contract = client.chain?.contracts?.ensUniversalResolver
-    if (!contract)
-      throw new ChainDoesNotSupportContract({
-        chain: client.chain,
-        contract: { name: 'ensUniversalResolver' },
-      })
-
-    if (
-      blockNumber &&
-      contract.blockCreated &&
-      contract.blockCreated > blockNumber
-    )
-      throw new ChainDoesNotSupportContract({
-        blockNumber,
-        chain: client.chain,
-        contract: {
-          name: 'ensUniversalResolver',
-          blockCreated: contract.blockCreated,
-        },
-      })
-
-    universalResolverAddress = contract.address
+    universalResolverAddress = getChainContractAddress({
+      blockNumber,
+      chain: client.chain,
+      contract: 'ensUniversalResolver',
+    })
   }
 
   const reverseNode = `${address.toLowerCase().substring(2)}.addr.reverse`

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -46,7 +46,7 @@ test('default', async () => {
         "status": "success",
       },
       {
-        "result": 231481998602n,
+        "result": 231481998553n,
         "status": "success",
       },
       {
@@ -99,7 +99,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998602n,
+            "result": 231481998553n,
             "status": "success",
           },
           {
@@ -153,7 +153,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998602n,
+            "result": 231481998553n,
             "status": "success",
           },
           {
@@ -207,7 +207,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998602n,
+            "result": 231481998553n,
             "status": "success",
           },
           {
@@ -252,11 +252,11 @@ describe('errors', async () => {
       ).toMatchInlineSnapshot(`
         [
           {
-            "result": 231481998602n,
+            "result": 231481998553n,
             "status": "success",
           },
           {
-            "result": 231481998602n,
+            "result": 231481998553n,
             "status": "success",
           },
           {

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -57,6 +57,45 @@ test('default', async () => {
   `)
 })
 
+test('args: multicallAddress', async () => {
+  expect(
+    await multicall(publicClient, {
+      blockNumber: initialBlockNumber,
+      contracts: [
+        {
+          ...usdcContractConfig,
+          functionName: 'totalSupply',
+        },
+        {
+          ...usdcContractConfig,
+          functionName: 'balanceOf',
+          args: [address.vitalik],
+        },
+        {
+          ...baycContractConfig,
+          functionName: 'totalSupply',
+        },
+      ],
+      multicallAddress: '0xca11bde05977b3631167028862be2a173976ca11',
+    }),
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "result": 41119586940119550n,
+        "status": "success",
+      },
+      {
+        "result": 231481998553n,
+        "status": "success",
+      },
+      {
+        "result": 10000n,
+        "status": "success",
+      },
+    ]
+  `)
+})
+
 describe('errors', async () => {
   describe('allowFailure is truthy', async () => {
     test('function not found', async () => {

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -3,7 +3,6 @@ import { multicall3Abi } from '../../constants'
 import {
   AbiDecodingZeroDataError,
   BaseError,
-  ChainDoesNotSupportContract,
   RawContractError,
 } from '../../errors'
 import { Address, ContractConfig, Hex, MulticallContracts } from '../../types'
@@ -13,6 +12,7 @@ import {
   decodeFunctionResult,
   encodeFunctionData,
   getContractError,
+  getChainContractAddress,
 } from '../../utils'
 import { CallParameters } from './call'
 import { readContract } from './readContract'
@@ -53,28 +53,11 @@ export async function multicall<
         'client chain not configured. multicallAddress is required.',
       )
 
-    const contract = client.chain?.contracts?.multicall3
-    if (!contract)
-      throw new ChainDoesNotSupportContract({
-        chain: client.chain,
-        contract: { name: 'multicall3' },
-      })
-
-    if (
-      blockNumber &&
-      contract.blockCreated &&
-      contract.blockCreated > blockNumber
-    )
-      throw new ChainDoesNotSupportContract({
-        blockNumber,
-        chain: client.chain,
-        contract: {
-          name: 'multicall3',
-          blockCreated: contract.blockCreated,
-        },
-      })
-
-    multicallAddress = contract.address
+    multicallAddress = getChainContractAddress({
+      blockNumber,
+      chain: client.chain,
+      contract: 'multicall3',
+    })
   }
 
   const calls = contracts.map(({ abi, address, args, functionName }) => {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,6 +1,12 @@
 import { Chain as Chain_ } from '@wagmi/chains'
+import { Address } from './abitype'
 import { Formatters } from './formatter'
 
 export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
   formatters?: TFormatters
 }
+
+export type Contract = {
+  address: Address;
+  blockCreated?: number;
+};

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -6,7 +6,7 @@ export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
   formatters?: TFormatters
 }
 
-export type Contract = {
+export type ChainContract = {
   address: Address
   blockCreated?: number
 }

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -7,6 +7,6 @@ export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
 }
 
 export type Contract = {
-  address: Address;
-  blockCreated?: number;
-};
+  address: Address
+  blockCreated?: number
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,7 +39,7 @@ export type {
   Uncle,
 } from './block'
 
-export type { Chain } from './chain'
+export type { Chain, ChainContract } from './chain'
 
 export type {
   AbiItem,

--- a/src/utils/chain.test.ts
+++ b/src/utils/chain.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { defineChain } from './chain'
+import { mainnet, optimism, polygon } from '../chains'
+import { defineChain, getChainContractAddress } from './chain'
 
 describe('defineChain', () => {
   test('default', () => {
@@ -37,6 +38,73 @@ describe('defineChain', () => {
           },
         },
       }
+    `)
+  })
+})
+
+describe('getChainContractAddress', () => {
+  test('default', () => {
+    expect(
+      getChainContractAddress({
+        chain: mainnet,
+        contract: 'multicall3',
+      }),
+    ).toMatchInlineSnapshot('"0xca11bde05977b3631167028862be2a173976ca11"')
+    expect(
+      getChainContractAddress({
+        chain: polygon,
+        contract: 'multicall3',
+      }),
+    ).toMatchInlineSnapshot('"0xca11bde05977b3631167028862be2a173976ca11"')
+    expect(
+      getChainContractAddress({
+        chain: optimism,
+        contract: 'multicall3',
+      }),
+    ).toMatchInlineSnapshot('"0xca11bde05977b3631167028862be2a173976ca11"')
+  })
+
+  test('no contract', () => {
+    expect(() =>
+      getChainContractAddress({
+        chain: {
+          ...mainnet,
+          contracts: {},
+        },
+        contract: 'multicall3',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Chain \\"Ethereum\\" does not support contract \\"multicall3\\".
+
+      This could be due to any of the following:
+      - The chain does not have the contract \\"multicall3\\" configured.
+
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('block number is less than created block number', () => {
+    expect(() =>
+      getChainContractAddress({
+        blockNumber: 69420n,
+        chain: {
+          ...mainnet,
+          contracts: {
+            multicall3: {
+              ...mainnet.contracts.multicall3,
+              blockCreated: 123456789,
+            },
+          },
+        },
+        contract: 'multicall3',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Chain \\"Ethereum\\" does not support contract \\"multicall3\\".
+
+      This could be due to any of the following:
+      - The contract \\"multicall3\\" was not deployed until block 123456789 (current block 69420).
+
+      Version: viem@1.0.2"
     `)
   })
 })

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,6 +1,5 @@
-import { Chain, Formatters } from '../types'
+import { Chain, ChainContract, Formatters } from '../types'
 import { ChainDoesNotSupportContract } from '../errors'
-import { Contract } from '../types/chain'
 
 export function defineChain<
   TFormatters extends Formatters = Formatters,
@@ -18,7 +17,7 @@ export function getChainContractAddress({
   chain: Chain
   contract: string
 }) {
-  const contract = (chain?.contracts as Record<string, Contract>)?.[name]
+  const contract = (chain?.contracts as Record<string, ChainContract>)?.[name]
   if (!contract)
     throw new ChainDoesNotSupportContract({
       chain,

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,8 +1,43 @@
 import { Chain, Formatters } from '../types'
+import { ChainDoesNotSupportContract } from '../errors'
+import { Contract } from '../types/chain'
 
 export function defineChain<
   TFormatters extends Formatters = Formatters,
   TChain extends Chain<TFormatters> = Chain<TFormatters>,
 >(chain: TChain) {
   return chain
+}
+
+export function getChainContractAddress({
+  blockNumber,
+  chain,
+  contract: name,
+}: {
+  blockNumber?: bigint
+  chain: Chain
+  contract: string
+}) {
+  const contract = (chain?.contracts as Record<string, Contract>)?.[name]
+  if (!contract)
+    throw new ChainDoesNotSupportContract({
+      chain,
+      contract: { name },
+    })
+
+  if (
+    blockNumber &&
+    contract.blockCreated &&
+    contract.blockCreated > blockNumber
+  )
+    throw new ChainDoesNotSupportContract({
+      blockNumber,
+      chain,
+      contract: {
+        name,
+        blockCreated: contract.blockCreated,
+      },
+    })
+
+  return contract.address
 }

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -56,6 +56,7 @@ test('exports utils', () => {
       "getAccount": [Function],
       "getAddress": [Function],
       "getCallError": [Function],
+      "getChainContractAddress": [Function],
       "getContractAddress": [Function],
       "getContractError": [Function],
       "getCreate2Address": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -59,7 +59,7 @@ export {
 
 export { buildRequest } from './buildRequest'
 
-export { defineChain } from './chain'
+export { defineChain, getChainContractAddress } from './chain'
 
 export {
   extractFunctionName,


### PR DESCRIPTION
Infers `multicallAddress` from client chain for `multicall` like we do in `getEnsName` and `getEnsAddress`.