### PR TITLE
docs: fix pad example

### DIFF
--- a/site/docs/utilities/pad.md
+++ b/site/docs/utilities/pad.md
@@ -69,6 +69,6 @@ Size (in bytes) of the targeted value.
 pad('0xa4e12a45', {
   size: 16
 })
-// 0xa4e12a45000000000000000000000000
+// 0x000000000000000000000000a4e12a45
 ```
 


### PR DESCRIPTION
`pad` is documented as using `dir: left` as the default, but the example for `size` uses `dir: right` implicitly. This fixes it.