### PR TITLE
fix: topics type for logs in rpc responses

### DIFF
--- a/.changeset/dull-windows-tease.md
+++ b/.changeset/dull-windows-tease.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed type of `topics` field on `Log`.

--- a/.changeset/dull-windows-tease.md
+++ b/.changeset/dull-windows-tease.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed type of `topics` field on `Log`.
+Fixed type of `topics` field on the `Log` type.

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -2,8 +2,6 @@ import { Abi, AbiEvent, Address, ExtractAbiEventNames } from 'abitype'
 import { ExtractEventArgsFromAbi } from './contract'
 import type { Hash, Hex } from './misc'
 
-type TopicFilter = (null | string | string[])[]
-
 type DecodedAbiEvent<
   TAbiEvent extends AbiEvent | undefined = undefined,
   TAbi extends Abi | readonly unknown[] = [TAbiEvent],
@@ -56,7 +54,7 @@ export type Log<
   /** Index of the transaction that created this log or `null` if pending */
   transactionIndex: TIndex | null
   /** List of order-dependent topics */
-  topics: TopicFilter
+  topics: Hex[]
   /** `true` if this filter has been destroyed and is invalid */
   removed: boolean
 } & DecodedAbiEvent<TAbiEvent, TAbi, TEventName>


### PR DESCRIPTION
AFAICT, the `topics` property of logs in RPC responses can only be an array of hex strings. Elements of this array will never be null, and will never be an array of strings, so I think the type suggested here is more precise. See [this discussion](https://github.com/wagmi-dev/viem/discussions/163) and the [JSON-RPC spec](https://ethereum.github.io/execution-apis/api-documentation/) for more details.

To summarize:
1. The `topics` argument passed to `eth_getLogs` and `eth_newFilter` has the type `(Hex | Hex[] | null)[]`
2. The `topics` property of logs returned by `eth_getLogs`, `eth_getFilterLogs`, and `eth_getFilterChanges` has the type `Hex[]` (and has length <= 4)