### PR TITLE
docs: fix copy pasta

### DIFF
--- a/site/docs/actions/public/call.md
+++ b/site/docs/actions/public/call.md
@@ -109,7 +109,6 @@ const data = await publicClient.call({
   accessList: [ // [!code focus:6]
     {
       address: '0x1',
-      import { getAccount } from 'viem' 
       storageKeys: ['0x1'],
     },
   ],


### PR DESCRIPTION
I assume this line got included accidentally. I left the `focus` line count because the current one is accurate after removing this line.