### PR TITLE
fix: assert that next block is valid in `watchBlocks` & `watchBlockNumber`

### DIFF
--- a/.changeset/early-worms-suffer.md
+++ b/.changeset/early-worms-suffer.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added assertion in `watchBlocks` and `watchBlockNumber` to check that the next block number is higher than the previously seen block number.

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -64,8 +64,13 @@ export function watchBlockNumber(
               }
             }
           }
-          prevBlockNumber = blockNumber
-          emit.onBlockNumber(blockNumber, prevBlockNumber)
+
+          // If the next block number is greater than the previous,
+          // it is not in the past, and we can emit the new block number.
+          if (!prevBlockNumber || blockNumber > prevBlockNumber) {
+            emit.onBlockNumber(blockNumber, prevBlockNumber)
+            prevBlockNumber = blockNumber
+          }
         } catch (err) {
           emit.onError?.(err as Error)
         }

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -99,8 +99,19 @@ export function watchBlocks<
               }
             }
           }
-          emit.onBlock(block, prevBlock)
-          prevBlock = block
+
+          if (
+            // If no previous block exists, emit.
+            !prevBlock?.number ||
+            // If the block tag is "pending" with no block number, emit.
+            (blockTag === 'pending' && !block?.number) ||
+            // If the next block number is greater than the previous block number, emit.
+            // We don't want to emit blocks in the past.
+            (block.number && block.number > prevBlock.number)
+          ) {
+            emit.onBlock(block, prevBlock)
+            prevBlock = block
+          }
         } catch (err) {
           emit.onError?.(err as Error)
         }


### PR DESCRIPTION
Some RPC Providers can be unreliable when polling for new block numbers. For example: the public Polygon RPC Provider can sometimes return block numbers in the past (that have already been seen before).

This PR adds a check to see if the next block number is greater than the previously seen block number.