### PR TITLE
fix: emit logs on missed blocks for `getLogs` fallback on `watchEvent`

### DIFF
--- a/.changeset/nervous-baboons-confess.md
+++ b/.changeset/nervous-baboons-confess.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `watchEvent` would not emit events on missed blocks for the `getLogs` fallback.

--- a/site/docs/actions/public/watchEvent.md
+++ b/site/docs/actions/public/watchEvent.md
@@ -346,4 +346,4 @@ Check out the usage of `watchEvent` in the live [Event Logs Example](https://sta
 
 **RPC Provider does not support `eth_newFilter`:**
 
-- Calls [`eth_getLogs`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) on a polling interval.
+- Calls [`eth_getLogs`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) for each block between the polling interval.

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -120,9 +120,7 @@ export function watchContractEvent<
               logs = await getLogs(client, {
                 address,
                 args,
-                fromBlock: previousBlockNumber
-                  ? previousBlockNumber + 1n
-                  : undefined,
+                fromBlock: previousBlockNumber + 1n,
                 toBlock: blockNumber,
                 event: getAbiItem({
                   abi,

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -79,7 +79,7 @@ export function watchContractEvent<
   ])
 
   return observe(observerId, { onLogs, onError }, (emit) => {
-    let currentBlockNumber: bigint
+    let previousBlockNumber: bigint
     let filter: Filter<'event', TAbi, TEventName> | undefined
     let initialized = false
 
@@ -116,11 +116,13 @@ export function watchContractEvent<
             // If the block number has changed, we will need to fetch the logs.
             // If the block number doesn't exist, we are yet to reach the first poll interval,
             // so do not emit any logs.
-            if (currentBlockNumber && currentBlockNumber !== blockNumber) {
+            if (previousBlockNumber && previousBlockNumber !== blockNumber) {
               logs = await getLogs(client, {
                 address,
                 args,
-                fromBlock: blockNumber,
+                fromBlock: previousBlockNumber
+                  ? previousBlockNumber + 1n
+                  : undefined,
                 toBlock: blockNumber,
                 event: getAbiItem({
                   abi,
@@ -130,7 +132,7 @@ export function watchContractEvent<
             } else {
               logs = []
             }
-            currentBlockNumber = blockNumber
+            previousBlockNumber = blockNumber
           }
 
           if (logs.length === 0) return

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -118,9 +118,7 @@ export function watchEvent<
               logs = await getLogs(client, {
                 address,
                 args,
-                fromBlock: previousBlockNumber
-                  ? previousBlockNumber + 1n
-                  : undefined,
+                fromBlock: previousBlockNumber + 1n,
                 toBlock: blockNumber,
                 event: event!,
               })

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -78,7 +78,7 @@ export function watchEvent<
   ])
 
   return observe(observerId, { onLogs, onError }, (emit) => {
-    let currentBlockNumber: bigint
+    let previousBlockNumber: bigint
     let filter: Filter<'event', [TAbiEvent], TEventName, any>
     let initialized = false
 
@@ -114,18 +114,20 @@ export function watchEvent<
             // If the block number has changed, we will need to fetch the logs.
             // If the block number doesn't exist, we are yet to reach the first poll interval,
             // so do not emit any logs.
-            if (currentBlockNumber && currentBlockNumber !== blockNumber) {
+            if (previousBlockNumber && previousBlockNumber !== blockNumber) {
               logs = await getLogs(client, {
                 address,
                 args,
-                fromBlock: blockNumber,
+                fromBlock: previousBlockNumber
+                  ? previousBlockNumber + 1n
+                  : undefined,
                 toBlock: blockNumber,
                 event: event!,
               })
             } else {
               logs = []
             }
-            currentBlockNumber = blockNumber
+            previousBlockNumber = blockNumber
           }
 
           if (logs.length === 0) return


### PR DESCRIPTION
Fixed an issue where `watchEvent` would not emit events on missed blocks for the `getLogs` fallback (when an RPC Provider does not support `getFilterChanges`).