### PR TITLE
feat: account hoisting

### DIFF
--- a/.changeset/smooth-cheetahs-shout.md
+++ b/.changeset/smooth-cheetahs-shout.md
@@ -1,0 +1,24 @@
+---
+"viem": patch
+---
+
+Added the ability to hoist an Account to the Wallet Client.
+
+```diff
+import { createWalletClient, http } from 'viem'
+import { mainnnet } from 'viem/chains'
+
+const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
+
+const client = createWalletClient({
++ account,
+  chain: mainnet,
+  transport: http()
+})
+
+const hash = await client.sendTransaction({
+- account,
+  to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  value: parseEther('0.001')
+})
+```

--- a/examples/clients/wallet-client/index.tsx
+++ b/examples/clients/wallet-client/index.tsx
@@ -1,13 +1,7 @@
 import 'viem/window'
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom/client'
-import {
-  Account,
-  createWalletClient,
-  custom,
-  getAccount,
-  parseEther,
-} from 'viem'
+import { Address, createWalletClient, custom, parseEther } from 'viem'
 import { goerli } from 'viem/chains'
 
 const walletClient = createWalletClient({
@@ -16,11 +10,11 @@ const walletClient = createWalletClient({
 })
 
 function Example() {
-  const [account, setAccount] = useState<Account>()
+  const [account, setAccount] = useState<Address>()
 
   const connect = async () => {
     const [address] = await walletClient.requestAddresses()
-    setAccount(getAccount(address))
+    setAccount(address)
   }
 
   const sendTransaction = async () => {
@@ -35,7 +29,7 @@ function Example() {
   if (account)
     return (
       <>
-        <div>Connected: {account.address}</div>
+        <div>Connected: {account}</div>
         <button onClick={sendTransaction}>Send Transaction</button>
       </>
     )

--- a/examples/contracts/deploying-contracts/index.tsx
+++ b/examples/contracts/deploying-contracts/index.tsx
@@ -2,13 +2,12 @@ import 'viem/window'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import {
-  Account,
+  Address,
   Hash,
   TransactionReceipt,
   createWalletClient,
   createPublicClient,
   custom,
-  getAccount,
   http,
   stringify,
 } from 'viem'
@@ -25,13 +24,13 @@ const walletClient = createWalletClient({
 })
 
 function Example() {
-  const [account, setAccount] = useState<Account>()
+  const [account, setAccount] = useState<Address>()
   const [hash, setHash] = useState<Hash>()
   const [receipt, setReceipt] = useState<TransactionReceipt>()
 
   const connect = async () => {
     const [address] = await walletClient.requestAddresses()
-    setAccount(getAccount(address))
+    setAccount(address)
   }
 
   const deployContract = async () => {
@@ -55,7 +54,7 @@ function Example() {
   if (account)
     return (
       <>
-        <div>Connected: {account.address}</div>
+        <div>Connected: {account}</div>
         <button onClick={deployContract}>Deploy</button>
         {receipt && (
           <>

--- a/examples/contracts/writing-to-contracts/index.tsx
+++ b/examples/contracts/writing-to-contracts/index.tsx
@@ -2,13 +2,12 @@ import 'viem/window'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import {
-  Account,
+  Address,
   Hash,
   TransactionReceipt,
   createWalletClient,
   createPublicClient,
   custom,
-  getAccount,
   http,
   stringify,
 } from 'viem'
@@ -24,13 +23,13 @@ const walletClient = createWalletClient({
 })
 
 function Example() {
-  const [account, setAccount] = useState<Account>()
+  const [account, setAccount] = useState<Address>()
   const [hash, setHash] = useState<Hash>()
   const [receipt, setReceipt] = useState<TransactionReceipt>()
 
   const connect = async () => {
     const [address] = await walletClient.requestAddresses()
-    setAccount(getAccount(address))
+    setAccount(address)
   }
 
   const mint = async () => {
@@ -56,7 +55,7 @@ function Example() {
   if (account)
     return (
       <>
-        <div>Connected: {account.address}</div>
+        <div>Connected: {account}</div>
         <button onClick={mint}>Mint</button>
         {receipt && (
           <>

--- a/examples/signing/typed-data/index.tsx
+++ b/examples/signing/typed-data/index.tsx
@@ -1,19 +1,19 @@
 import 'viem/window'
 import React, { useState } from 'react'
 import ReactDOM from 'react-dom/client'
-import { Account, Hash, createWalletClient, custom, getAccount } from 'viem'
+import { Address, Hash, createWalletClient, custom } from 'viem'
 
 const walletClient = createWalletClient({
   transport: custom(window.ethereum!),
 })
 
 function Example() {
-  const [account, setAccount] = useState<Account>()
+  const [account, setAccount] = useState<Address>()
   const [signature, setSignature] = useState<Hash>()
 
   const connect = async () => {
     const [address] = await walletClient.requestAddresses()
-    setAccount(getAccount(address))
+    setAccount(address)
   }
 
   const signTypedData = async () => {
@@ -56,7 +56,7 @@ function Example() {
   if (account)
     return (
       <>
-        <div>Connected: {account.address}</div>
+        <div>Connected: {account}</div>
         <button onClick={signTypedData}>Sign Typed Data</button>
         {signature && <div>Receipt: {signature}</div>}
       </>

--- a/examples/transactions/sending-transactions/index.tsx
+++ b/examples/transactions/sending-transactions/index.tsx
@@ -2,14 +2,12 @@ import 'viem/window'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import {
-  Account,
   Address,
   Hash,
   TransactionReceipt,
   createWalletClient,
   createPublicClient,
   custom,
-  getAccount,
   http,
   parseEther,
   stringify,
@@ -26,7 +24,7 @@ const walletClient = createWalletClient({
 })
 
 function Example() {
-  const [account, setAccount] = useState<Account>()
+  const [account, setAccount] = useState<Address>()
   const [hash, setHash] = useState<Hash>()
   const [receipt, setReceipt] = useState<TransactionReceipt>()
 
@@ -35,7 +33,7 @@ function Example() {
 
   const connect = async () => {
     const [address] = await walletClient.requestAddresses()
-    setAccount(getAccount(address))
+    setAccount(address)
   }
 
   const sendTransaction = async () => {
@@ -60,7 +58,7 @@ function Example() {
   if (account)
     return (
       <>
-        <div>Connected: {account.address}</div>
+        <div>Connected: {account}</div>
         <input ref={addressInput} placeholder="address" />
         <input ref={valueInput} placeholder="value (ether)" />
         <button onClick={sendTransaction}>Send</button>

--- a/playgrounds/browser/src/components/actions/SendTransaction.tsx
+++ b/playgrounds/browser/src/components/actions/SendTransaction.tsx
@@ -1,4 +1,4 @@
-import { getAccount, WalletClient } from 'viem'
+import type { WalletClient } from 'viem'
 import { parseEther } from 'viem'
 
 export function SendTransaction({ client }: { client: WalletClient }) {
@@ -7,9 +7,8 @@ export function SendTransaction({ client }: { client: WalletClient }) {
       <button
         onClick={async () => {
           const [address] = await client.getAddresses()
-          const account = getAccount(address)
           await client.sendTransaction({
-            account,
+            account: address,
             to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
             value: parseEther('0.0001'),
           })

--- a/site/docs/actions/public/call.md
+++ b/site/docs/actions/public/call.md
@@ -21,10 +21,7 @@ Executes a new message call immediately without submitting a transaction to the 
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem' 
-import { publicClient } from './client'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+import { account, publicClient } from './config'
  
 const data = await publicClient.call({ // [!code focus:7]
   account,
@@ -33,9 +30,14 @@ const data = await publicClient.call({ // [!code focus:7]
 })
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
+```ts [config.ts]
+import { createPublicClient, http, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -55,15 +57,15 @@ The call data.
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to call from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
-import { getAccount } from 'viem' 
-
 const data = await publicClient.call({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'), // [!code focus)]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus]
   data: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
 })

--- a/site/docs/actions/public/estimateGas.md
+++ b/site/docs/actions/public/estimateGas.md
@@ -21,19 +21,23 @@ Estimates the gas necessary to complete a transaction without submitting it to t
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem'
-import { publicClient } from './client'
+import { account, publicClient } from './config'
 
 const gasEstimate = await publicClient.estimateGas({ // [!code focus:7]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account,
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1')
 })
 ```
 
-```ts [client.ts]
-import { createPublicClient, http } from 'viem'
+```ts [config.ts]
+import { createPublicClient, http, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -53,15 +57,15 @@ The gas estimate (in wei).
 
 ### account (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to estimate gas from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus)]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus)]
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1')
 })
@@ -74,11 +78,9 @@ const gasEstimate = await publicClient.estimateGas({
 Contract code or a hashed method call with encoded args.
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
   data: '0x...', // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1')
 })
@@ -91,10 +93,8 @@ const gasEstimate = await publicClient.estimateGas({
 The price (in wei) to pay per gas. Only applies to [Legacy Transactions](/docs/glossary/terms#legacy-transaction).
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   gasPrice: parseGwei('20'), // [!code focus]
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1') 
@@ -108,10 +108,8 @@ const gasEstimate = await publicClient.estimateGas({
 Total fee per gas (in wei), inclusive of `maxPriorityFeePerGas`. Only applies to [EIP-1559 Transactions](/docs/glossary/terms#eip-1559-transaction)
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   maxFeePerGas: parseGwei('20'),  // [!code focus]
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1')
@@ -125,10 +123,8 @@ const gasEstimate = await publicClient.estimateGas({
 Max priority fee per gas (in wei). Only applies to [EIP-1559 Transactions](/docs/glossary/terms#eip-1559-transaction)
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   maxFeePerGas: parseGwei('20'),
   maxPriorityFeePerGas: parseGwei('2'), // [!code focus]
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
@@ -143,10 +139,8 @@ const gasEstimate = await publicClient.estimateGas({
 Transaction recipient.
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
   value: parseEther('1')
 })
@@ -159,10 +153,8 @@ const gasEstimate = await publicClient.estimateGas({
 Value (in wei) sent with this transaction.
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1') // [!code focus]
 })
@@ -175,11 +167,9 @@ const gasEstimate = await publicClient.estimateGas({
 The block number to perform the gas estimate against.
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
   blockNumber: 15121123n, // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1') 
 })
@@ -193,11 +183,9 @@ const gasEstimate = await publicClient.estimateGas({
 The block tag to perform the gas estimate against.
 
 ```ts
-import { getAccount } from 'viem'
-
 const gasEstimate = await publicClient.estimateGas({
   blockTag: 'safe', // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: parseEther('1') 
 })

--- a/site/docs/actions/wallet/sendTransaction.md
+++ b/site/docs/actions/wallet/sendTransaction.md
@@ -21,10 +21,7 @@ Creates, signs, and sends a new transaction to the network.
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem'
-import { walletClient } from './client'
- 
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+import { account, walletClient } from './config'
  
 const hash = await walletClient.sendTransaction({ // [!code focus:99]
   account,
@@ -34,12 +31,60 @@ const hash = await walletClient.sendTransaction({ // [!code focus:99]
 // '0x...'
 ```
 
-```ts [client.ts]
-import { createWalletClient, custom } from 'viem'
+```ts [config.ts]
+import { createWalletClient, custom, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
 
 export const walletClient = createWalletClient({
   chain: mainnet,
+  transport: custom(window.ethereum)
+})
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
+```
+
+:::
+
+### Account Hoisting
+
+If you do not wish to pass an `account` to every `sendTransaction`, you can also hoist the Account on the Wallet Client (see `config.ts`).
+
+[Learn more](/docs/clients/wallet.html#account).
+
+::: code-group
+
+```ts [example.ts]
+import { walletClient } from './config'
+ 
+const hash = await walletClient.sendTransaction({ // [!code focus:99]
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  value: 1000000000000000000n
+})
+// '0x...'
+```
+
+```ts {4-6,9} [config.ts (JSON-RPC Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+// Retrieve Account from an EIP-1193 Provider.
+const [account] = await window.ethereum.request({ 
+  method: 'eth_requestAccounts' 
+})
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum)
+})
+```
+
+```ts {4} [config.ts (Local Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+export const walletClient = createWalletClient({
+  account: getAccount(...),
   transport: custom(window.ethereum)
 })
 ```
@@ -56,13 +101,15 @@ The [Transaction](/docs/glossary/terms#transaction) hash.
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to send the transaction from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const hash = await walletClient.sendTransaction({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'), // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus]
   to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
   value: 1000000000000000000n
 })

--- a/site/docs/actions/wallet/signMessage.md
+++ b/site/docs/actions/wallet/signMessage.md
@@ -25,10 +25,7 @@ With the calculated signature, you can:
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem'
-import { walletClient } from './client'
- 
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+import { account, walletClient } from './config'
  
 const signature = await walletClient.signMessage({ // [!code focus:99]
   account,
@@ -37,12 +34,59 @@ const signature = await walletClient.signMessage({ // [!code focus:99]
 // "0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
 export const walletClient = createWalletClient({
   chain: mainnet,
+  transport: custom(window.ethereum)
+})
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
+```
+
+:::
+
+### Account Hoisting
+
+If you do not wish to pass an `account` to every `signMessage`, you can also hoist the Account on the Wallet Client (see `config.ts`).
+
+[Learn more](/docs/clients/wallet.html#withaccount).
+
+::: code-group
+
+```ts [example.ts]
+import { walletClient } from './config'
+ 
+const signature = await walletClient.signMessage({ // [!code focus:99]
+  message: 'hello world',
+})
+// "0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"
+```
+
+```ts {4-6,9} [config.ts (JSON-RPC Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+// Retrieve Account from an EIP-1193 Provider.
+const [account] = await window.ethereum.request({ 
+  method: 'eth_requestAccounts' 
+})
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum)
+})
+```
+
+```ts {4} [config.ts (Local Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+export const walletClient = createWalletClient({
+  account: getAccount(...),
   transport: custom(window.ethereum)
 })
 ```
@@ -59,13 +103,15 @@ The signed message.
 
 ### account
 
-- **Type:** [`Address`](/docs/glossary/types#address)
+- **Type:** `Account | Address`
 
-Account to use for signing. [Read more](/docs/clients/wallet).
+Account to use for signing.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const signature = await walletClient.signMessage({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'), // [!code focus:1]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus:1]
   message: 'hello world',
 })
 ```
@@ -78,7 +124,7 @@ Message to sign.
 
 ```ts
 const signature = await walletClient.signMessage({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   message: 'hello world', // [!code focus:1]
 })
 ```

--- a/site/docs/actions/wallet/signTypedData.md
+++ b/site/docs/actions/wallet/signTypedData.md
@@ -21,10 +21,8 @@ Signs typed data and calculates an Ethereum-specific signature in [EIP-191 forma
 ::: code-group
 
 ```ts [example.ts]
-import { walletClient } from './client'
+import { account, walletClient } from './config'
 import { domain, types } from './data'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const signature = await walletClient.signTypedData({
   account,
@@ -68,12 +66,95 @@ export const types = {
 } as const
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
 export const walletClient = createWalletClient({
   chain: mainnet,
+  transport: custom(window.ethereum)
+})
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
+```
+
+:::
+
+### Account Hoisting
+
+If you do not wish to pass an `account` to every `signTypedData`, you can also hoist the Account on the Wallet Client (see `config.ts`).
+
+[Learn more](/docs/clients/wallet.html#withaccount).
+
+::: code-group
+
+```ts [example.ts]
+import { walletClient } from './config'
+import { domain, types } from './data'
+
+const signature = await walletClient.signTypedData({
+  domain,
+  types,
+  primaryType: 'Mail',
+  message: {
+    from: {
+      name: 'Cow',
+      wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    },
+    to: {
+      name: 'Bob',
+      wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+    },
+    contents: 'Hello, Bob!',
+  },
+})
+```
+
+```ts [data.ts]
+// All properties on a domain are optional
+export const domain = {
+  name: 'Ether Mail',
+  version: '1',
+  chainId: 1,
+  verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+} as const
+ 
+// The named list of all type definitions
+export const types = {
+  Person: [
+    { name: 'name', type: 'string' },
+    { name: 'wallet', type: 'address' },
+  ],
+  Mail: [
+    { name: 'from', type: 'Person' },
+    { name: 'to', type: 'Person' },
+    { name: 'contents', type: 'string' },
+  ],
+} as const
+```
+
+```ts {4-6,9} [config.ts (JSON-RPC Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+// Retrieve Account from an EIP-1193 Provider.
+const [account] = await window.ethereum.request({ 
+  method: 'eth_requestAccounts' 
+})
+
+export const walletClient = createWalletClient({
+  account,
+  transport: custom(window.ethereum)
+})
+```
+
+```ts {4} [config.ts (Local Account)]
+import { createWalletClient, custom, getAccount } from 'viem'
+
+export const walletClient = createWalletClient({
+  account: getAccount(...),
   transport: custom(window.ethereum)
 })
 ```
@@ -90,13 +171,15 @@ The signed data.
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to use for signing.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const signature = await walletClient.signTypedData({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'), // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus]
   domain: {
     name: 'Ether Mail',
     version: '1',
@@ -127,7 +210,7 @@ The typed data domain.
 
 ```ts
 const signature = await walletClient.signTypedData({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   domain: { // [!code focus:6]
     name: 'Ether Mail',
     version: '1',
@@ -156,7 +239,7 @@ The type definitions for the typed data.
 
 ```ts
 const signature = await walletClient.signTypedData({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   domain,
   types: { // [!code focus:11]
     Person: [
@@ -192,7 +275,7 @@ The primary type to extract from `types` and use in `value`.
 
 ```ts
 const signature = await walletClient.signTypedData({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   domain,
   types: {
     Person: [
@@ -226,7 +309,7 @@ const signature = await walletClient.signTypedData({
 
 ```ts
 const signature = await walletClient.signTypedData({
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   domain,
   types: {
     Person: [

--- a/site/docs/clients/wallet.md
+++ b/site/docs/clients/wallet.md
@@ -20,7 +20,7 @@ The `createWalletClient` function sets up a Wallet Client with a given [Transpor
 
 The Wallet Client supports signing over:
 - a [JSON-RPC Account](#json-rpc-accounts) (ie. Browser Extension Wallets, WalletConnect, etc). 
-- a [Local Account](#local-accounts) (ie. local private key/mnemonic wallets).
+- a [Local Account](#local-accounts-experimental) (ie. local private key/mnemonic wallets).
 
 ## Import
 
@@ -34,7 +34,7 @@ A JSON-RPC Account **defers** signing of transactions & messages to the target W
 
 Below is an example of how you can set up a JSON-RPC Account.
 
-#### Initialize a Wallet Client
+#### 1: Initialize a Wallet Client
 
 Before we set up our Account and start consuming Wallet Actions, we will need to set up our Wallet Client with the [`custom` Transport](/docs/clients/transports/custom), where we will pass in the `window.ethereum` Provider:
 
@@ -48,12 +48,12 @@ const client = createWalletClient({
 })
 ```
 
-#### Set up your JSON-RPC Account
+#### 2: Set up your JSON-RPC Account
 
-We will want to retrieve a list of addresses we can access in our Wallet (e.g. MetaMask), and then use one of them to retrieve an Account:
+We will want to retrieve an address that we can access in our Wallet (e.g. MetaMask).
 
 ```ts
-import { createWalletClient, custom, getAccount } from 'viem' // [!code focus]
+import { createWalletClient, custom } from 'viem' // [!code focus]
 import { mainnet } from 'viem/chains'
 
 const client = createWalletClient({
@@ -63,14 +63,13 @@ const client = createWalletClient({
 
 const [address] = await client.getAddresses() // [!code focus:10]
 // or: const [address] = await client.requestAddresses() // [!code focus:10]
-const account = getAccount(address)
 ```
 
 > Note: Some Wallets (like MetaMask) may require you to request access to Account addresses via [`client.requestAddresses`](/docs/actions/wallet/requestAddresses) first.
 
-#### Consume [Wallet Actions](/docs/actions/wallet/introduction)
+#### 3: Consume [Wallet Actions](/docs/actions/wallet/introduction)
 
-Now you can use that Account within Wallet Actions that require a signature from the user:
+Now you can use that address within Wallet Actions that require a signature from the user:
 
 ```ts
 import { createWalletClient, custom } from 'viem'
@@ -82,10 +81,32 @@ const client = createWalletClient({
 })
 
 const [address] = await client.getAddresses()
-const account = getAccount(address)
 
 const hash = await client.sendTransaction({ // [!code focus:10]
-  account,
+  account: address,
+  to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  value: parseEther('0.001')
+})
+```
+
+#### Optional: Hoist the Account
+
+If you do not wish to pass an account around to every Action that requires an `account`, you can also hoist the account into the Wallet Client.
+
+```ts
+import { createWalletClient, http } from 'viem'
+import { mainnnet } from 'viem/chains'
+
+const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
+
+const client = createWalletClient({ // [!code focus:99]
+  account, // [!code ++]
+  chain: mainnet,
+  transport: http()
+})
+
+const hash = await client.sendTransaction({
+  account, // [!code --]
   to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
   value: parseEther('0.001')
 })
@@ -101,7 +122,7 @@ A Local Account performs signing of transactions & messages with a private key *
 
 Below are the steps to integrate an Local Account into viem.
 
-#### Initialize a Wallet Client
+#### 1: Initialize a Wallet Client
 
 Before we set up our Account and start consuming Wallet Actions, we will need to set up our Wallet Client with the [`http` Transport](/docs/clients/transports/http):
 
@@ -115,7 +136,7 @@ const client = createWalletClient({
 })
 ```
 
-#### Set up your Local Account
+#### 2: Set up your Local Account
 
 Next, we will instantiate a viem Account using `getAccount`.
 
@@ -145,7 +166,7 @@ const account = getAccount({
 
 > Tip: Instead of building private key signing utilities yourself, you can plug in a third-party signer into the `getAccount` interface. We have an [Ethers.js Wallet Adapter](#ethers-js-wallet) if you are coming from Ethers.js, but you could also hook up a [web3.js Wallet](https://web3js.readthedocs.io/en/v1.8.2/web3-eth-accounts.html#wallet-add), [micro-eth-signer](https://github.com/paulmillr/micro-eth-signer), etc to the `getAccount` interface.
 
-#### Consume [Wallet Actions](/docs/actions/wallet/introduction)
+#### 3: Consume [Wallet Actions](/docs/actions/wallet/introduction)
 
 Now you can use that Account within Wallet Actions that need a signature from the user:
 
@@ -177,7 +198,63 @@ const hash = await client.sendTransaction({ // [!code focus:5]
 })
 ```
 
+#### Optional: Hoist the Account
+
+If you do not wish to pass an account around to every Action that requires an `account`, you can also hoist the account into the Wallet Client.
+
+```ts
+import { createWalletClient, http, getAccount } from 'viem'
+import { mainnet } from 'viem/chains'
+import { getAddress, signMessage, signTransaction } from './sign-utils'
+
+const privateKey = '0x...'
+const account = getAccount({
+  address: getAddress(privateKey),
+  signMessage(message) {
+    return signMessage(message, privateKey)
+  },
+  signTransaction(transaction) {
+    return signTransaction(transaction, privateKey)
+  }
+})
+
+const client = createWalletClient({ // [!code focus:99]
+  account, // [!code ++]
+  chain: mainnet,
+  transport: http()
+})
+
+const hash = await client.sendTransaction({
+  account, // [!code --]
+  to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  value: parseEther('0.001')
+})
+```
+
 ## Parameters
+
+### account (optional)
+
+- **Type:** `Account | Address`
+
+The Account to use for the Wallet Client. This will be used for Actions that require an `account` as an argument.
+
+Accepts a [JSON-RPC Account](#json-rpc-accounts) or [Local Account (Private Key, etc)](#local-accounts-experimental).
+
+```ts
+import { createWalletClient, custom } from 'viem'
+
+const client = createWalletClient({
+  account: getAccount('0x...') // [!code focus]
+  key: 'foo', 
+  transport: custom(window.ethereum)
+})
+
+const hash = await client.sendTransaction({
+  to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  value: parseEther('0.001')
+})
+```
 
 ### chain (optional)
 

--- a/site/docs/contract/deployContract.md
+++ b/site/docs/contract/deployContract.md
@@ -22,9 +22,7 @@ Deploys a contract to the network, given bytecode & constructor arguments.
 
 ```ts [example.ts]
 import { wagmiAbi } from './abi'
-import { walletClient } from './client'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+import { account, walletClient } from './config'
 
 await walletClient.deployContract({
   abi,
@@ -53,6 +51,11 @@ export const walletClient = createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::
@@ -64,9 +67,7 @@ export const walletClient = createWalletClient({
 ```ts {7} [example.ts]
 import { deployContract } from 'viem'
 import { wagmiAbi } from './abi'
-import { walletClient } from './client'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+import { account, walletClient } from './config'
 
 await walletClient.deployContract({
   abi,
@@ -96,6 +97,11 @@ export const walletClient = createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::
@@ -111,21 +117,23 @@ The contract's ABI.
 ```ts
 await walletClient.deployContract({
   abi: wagmiAbi, // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...',
 })
 ```
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account to deploy the contract from. [Read more](/docs/clients/wallet).
+The Account to deploy the contract from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 await walletClient.deployContract({
   abi: wagmiAbi, 
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'), // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266', // [!code focus]
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...',
 })
 ```
@@ -139,7 +147,7 @@ The contract's bytecode.
 ```ts
 await walletClient.deployContract({
   abi: wagmiAbi,
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...', // [!code focus]
 })
 ```
@@ -153,7 +161,7 @@ Constructor arguments to call upon deployment.
 ```ts
 await walletClient.deployContract({
   abi: wagmiAbi,
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'),
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...',
   args: [69] // [!code focus]
 })

--- a/site/docs/contract/estimateContractGas.md
+++ b/site/docs/contract/estimateContractGas.md
@@ -25,10 +25,8 @@ The `mint` function accepts no arguments, and returns a token ID.
 ::: code-group
 
 ```ts [example.ts]
-import { publicClient } from './client'
+import { account, publicClient } from './config'
 import { wagmiAbi } from './abi'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const gas = await publicClient.estimateContractGas({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
@@ -53,9 +51,14 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -76,10 +79,8 @@ For example, the `mint` function name below requires a **tokenId** argument, and
 ::: code-group
 
 ```ts {9} [example.ts]
-import { publicClient } from './client'
+import { account, publicClient } from './config'
 import { wagmiAbi } from './abi'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const gas = await publicClient.estimateContractGas({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
@@ -105,9 +106,14 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const account = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -172,18 +178,18 @@ const { result } = await publicClient.estimateContractGas({
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to estimate gas from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
-import { getAccount } from 'viem'
-
 const { result } = await publicClient.estimateContractGas({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266') // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' // [!code focus]
 })
 ```
 

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -203,9 +203,11 @@ const results = await publicClient.multicall({
 
 ### account (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-Optional Account sender override. [Read more](/docs/clients/wallet).
+Optional Account sender override. 
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const results = await publicClient.multicall({
@@ -217,7 +219,7 @@ const results = await publicClient.multicall({
     },
     ...
   ],
-  account: getAccount('0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b') // [!code focus]
+  account: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b' // [!code focus]
 })
 ```
 

--- a/site/docs/contract/readContract.md
+++ b/site/docs/contract/readContract.md
@@ -177,16 +177,18 @@ const data = await publicClient.readContract({
 
 ### account (optional)
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-Optional Account sender override. [Read more](/docs/clients/wallet).
+Optional Account sender override.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const data = await publicClient.readContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'totalSupply',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266') // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' // [!code focus]
 })
 ```
 

--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -29,10 +29,8 @@ The `mint` function accepts no arguments, and returns a token ID.
 ::: code-group
 
 ```ts [example.ts]
-import { publicClient } from './client'
+import { account, publicClient } from './config'
 import { wagmiAbi } from './abi'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
@@ -61,6 +59,11 @@ export const wagmiAbi = [
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 
+// JSON-RPC Account
+export const [account] = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
+
 export const publicClient = createPublicClient({
   chain: mainnet,
   transport: http()
@@ -80,10 +83,8 @@ For example, the `mint` function name below requires a **tokenId** argument, and
 ::: code-group
 
 ```ts {9} [example.ts]
-import { publicClient } from './client'
+import { account, publicClient } from './config'
 import { wagmiAbi } from './abi'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
@@ -109,9 +110,14 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const [account] = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -130,10 +136,8 @@ In the example below, we are **validating** if the contract write will be succes
 ::: code-group
 
 ```ts [example.ts]
-import { walletClient, publicClient } from './client'
+import { account, walletClient, publicClient } from './config'
 import { wagmiAbi } from './abi'
-
-const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
 
 const { request } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
@@ -158,9 +162,14 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
+
+// JSON-RPC Account
+export const [account] = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 
 export const publicClient = createPublicClient({
   chain: mainnet,
@@ -187,7 +196,7 @@ const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2', // [!code focus]
   abi: wagmiAbi,
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
 
@@ -202,7 +211,7 @@ const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi, // [!code focus]
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
 
@@ -217,22 +226,24 @@ const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint', // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
 
 ### account
 
-- **Type:** `Account`
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to simulate the contract method from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266') // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' // [!code focus]
 })
 ```
 
@@ -252,7 +263,7 @@ const { result } = await publicClient.simulateContract({
     address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     storageKeys: ['0x1'],
   }], 
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
 
@@ -269,7 +280,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'balanceOf',
   args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'], // [!code focus]
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
 
@@ -285,7 +296,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   gasPrice: parseGwei('20'), // [!code focus]
 })
 ```
@@ -302,7 +313,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   maxFeePerGas: parseGwei('20'),  // [!code focus]
 })
 ```
@@ -319,7 +330,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   maxFeePerGas: parseGwei('20'),
   maxPriorityFeePerGas: parseGwei('2'), // [!code focus]
 })
@@ -337,7 +348,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   nonce: 69 // [!code focus]
 })
 ```
@@ -354,7 +365,7 @@ const { result } = await publicClient.simulateContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   value: parseEther('1') // [!code focus]
 })
 ```
@@ -372,7 +383,7 @@ const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   blockNumber: 15121123n, // [!code focus]
 })
 ```
@@ -389,7 +400,7 @@ const { result } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
   blockTag: 'safe', // [!code focus]
 })
 ```

--- a/site/docs/contract/writeContract.md
+++ b/site/docs/contract/writeContract.md
@@ -35,10 +35,11 @@ While you can use `writeContract` [by itself](#standalone), it is highly recomme
 ::: code-group
 
 ```ts [example.ts]
-import { publicClient, walletClient } from './client'
+import { account, publicClient, walletClient } from './config'
 import { wagmiAbi } from './abi'
 
 const { request } = await publicClient.simulateContract({
+  account,
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
@@ -60,14 +61,24 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http()
+})
 
 export const walletClient = createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::
@@ -83,14 +94,15 @@ For example, the `mint` function name below requires a **tokenId** argument, and
 ::: code-group
 
 ```ts {9} [example.ts]
-import { walletClient } from './client'
+import { account, walletClient } from './client'
 import { wagmiAbi } from './abi'
 
 const { request } = await publicClient.simulateContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
-  args: [69420]
+  args: [69420],
+  account
 })
 await walletClient.writeContract(request)
 ```
@@ -109,14 +121,24 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http()
+})
 
 export const walletClient = createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::
@@ -128,13 +150,14 @@ If you don't need to perform validation on the contract write, you can also use 
 ::: code-group
 
 ```ts [example.ts]
-import { walletClient } from './client'
+import { account, walletClient } from './config'
 import { wagmiAbi } from './abi'
 
 await walletClient.writeContract({
   address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
   abi: wagmiAbi,
   functionName: 'mint',
+  account,
 })
 ```
 
@@ -152,14 +175,24 @@ export const wagmiAbi = [
 ] as const;
 ```
 
-```ts [client.ts]
+```ts [config.ts]
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http()
+})
 
 export const walletClient = createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::
@@ -222,9 +255,11 @@ await walletClient.writeContract({
 
 ### account
 
-- **Type:** [`Address`](/docs/glossary/types#address)
+- **Type:** `Account | Address`
 
-The Account sender. [Read more](/docs/clients/wallet).
+The Account to write to the contract from.
+
+Accepts a [JSON-RPC Account](/docs/clients/wallet#json-rpc-accounts) or [Local Account (Private Key, etc)](/docs/clients/wallet#local-accounts-experimental).
 
 ```ts
 await walletClient.writeContract({
@@ -232,7 +267,7 @@ await walletClient.writeContract({
   abi: wagmiAbi,
   functionName: 'mint',
   args: [69420],
-  account: getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266') // [!code focus]
+  account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266' // [!code focus]
 })
 ```
 

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -292,7 +292,7 @@ const client = createPublicClient({
 })
 ```
 
-## Signers → getAccount
+## Signers → Accounts
 
 ### JsonRpcSigner
 
@@ -315,15 +315,17 @@ signer.sendTransaction({ ... })
 import { createWalletClient, custom, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
 
+const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
+
 const client = createWalletClient({
+  account,
   chain: mainnet,
   transport: custom(window.ethereum)
 })
 
 const [address] = await client.getAddresses()
-const account = getAccount(address)
 
-client.sendTransaction({ account, ... })
+client.sendTransaction({ ... })
 ```
 
 > viem uses the term ["Account"](https://ethereum.org/en/developers/docs/accounts/) rather than "Signer".
@@ -352,14 +354,15 @@ import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 import { getAccount } from 'viem/ethers'
 
+const account = getAccount(new Wallet('0x...'))
+
 const client = createWalletClient({
+  account,
   chain: mainnet,
   transport: custom(window.ethereum)
 })
 
-const account = getAccount(new Wallet('0x...'))
-
-client.sendTransaction({ account, ... })
+client.sendTransaction({ ... })
 ```
 
 > viem uses the term ["Account"](https://ethereum.org/en/developers/docs/accounts/) rather than "Signer".
@@ -420,19 +423,21 @@ signer.signMessage(...)
 #### viem
 
 ```ts {9-12}
-import { createWalletClient, custom, getAccount } from 'viem'
+import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
+const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
+
 const client = createWalletClient({
+  account,
   chain: mainnet,
   transport: custom(window.ethereum)
 })
 
 const [address] = await client.getAddresses()
-const account = getAccount(address)
 
-client.sendTransaction({ account, ... })
-client.signMessage({ account, ... })
+client.sendTransaction({ ... })
+client.signMessage({ ... })
 ...
 ```
 
@@ -510,12 +515,11 @@ const walletClient = createWalletClient({
 })
 
 const [address] = await walletClient.getAddresses()
-const account = getAccount(address)
 
 const request = await publicClient.simulateContract({
   ...wagmiContractConfig,
   functionName: 'mint',
-  account,
+  account: address,
 })
 const supply = await walletClient.writeContract(request)
 ```
@@ -550,11 +554,10 @@ const walletClient = createWalletClient({
 })
 
 const [address] = await walletClient.getAddresses()
-const account = getAccount(address)
 
 await walletClient.deployContract({
   abi,
-  account,
+  account: address,
   bytecode,
 })
 ```

--- a/site/docs/utilities/recoverMessageAddress.md
+++ b/site/docs/utilities/recoverMessageAddress.md
@@ -23,8 +23,7 @@ Useful for obtaining the address of a message that was signed with [`signMessage
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem'
-import { account, walletClient } from './client'
+import { account, walletClient } from './config'
  
 const signature = await walletClient.signMessage({
   account,
@@ -37,14 +36,17 @@ const address = recoverMessageAddress({ // [!code focus:99]
 })
 ```
 
-```ts [client.ts]
-import { createWalletClient, custom, getAccount } from 'viem'
-
-export const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+```ts [config.ts]
+import { createWalletClient, custom } from 'viem'
 
 export const walletClient = createWalletClient({
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::

--- a/site/docs/utilities/verifyMessage.md
+++ b/site/docs/utilities/verifyMessage.md
@@ -21,8 +21,7 @@ Verify that a message was signed by the provided address.
 ::: code-group
 
 ```ts [example.ts]
-import { getAccount } from 'viem'
-import { account, walletClient } from './client'
+import { account, walletClient } from './config'
  
 const signature = await walletClient.signMessage({
   account,
@@ -37,14 +36,17 @@ const valid = verifyMessage({ // [!code focus:99]
 // true
 ```
 
-```ts [client.ts]
-import { createWalletClient, custom, getAccount } from 'viem'
-
-export const account = getAccount('0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266')
+```ts [config.ts]
+import { createWalletClient, custom } from 'viem'
 
 export const walletClient = createWalletClient({
   transport: custom(window.ethereum)
 })
+
+// JSON-RPC Account
+export const [account] = await walletClient.getAddresses()
+// Local Account (Private Key, etc)
+export const account = getAccount(...)
 ```
 
 :::

--- a/src/_test/index.ts
+++ b/src/_test/index.ts
@@ -19,6 +19,7 @@ export {
   deploy,
   deployBAYC,
   getLocalAccount,
+  walletClientWithAccount,
   publicClient,
   testClient,
   walletClient,

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -20,7 +20,7 @@ import {
 import { getAccount as getEthersAccount } from '../ethers'
 import type { Hex } from '../types'
 import { RpcError } from '../types/eip1193'
-import { getAccount, rpc } from '../utils'
+import { rpc } from '../utils'
 import { baycContractConfig } from './abis'
 import { accounts, localWsUrl } from './constants'
 import { errorsExampleABI } from './generated'
@@ -34,6 +34,61 @@ export const anvilChain = {
   id: 1,
   contracts: mainnet.contracts,
 } as const satisfies Chain
+
+const provider = {
+  on: (message: string, listener: (...args: any[]) => null) => {
+    if (message === 'accountsChanged') {
+      listener([accounts[0].address] as any)
+    }
+  },
+  removeListener: () => null,
+  request: async ({ method, params }: any) => {
+    if (method === 'eth_requestAccounts') {
+      return [accounts[0].address]
+    }
+    if (method === 'personal_sign') {
+      method = 'eth_sign'
+      params = [params[1], params[0]]
+    }
+    if (method === 'wallet_watchAsset') {
+      if (params[0].type === 'ERC721') {
+        throw new RpcError(-32602, 'Token type ERC721 not supported.')
+      }
+      return true
+    }
+    if (method === 'wallet_addEthereumChain') return null
+    if (method === 'wallet_switchEthereumChain') {
+      if (params[0].chainId === '0xfa') {
+        throw new RpcError(-4902, 'Unrecognized chain.')
+      }
+      return null
+    }
+    if (
+      method === 'wallet_getPermissions' ||
+      method === 'wallet_requestPermissions'
+    )
+      return [
+        {
+          invoker: 'https://example.com',
+          parentCapability: 'eth_accounts',
+          caveats: [
+            {
+              type: 'filterResponse',
+              value: ['0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb'],
+            },
+          ],
+        },
+      ]
+
+    const { result } = await rpc.http(anvilChain.rpcUrls.default.http[0], {
+      body: {
+        method,
+        params,
+      },
+    })
+    return result
+  },
+}
 
 export const publicClient =
   process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket'
@@ -49,60 +104,12 @@ export const publicClient =
       })
 
 export const walletClient = createWalletClient({
-  transport: custom({
-    on: (message: string, listener: (...args: any[]) => null) => {
-      if (message === 'accountsChanged') {
-        listener([accounts[0].address] as any)
-      }
-    },
-    removeListener: () => null,
-    request: async ({ method, params }: any) => {
-      if (method === 'eth_requestAccounts') {
-        return [accounts[0].address]
-      }
-      if (method === 'personal_sign') {
-        method = 'eth_sign'
-        params = [params[1], params[0]]
-      }
-      if (method === 'wallet_watchAsset') {
-        if (params[0].type === 'ERC721') {
-          throw new RpcError(-32602, 'Token type ERC721 not supported.')
-        }
-        return true
-      }
-      if (method === 'wallet_addEthereumChain') return null
-      if (method === 'wallet_switchEthereumChain') {
-        if (params[0].chainId === '0xfa') {
-          throw new RpcError(-4902, 'Unrecognized chain.')
-        }
-        return null
-      }
-      if (
-        method === 'wallet_getPermissions' ||
-        method === 'wallet_requestPermissions'
-      )
-        return [
-          {
-            invoker: 'https://example.com',
-            parentCapability: 'eth_accounts',
-            caveats: [
-              {
-                type: 'filterResponse',
-                value: ['0x0c54fccd2e384b4bb6f2e405bf5cbc15a017aafb'],
-              },
-            ],
-          },
-        ]
+  transport: custom(provider),
+})
 
-      const { result } = await rpc.http(anvilChain.rpcUrls.default.http[0], {
-        body: {
-          method,
-          params,
-        },
-      })
-      return result
-    },
-  }),
+export const walletClientWithAccount = createWalletClient({
+  account: accounts[0].address,
+  transport: custom(provider),
 })
 
 export const testClient = createTestClient({
@@ -147,7 +154,7 @@ export async function deployBAYC() {
   return deploy({
     ...baycContractConfig,
     args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
   })
 }
 
@@ -155,7 +162,7 @@ export async function deployErrorExample() {
   return deploy({
     abi: errorsExampleABI,
     bytecode: errorsExample.bytecode.object as Hex,
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
   })
 }
 /* c8 ignore stop */

--- a/src/actions/public/call.bench.ts
+++ b/src/actions/public/call.bench.ts
@@ -1,5 +1,4 @@
 import { bench, describe } from 'vitest'
-import { getAccount } from '../../utils'
 
 import {
   accounts,
@@ -17,7 +16,7 @@ describe('Call', () => {
   bench('viem: `call`', async () => {
     await call(publicClient, {
       data: name4bytes,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: wagmiContractAddress,
     })
   })

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { accounts, publicClient } from '../../_test'
 import { celo } from '../../chains'
 import { createPublicClient, http } from '../../clients'
-import { getAccount, numberToHex, parseEther, parseGwei } from '../../utils'
+import { numberToHex, parseEther, parseGwei } from '../../utils'
 
 import { call } from './call'
 
@@ -19,7 +19,7 @@ const sourceAccount = accounts[0]
 test('default', async () => {
   const { data } = await call(publicClient, {
     data: name4bytes,
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: wagmiContractAddress,
   })
   expect(data).toMatchInlineSnapshot(
@@ -36,7 +36,7 @@ test('custom formatter', async () => {
   const { data } = await call(client, {
     gatewayFee: numberToHex(1n),
     data: name4bytes,
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: wagmiContractAddress,
   })
   expect(data).toBeUndefined()
@@ -45,7 +45,7 @@ test('custom formatter', async () => {
 test('zero data', async () => {
   const { data } = await call(publicClient, {
     data: mint4bytes,
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: wagmiContractAddress,
   })
   expect(data).toMatchInlineSnapshot('undefined')
@@ -55,7 +55,7 @@ test('args: blockNumber', async () => {
   const { data } = await call(publicClient, {
     blockNumber: 15564164n,
     data: `${mintWithParams4bytes}${fourTwenty}`,
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: wagmiContractAddress,
   })
   expect(data).toMatchInlineSnapshot('undefined')
@@ -66,7 +66,7 @@ describe('errors', () => {
     await expect(() =>
       call(publicClient, {
         data: `${mintWithParams4bytes}${fourTwenty}`,
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: wagmiContractAddress,
         maxFeePerGas: 2n ** 256n - 1n + 1n,
       }),
@@ -88,7 +88,7 @@ describe('errors', () => {
     await expect(() =>
       call(publicClient, {
         data: `${mintWithParams4bytes}${fourTwenty}`,
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: wagmiContractAddress,
         gas: 100n,
       }),
@@ -113,7 +113,7 @@ describe('errors', () => {
   test.skip('gas too high', async () => {
     await expect(() =>
       call(publicClient, {
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: accounts[0].address,
         value: 1n,
         gas: 100_000_000_000_000_000n,
@@ -125,7 +125,7 @@ describe('errors', () => {
   test.skip('gas fee is less than block base fee', async () => {
     await expect(() =>
       call(publicClient, {
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: accounts[0].address,
         value: 1n,
         maxFeePerGas: 1n,
@@ -137,7 +137,7 @@ describe('errors', () => {
   test.skip('nonce too low', async () => {
     await expect(() =>
       call(publicClient, {
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: accounts[0].address,
         value: 1n,
         nonce: 0,
@@ -149,7 +149,7 @@ describe('errors', () => {
   test('insufficient funds', async () => {
     await expect(() =>
       call(publicClient, {
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: accounts[0].address,
         value: parseEther('100000'),
       }),
@@ -170,7 +170,7 @@ describe('errors', () => {
     await expect(
       call(publicClient, {
         data: `${mintWithParams4bytes}${fourTwenty}`,
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: wagmiContractAddress,
         maxFeePerGas: parseGwei('20'),
         maxPriorityFeePerGas: parseGwei('22'),
@@ -193,7 +193,7 @@ describe('errors', () => {
     await expect(
       call(publicClient, {
         data: `${mintWithParams4bytes}${fourTwenty}`,
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: wagmiContractAddress,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
@@ -215,7 +215,7 @@ describe('errors', () => {
     await expect(
       call(publicClient, {
         data: mintWithParams4bytes,
-        account: getAccount(sourceAccount.address),
+        account: sourceAccount.address,
         to: wagmiContractAddress,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -1,6 +1,7 @@
 import type { PublicClient } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
+  Address,
   BlockTag,
   Chain,
   Formatter,
@@ -17,6 +18,7 @@ import {
   formatTransactionRequest,
   getCallError,
   numberToHex,
+  parseAccount,
   TransactionRequestFormatter,
 } from '../../utils'
 
@@ -30,7 +32,7 @@ export type FormattedCall<
 export type CallParameters<TChain extends Chain = Chain> = FormattedCall<
   TransactionRequestFormatter<TChain>
 > & {
-  account?: Account
+  account?: Account | Address
 } & (
     | {
         /** The balance of the account at a block number. */
@@ -51,7 +53,7 @@ export async function call<TChain extends Chain>(
   args: CallParameters<TChain>,
 ): Promise<CallReturnType> {
   const {
-    account,
+    account: account_,
     blockNumber,
     blockTag = 'latest',
     accessList,
@@ -65,6 +67,8 @@ export async function call<TChain extends Chain>(
     value,
     ...rest
   } = args
+  const account = account_ ? parseAccount(account_) : undefined
+
   try {
     assertRequest(args)
 
@@ -99,6 +103,7 @@ export async function call<TChain extends Chain>(
   } catch (err) {
     throw getCallError(err as BaseError, {
       ...args,
+      account,
       chain: client.chain,
     })
   }

--- a/src/actions/public/estimateContractGas.test.ts
+++ b/src/actions/public/estimateContractGas.test.ts
@@ -15,7 +15,7 @@ import {
   walletClient,
 } from '../../_test'
 import { baycContractConfig } from '../../_test/abis'
-import { encodeFunctionData, getAccount } from '../../utils'
+import { encodeFunctionData } from '../../utils'
 import { mine } from '../test'
 import { sendTransaction } from '../wallet'
 
@@ -28,7 +28,7 @@ describe('wagmi', () => {
     expect(
       await estimateContractGas(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
       }),
@@ -36,7 +36,7 @@ describe('wagmi', () => {
     expect(
       await estimateContractGas(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6'),
+        account: '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
         functionName: 'safeTransferFrom',
         args: [
           '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
@@ -51,7 +51,7 @@ describe('wagmi', () => {
     expect(
       await estimateContractGas(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
       }),
     ).toEqual(61401n)
@@ -63,7 +63,7 @@ describe('wagmi', () => {
         ...wagmiContractConfig,
         functionName: 'approve',
         args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 420n],
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       "The contract function \\"approve\\" reverted with the following reason:
@@ -83,7 +83,7 @@ describe('wagmi', () => {
         ...wagmiContractConfig,
         functionName: 'mint',
         args: [1n],
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       "The contract function \\"mint\\" reverted with the following reason:
@@ -102,7 +102,7 @@ describe('wagmi', () => {
       estimateContractGas(publicClient, {
         ...wagmiContractConfig,
         functionName: 'safeTransferFrom',
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         args: [
           '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
           '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
@@ -137,7 +137,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           functionName: 'flipSaleState',
         }),
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
         to: contractAddress!,
       })
       await mine(testClient, { blocks: 1 })
@@ -148,7 +148,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           address: contractAddress!,
           functionName: 'mintApe',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
           args: [1n],
           value: 1000000000000000000n,
         }),
@@ -164,7 +164,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           address: contractAddress!,
           functionName: 'reserveApes',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
         }),
       ).toBe(3607035n)
     })
@@ -180,7 +180,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           address: contractAddress!,
           functionName: 'mintApe',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
           args: [1n],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -226,7 +226,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'revertWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "revertWrite" reverted with the following reason:
@@ -250,7 +250,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'assertWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "assertWrite" reverted with the following reason:
@@ -274,7 +274,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'overflowWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "overflowWrite" reverted with the following reason:
@@ -298,7 +298,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'divideByZeroWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "divideByZeroWrite" reverted with the following reason:
@@ -322,7 +322,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'requireWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "requireWrite" reverted with the following reason:
@@ -346,7 +346,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'simpleCustomWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "simpleCustomWrite" reverted.
@@ -372,7 +372,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'complexCustomWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "complexCustomWrite" reverted.

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -7,6 +7,7 @@ import {
   encodeFunctionData,
   EncodeFunctionDataParameters,
   getContractError,
+  parseAccount,
 } from '../../utils'
 import { estimateGas, EstimateGasParameters } from './estimateGas'
 
@@ -38,6 +39,7 @@ export async function estimateContractGas<
     ...request
   }: EstimateContractGasParameters<TChain, TAbi, TFunctionName>,
 ): Promise<EstimateContractGasReturnType> {
+  const account = parseAccount(request.account)
   const data = encodeFunctionData({
     abi,
     args,
@@ -57,7 +59,7 @@ export async function estimateContractGas<
       args,
       docsPath: '/docs/contract/simulateContract',
       functionName,
-      sender: request.account?.address,
+      sender: account?.address,
     })
   }
 }

--- a/src/actions/public/estimateGas.bench.ts
+++ b/src/actions/public/estimateGas.bench.ts
@@ -6,14 +6,14 @@ import {
   ethersV6Provider,
   publicClient,
 } from '../../_test'
-import { getAccount, parseEther } from '../../utils'
+import { parseEther } from '../../utils'
 
 import { estimateGas } from './estimateGas'
 
 describe.skip('Estimate Gas', () => {
   bench('viem: `estimateGas`', async () => {
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     })

--- a/src/actions/public/estimateGas.test.ts
+++ b/src/actions/public/estimateGas.test.ts
@@ -7,7 +7,7 @@ import {
   publicClient,
   testClient,
 } from '../../_test'
-import { getAccount, parseEther, parseGwei } from '../../utils'
+import { parseEther, parseGwei } from '../../utils'
 import { reset } from '../test'
 import { estimateGas } from './estimateGas'
 import { getLocalAccount } from '../../_test/utils'
@@ -17,7 +17,7 @@ const wethContractAddress = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 test('estimates gas', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     }),
@@ -32,7 +32,7 @@ test('args: blockNumber', async () => {
   expect(
     await estimateGas(publicClient, {
       blockNumber: initialBlockNumber,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     }),
@@ -43,7 +43,7 @@ test('args: data', async () => {
   expect(
     await estimateGas(publicClient, {
       data: '0x00000000000000000000000000000000000000000000000004fefa17b7240000',
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: wethContractAddress,
     }),
   ).toMatchInlineSnapshot('26145n')
@@ -52,7 +52,7 @@ test('args: data', async () => {
 test('args: gasPrice', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       gasPrice: parseGwei('33'),
       value: parseEther('1'),
@@ -63,7 +63,7 @@ test('args: gasPrice', async () => {
 test('args: nonce', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       nonce: 69,
       value: parseEther('1'),
@@ -74,7 +74,7 @@ test('args: nonce', async () => {
 test('args: maxFeePerGas', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       maxFeePerGas: parseGwei('33'),
       value: parseEther('1'),
@@ -85,7 +85,7 @@ test('args: maxFeePerGas', async () => {
 test('args: maxPriorityFeePerGas', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       maxPriorityFeePerGas: parseGwei('2'),
       value: parseEther('1'),
@@ -96,7 +96,7 @@ test('args: maxPriorityFeePerGas', async () => {
 test('args: gas', async () => {
   expect(
     await estimateGas(publicClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       gas: parseGwei('2'),
       value: parseEther('1'),
@@ -210,10 +210,27 @@ describe('local account', () => {
 })
 
 describe('errors', () => {
+  test('no account', async () => {
+    await expect(() =>
+      // @ts-expect-error
+      estimateGas(publicClient, {
+        to: accounts[1].address,
+        value: parseEther('1'),
+        maxFeePerGas: 2n ** 256n - 1n + 1n,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Could not find an Account to execute with this Action.
+      Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the WalletClient.
+
+      Docs: https://viem.sh/docs/actions/public/estimateGas.html#account.html
+      Version: viem@1.0.2"
+    `)
+  })
+
   test('fee cap too high', async () => {
     await expect(() =>
       estimateGas(publicClient, {
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
         to: accounts[1].address,
         value: parseEther('1'),
         maxFeePerGas: 2n ** 256n - 1n + 1n,
@@ -234,7 +251,7 @@ describe('errors', () => {
   test('tip higher than fee cap', async () => {
     await expect(() =>
       estimateGas(publicClient, {
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
         to: accounts[1].address,
         value: parseEther('1'),
         maxPriorityFeePerGas: parseGwei('11'),

--- a/src/actions/public/estimateGas.test.ts
+++ b/src/actions/public/estimateGas.test.ts
@@ -222,7 +222,7 @@ describe('errors', () => {
       "Could not find an Account to execute with this Action.
       Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the WalletClient.
 
-      Docs: https://viem.sh/docs/actions/public/estimateGas.html#account.html
+      Docs: https://viem.sh/docs/actions/public/estimateGas.html#account
       Version: viem@1.0.2"
     `)
   })

--- a/src/actions/public/getBalance.test.ts
+++ b/src/actions/public/getBalance.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest'
 
 import { accounts, publicClient, testClient, walletClient } from '../../_test'
-import { getAccount, parseEther } from '../../utils'
+import { parseEther } from '../../utils'
 import { getBlockNumber, sendTransaction } from '..'
 import { mine, setBalance } from '../test'
 
@@ -17,19 +17,19 @@ async function setup() {
   })
 
   await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
   })
   await mine(testClient, { blocks: 1 })
   await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('2'),
   })
   await mine(testClient, { blocks: 1 })
   await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('3'),
   })

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -1,6 +1,6 @@
 import type { PublicClient, WalletClient } from '../../clients'
 import { BlockNotFoundError } from '../../errors'
-import type { BlockTag, Chain, Hash, RpcBlock } from '../../types'
+import type { Account, BlockTag, Chain, Hash, RpcBlock } from '../../types'
 import type { BlockFormatter, FormattedBlock } from '../../utils'
 import { format, formatBlock, numberToHex } from '../../utils'
 
@@ -32,8 +32,11 @@ export type GetBlockReturnType<TChain extends Chain = Chain> = FormattedBlock<
   BlockFormatter<TChain>
 >
 
-export async function getBlock<TChain extends Chain>(
-  client: PublicClient<any, TChain> | WalletClient,
+export async function getBlock<
+  TChain extends Chain,
+  TAccount extends Account | undefined,
+>(
+  client: PublicClient<any, TChain> | WalletClient<any, any, TAccount>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getBlockTransactionCount.test.ts
+++ b/src/actions/public/getBlockTransactionCount.test.ts
@@ -7,7 +7,7 @@ import {
   testClient,
   walletClient,
 } from '../../_test'
-import { getAccount, parseEther } from '../../utils'
+import { parseEther } from '../../utils'
 import { mine } from '../test'
 import { sendTransaction } from '..'
 import { getBlock } from './getBlock'
@@ -44,7 +44,7 @@ test('args: blockTag', async () => {
     }),
   ).toBe(0)
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })

--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -1,10 +1,11 @@
 import type { PublicClient, WalletClient } from '../../clients'
+import type { Account } from '../../types'
 import { hexToNumber } from '../../utils'
 
 export type GetChainIdReturnType = number
 
-export async function getChainId(
-  client: PublicClient | WalletClient,
+export async function getChainId<TAccount extends Account | undefined>(
+  client: PublicClient | WalletClient<any, any, TAccount>,
 ): Promise<GetChainIdReturnType> {
   const chainIdHex = await client.request({ method: 'eth_chainId' })
   return hexToNumber(chainIdHex)

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -17,7 +17,7 @@ import {
   stopImpersonatingAccount,
 } from '../test'
 import { sendTransaction, writeContract } from '../wallet'
-import { getAccount, getAddress, parseEther } from '../../utils'
+import { getAddress, parseEther } from '../../utils'
 import type { Hash, Log } from '../../types'
 import { createBlockFilter } from './createBlockFilter'
 import { createEventFilter } from './createEventFilter'
@@ -98,12 +98,12 @@ test('pending txns', async () => {
   const filter = await createPendingTransactionFilter(publicClient)
 
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -118,7 +118,7 @@ test('pending txns', async () => {
   expect(hashes.length).toBe(0)
 
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -155,17 +155,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -209,17 +209,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -284,17 +284,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -332,17 +332,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -386,17 +386,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -434,17 +434,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -484,13 +484,13 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
 
     await mine(testClient, { blocks: 1 })
@@ -506,7 +506,7 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[2].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
 
     await mine(testClient, { blocks: 1 })
@@ -524,13 +524,13 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
 
     await mine(testClient, { blocks: 1 })
@@ -558,7 +558,7 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[2].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
 
@@ -607,25 +607,25 @@ describe('events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[2].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -681,25 +681,25 @@ describe('events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -766,25 +766,25 @@ describe('events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -825,25 +825,25 @@ describe('events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -20,7 +20,7 @@ import { writeContract } from '../wallet'
 import type { Log } from '../../types'
 import { createEventFilter } from './createEventFilter'
 import { getFilterLogs } from './getFilterLogs'
-import { getAccount, getAddress } from '../../utils'
+import { getAddress } from '../../utils'
 import { createContractEventFilter } from './createContractEventFilter'
 
 const event = {
@@ -103,17 +103,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -157,17 +157,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -232,17 +232,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -280,17 +280,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -334,17 +334,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -382,17 +382,17 @@ describe('contract events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -432,13 +432,13 @@ describe('raw events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
     })
 
     await mine(testClient, { blocks: 1 })
@@ -457,13 +457,13 @@ describe('raw events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
 
     await mine(testClient, { blocks: 1 })
@@ -511,25 +511,25 @@ describe('raw events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -583,25 +583,25 @@ describe('raw events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -642,25 +642,25 @@ describe('raw events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -701,25 +701,25 @@ describe('raw events', () => {
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })

--- a/src/actions/public/getGasPrice.ts
+++ b/src/actions/public/getGasPrice.ts
@@ -1,12 +1,13 @@
 import type { PublicClient, WalletClient } from '../../clients'
+import type { Account } from '../../types'
 
 export type GetGasPriceReturnType = bigint
 
 /**
  * @description Returns the current price of gas (in wei).
  */
-export async function getGasPrice(
-  client: PublicClient | WalletClient,
+export async function getGasPrice<TAccount extends Account | undefined>(
+  client: PublicClient | WalletClient<any, any, TAccount>,
 ): Promise<GetGasPriceReturnType> {
   const gasPrice = await client.request({
     method: 'eth_gasPrice',

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -95,13 +95,13 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
 
@@ -115,13 +115,13 @@ describe('events', () => {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
 
@@ -181,25 +181,25 @@ describe('events', () => {
   test('args: singular `from`', async () => {
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -247,25 +247,25 @@ describe('events', () => {
   test('args: multiple `from`', async () => {
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -301,25 +301,25 @@ describe('events', () => {
   test('args: singular `to`', async () => {
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -355,25 +355,25 @@ describe('events', () => {
   test('args: multiple `to`', async () => {
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.usdcHolder),
+      account: address.usdcHolder,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })

--- a/src/actions/public/getTransaction.test.ts
+++ b/src/actions/public/getTransaction.test.ts
@@ -86,7 +86,7 @@ test('gets transaction (eip2930)', async () => {
 
   const hash = await sendTransaction(walletClient, {
     accessList: [{ address: targetAccount.address, storageKeys: [] }],
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
     gasPrice: BigInt(block.baseFeePerGas ?? 0),
@@ -299,7 +299,7 @@ describe('args: blockNumber', () => {
 describe('args: blockTag', () => {
   test('gets transaction by block tag & index', async () => {
     await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
     })

--- a/src/actions/public/getTransactionConfirmations.test.ts
+++ b/src/actions/public/getTransactionConfirmations.test.ts
@@ -9,7 +9,7 @@ import { sendTransaction } from '..'
 
 test('default', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -26,7 +26,7 @@ test('default', async () => {
 
 test('multiple confirmations', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -43,7 +43,7 @@ test('multiple confirmations', async () => {
 
 test('args: hash', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -57,7 +57,7 @@ test('args: hash', async () => {
 
 test('no confirmations', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })

--- a/src/actions/public/getTransactionCount.test.ts
+++ b/src/actions/public/getTransactionCount.test.ts
@@ -18,7 +18,7 @@ test(
     ).toBe(0)
 
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[0].address,
       value: parseEther('1'),
     })

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -1,5 +1,5 @@
 import type { PublicClient, WalletClient } from '../../clients'
-import type { Address, BlockTag } from '../../types'
+import type { Account, Address, BlockTag } from '../../types'
 import { hexToNumber, numberToHex } from '../../utils'
 
 export type GetTransactionCountParameters = {
@@ -22,8 +22,8 @@ export type GetTransactionCountReturnType = number
 /**
  * @description Returns the number of transactions an account has broadcast / sent.
  */
-export async function getTransactionCount(
-  client: PublicClient | WalletClient,
+export async function getTransactionCount<TAccount extends Account | undefined>(
+  client: PublicClient | WalletClient<any, any, TAccount>,
   { address, blockTag = 'latest', blockNumber }: GetTransactionCountParameters,
 ): Promise<GetTransactionCountReturnType> {
   const count = await client.request({

--- a/src/actions/public/getTransactionReceipt.test.ts
+++ b/src/actions/public/getTransactionReceipt.test.ts
@@ -122,7 +122,7 @@ describe('e2e', () => {
     const maxPriorityFeePerGas = parseGwei('10')
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas,

--- a/src/actions/public/simulateContract.bench.ts
+++ b/src/actions/public/simulateContract.bench.ts
@@ -19,7 +19,7 @@ describe('Simulate Contract', () => {
       ...wagmiContractConfig,
       functionName: 'mint',
       args: [42111n],
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
     })
   })
 

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -18,12 +18,7 @@ import {
   walletClient,
 } from '../../_test'
 import { baycContractConfig } from '../../_test/abis'
-import {
-  encodeFunctionData,
-  getAccount,
-  parseEther,
-  parseGwei,
-} from '../../utils'
+import { encodeFunctionData, parseEther, parseGwei } from '../../utils'
 import { mine } from '../test'
 import { sendTransaction } from '../wallet'
 
@@ -37,7 +32,7 @@ describe('wagmi', () => {
       (
         await simulateContract(publicClient, {
           ...wagmiContractConfig,
-          account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+          account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
           functionName: 'mint',
           args: [69420n],
         })
@@ -48,7 +43,7 @@ describe('wagmi', () => {
         await simulateContract(publicClient, {
           ...wagmiContractConfig,
           functionName: 'safeTransferFrom',
-          account: getAccount('0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6'),
+          account: '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
           args: [
             '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
             '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
@@ -64,11 +59,32 @@ describe('wagmi', () => {
       (
         await simulateContract(publicClient, {
           ...wagmiContractConfig,
-          account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+          account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
           functionName: 'mint',
         })
       ).result,
     ).toEqual(undefined)
+  })
+
+  test('no account', async () => {
+    await expect(() =>
+      simulateContract(publicClient, {
+        ...wagmiContractConfig,
+        functionName: 'mint',
+        args: [69420n],
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "The contract function \\"mint\\" reverted with the following reason:
+      ERC721: mint to the zero address
+
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  mint(uint256 tokenId)
+        args:          (69420)
+
+      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Version: viem@1.0.2"
+    `)
   })
 
   test('revert', async () => {
@@ -77,7 +93,7 @@ describe('wagmi', () => {
         ...wagmiContractConfig,
         functionName: 'approve',
         args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 420n],
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       "The contract function \\"approve\\" reverted with the following reason:
@@ -97,7 +113,7 @@ describe('wagmi', () => {
         ...wagmiContractConfig,
         functionName: 'mint',
         args: [1n],
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(`
       "The contract function \\"mint\\" reverted with the following reason:
@@ -116,7 +132,7 @@ describe('wagmi', () => {
       simulateContract(publicClient, {
         ...wagmiContractConfig,
         functionName: 'safeTransferFrom',
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         args: [
           '0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6',
           '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
@@ -151,7 +167,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           functionName: 'flipSaleState',
         }),
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
         to: contractAddress!,
       })
       await mine(testClient, { blocks: 1 })
@@ -163,7 +179,7 @@ describe('BAYC', () => {
             abi: baycContractConfig.abi,
             address: contractAddress!,
             functionName: 'mintApe',
-            account: getAccount(accounts[0].address),
+            account: accounts[0].address,
             args: [1n],
             value: 1000000000000000000n,
           })
@@ -181,7 +197,7 @@ describe('BAYC', () => {
             abi: baycContractConfig.abi,
             address: contractAddress!,
             functionName: 'reserveApes',
-            account: getAccount(accounts[0].address),
+            account: accounts[0].address,
           })
         ).result,
       ).toBe(undefined)
@@ -198,7 +214,7 @@ describe('BAYC', () => {
           abi: baycContractConfig.abi,
           address: contractAddress!,
           functionName: 'mintApe',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
           args: [1n],
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
@@ -229,7 +245,7 @@ describe('contract errors', () => {
           abi: errorsExampleABI,
           address: contractAddress!,
           functionName: 'revertWrite',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
         }),
       ).rejects.toMatchInlineSnapshot(`
         [ContractFunctionExecutionError: The contract function "revertWrite" reverted with the following reason:
@@ -257,7 +273,7 @@ describe('contract errors', () => {
           abi: errorsExampleABI,
           address: contractAddress!,
           functionName: 'assertWrite',
-          account: getAccount(accounts[0].address),
+          account: accounts[0].address,
         }),
       ).rejects.toMatchInlineSnapshot(`
         [ContractFunctionExecutionError: The contract function "assertWrite" reverted with the following reason:
@@ -283,7 +299,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'overflowWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "overflowWrite" reverted with the following reason:
@@ -307,7 +323,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'divideByZeroWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "divideByZeroWrite" reverted with the following reason:
@@ -331,7 +347,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'requireWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "requireWrite" reverted with the following reason:
@@ -355,7 +371,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'simpleCustomWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "simpleCustomWrite" reverted.
@@ -381,7 +397,7 @@ describe('contract errors', () => {
         abi: errorsExampleABI,
         address: contractAddress!,
         functionName: 'complexCustomWrite',
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
       }),
     ).rejects.toMatchInlineSnapshot(`
       [ContractFunctionExecutionError: The contract function "complexCustomWrite" reverted.
@@ -414,7 +430,7 @@ test('fake contract address', async () => {
       ],
       address: '0x0000000000000000000000000000000000000069',
       functionName: 'mint',
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
     }),
   ).rejects.toThrowErrorMatchingInlineSnapshot(`
     "The contract function \\"mint\\" returned no data (\\"0x\\").
@@ -439,7 +455,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         maxFeePerGas: 2n ** 256n - 1n + 1n,
@@ -469,7 +485,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         gas: 100n,
@@ -503,7 +519,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         gas: 100_000_000_000_000_000n,
@@ -516,7 +532,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         maxFeePerGas: 1n,
@@ -529,7 +545,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         nonce: 0,
@@ -542,7 +558,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         // @ts-expect-error
@@ -567,7 +583,7 @@ describe('node errors', () => {
     await expect(() =>
       simulateContract(publicClient, {
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69420n],
         maxFeePerGas: parseGwei('20'),

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -14,6 +14,7 @@ import {
   encodeFunctionData,
   EncodeFunctionDataParameters,
   getContractError,
+  parseAccount,
 } from '../../utils'
 import type { WriteContractParameters } from '../wallet'
 import { call, CallParameters } from './call'
@@ -63,6 +64,9 @@ export async function simulateContract<
     TFunctionName
   >
 > {
+  const account = callRequest.account
+    ? parseAccount(callRequest.account)
+    : undefined
   const calldata = encodeFunctionData({
     abi,
     args,
@@ -101,7 +105,7 @@ export async function simulateContract<
       args,
       docsPath: '/docs/contract/simulateContract',
       functionName,
-      sender: callRequest.account?.address,
+      sender: account?.address,
     })
   }
 }

--- a/src/actions/public/uninstallFilter.test.ts
+++ b/src/actions/public/uninstallFilter.test.ts
@@ -19,12 +19,12 @@ test('pending txns', async () => {
   const filter = await createPendingTransactionFilter(publicClient)
 
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
@@ -41,7 +41,7 @@ test('pending txns', async () => {
   expect(await uninstallFilter(publicClient, { filter })).toBeTruthy()
 
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -13,7 +13,7 @@ const targetAccount = accounts[1]
 
 test('waits for transaction (send -> wait -> mine)', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
   })
@@ -25,7 +25,7 @@ test('waits for transaction (send -> wait -> mine)', async () => {
 
 test('waits for transaction (send -> mine -> wait)', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
   })
@@ -49,7 +49,7 @@ describe('replaced transactions', () => {
     )
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -67,7 +67,7 @@ describe('replaced transactions', () => {
 
         // speed up
         await sendTransaction(walletClient, {
-          account: getAccount(sourceAccount.address),
+          account: sourceAccount.address,
           to: targetAccount.address,
           value: parseEther('1'),
           nonce,
@@ -97,7 +97,7 @@ describe('replaced transactions', () => {
     )
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -113,7 +113,7 @@ describe('replaced transactions', () => {
 
         // speed up
         await sendTransaction(walletClient, {
-          account: getAccount(sourceAccount.address),
+          account: sourceAccount.address,
           to: targetAccount.address,
           value: parseEther('1'),
           nonce,
@@ -142,7 +142,7 @@ describe('replaced transactions', () => {
     )
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -160,7 +160,7 @@ describe('replaced transactions', () => {
 
         // speed up
         await sendTransaction(walletClient, {
-          account: getAccount(sourceAccount.address),
+          account: sourceAccount.address,
           to: sourceAccount.address,
           value: parseEther('0'),
           nonce,
@@ -190,7 +190,7 @@ describe('replaced transactions', () => {
     )
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -208,7 +208,7 @@ describe('replaced transactions', () => {
 
         // speed up
         await sendTransaction(walletClient, {
-          account: getAccount(sourceAccount.address),
+          account: sourceAccount.address,
           to: targetAccount.address,
           value: parseEther('2'),
           nonce,
@@ -230,7 +230,7 @@ describe('replaced transactions', () => {
 describe('args: confirmations', () => {
   test('waits for confirmations', async () => {
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -260,7 +260,7 @@ describe('args: confirmations', () => {
     )
 
     const hash = await sendTransaction(walletClient, {
-      account: getAccount(sourceAccount.address),
+      account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
       maxFeePerGas: parseGwei('10'),
@@ -277,7 +277,7 @@ describe('args: confirmations', () => {
 
         // speed up
         await sendTransaction(walletClient, {
-          account: getAccount(sourceAccount.address),
+          account: sourceAccount.address,
           to: targetAccount.address,
           value: parseEther('1'),
           nonce,
@@ -295,7 +295,7 @@ describe('args: confirmations', () => {
 
 test('args: timeout', async () => {
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
   })

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -42,7 +42,7 @@ test(
     })
 
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     })

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -7,7 +7,7 @@ import {
   test,
   vi,
 } from 'vitest'
-import { getAccount, getAddress } from '../../utils'
+import { getAddress } from '../../utils'
 import { wait } from '../../utils/wait'
 import {
   accounts,
@@ -67,20 +67,20 @@ test(
 
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
     await wait(1000)
     await writeContract(walletClient, {
       ...usdcContractConfig,
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
@@ -125,20 +125,20 @@ test('args: batch', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [address.vitalik, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [address.vitalik, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -170,20 +170,20 @@ test('args: eventName', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [address.vitalik, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [address.vitalik, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -222,20 +222,20 @@ test('args: args', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[1].address, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -268,20 +268,20 @@ test('args: args', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[1].address, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -320,20 +320,20 @@ test('args: args', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.usdcHolder),
+    account: address.usdcHolder,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[1].address, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -384,20 +384,20 @@ test('args: args unnamed', async () => {
 
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'transfer',
     args: [accounts[1].address, 1n],
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     functionName: 'approve',
     args: [address.vitalik, 1n],
   })
@@ -448,20 +448,20 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await wait(1000)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[1].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await wait(2000)
       unwatch()
@@ -500,13 +500,13 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[1].address, 1n],
-        account: getAccount(address.usdcHolder),
+        account: address.usdcHolder,
       })
       await mine(testClient, { blocks: 1 })
       await wait(1000)
@@ -514,7 +514,7 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await mine(testClient, { blocks: 2 })
       await wait(1000)
@@ -522,13 +522,13 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await mine(testClient, { blocks: 5 })
       await wait(2000)

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
-import { getAccount, getAddress } from '../../utils'
+import { getAddress } from '../../utils'
 import { wait } from '../../utils/wait'
 import {
   accounts,
@@ -95,20 +95,20 @@ test(
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await wait(1000)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
     })
     await wait(2000)
     unwatch()
@@ -133,20 +133,20 @@ test('args: batch', async () => {
     ...usdcContractConfig,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   await writeContract(walletClient, {
     ...usdcContractConfig,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   await wait(1000)
   await writeContract(walletClient, {
     ...usdcContractConfig,
     functionName: 'transfer',
     args: [accounts[1].address, 1n],
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   await wait(2000)
   unwatch()
@@ -175,7 +175,7 @@ test('args: address', async () => {
     ...usdcContractConfig,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   await wait(2000)
   unwatch()
@@ -205,7 +205,7 @@ test('args: address + event', async () => {
     ...usdcContractConfig,
     functionName: 'transfer',
     args: [accounts[0].address, 1n],
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   await wait(2000)
   unwatch()
@@ -248,20 +248,20 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await wait(2000)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[1].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await wait(2000)
       unwatch()
@@ -298,20 +298,20 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[0].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[1].address, 1n],
-        account: getAccount(address.usdcHolder),
+        account: address.usdcHolder,
       })
       await wait(1000)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await mine(testClient, { blocks: 2 })
       await wait(1000)
@@ -319,13 +319,13 @@ describe('`getLogs` fallback', () => {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[2].address, 1n],
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       })
       await mine(testClient, { blocks: 5 })
       await wait(2000)

--- a/src/actions/public/watchPendingTransactions.test.ts
+++ b/src/actions/public/watchPendingTransactions.test.ts
@@ -24,13 +24,13 @@ test(
     })
     await wait(1000)
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     })
     await wait(1000)
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[2].address),
+      account: accounts[2].address,
       to: accounts[3].address,
       value: parseEther('1'),
     })
@@ -57,18 +57,18 @@ test('watches for pending transactions (unbatched)', async () => {
   })
   await wait(1000)
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
   await wait(1000)
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('1'),
   })

--- a/src/actions/test/dropTransaction.test.ts
+++ b/src/actions/test/dropTransaction.test.ts
@@ -18,7 +18,7 @@ test('drops transaction', async () => {
     address: sourceAccount.address,
   })
   const hash = await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('2'),
   })

--- a/src/actions/test/getTxpoolContent.test.ts
+++ b/src/actions/test/getTxpoolContent.test.ts
@@ -20,12 +20,12 @@ test('gets txpool content (empty)', async () => {
 
 test('gets txpool content (pending)', async () => {
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('2'),
   })
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[2].address),
+    account: accounts[2].address,
     to: accounts[3].address,
     value: parseEther('3'),
   })

--- a/src/actions/test/getTxpoolStatus.test.ts
+++ b/src/actions/test/getTxpoolStatus.test.ts
@@ -20,12 +20,12 @@ test('gets txpool content (empty)', async () => {
 
 test('gets txpool content (pending)', async () => {
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     to: accounts[1].address,
     value: parseEther('2'),
   })
   await sendTransaction(walletClient, {
-    account: getAccount(accounts[2].address),
+    account: accounts[2].address,
     to: accounts[3].address,
     value: parseEther('3'),
   })

--- a/src/actions/test/impersonateAccount.test.ts
+++ b/src/actions/test/impersonateAccount.test.ts
@@ -8,7 +8,7 @@ import { impersonateAccount } from './impersonateAccount'
 test('impersonates account', async () => {
   await expect(
     sendTransaction(walletClient, {
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       to: accounts[0].address,
       value: parseEther('1'),
     }),
@@ -18,7 +18,7 @@ test('impersonates account', async () => {
 
   expect(
     await sendTransaction(walletClient, {
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       to: accounts[0].address,
       value: parseEther('1'),
     }),

--- a/src/actions/test/inspectTxpool.test.ts
+++ b/src/actions/test/inspectTxpool.test.ts
@@ -22,12 +22,12 @@ test(
   'inspects txpool (pending)',
   async () => {
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('2'),
     })
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[2].address),
+      account: accounts[2].address,
       to: accounts[3].address,
       value: parseEther('3'),
     })

--- a/src/actions/test/revert.test.ts
+++ b/src/actions/test/revert.test.ts
@@ -19,7 +19,7 @@ test('reverts', async () => {
   const id = await snapshot(testClient)
 
   await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('2'),
   })

--- a/src/actions/test/snapshot.test.ts
+++ b/src/actions/test/snapshot.test.ts
@@ -10,7 +10,7 @@ const targetAccount = accounts[1]
 
 test('snapshots', async () => {
   await sendTransaction(walletClient, {
-    account: getAccount(sourceAccount.address),
+    account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
   })

--- a/src/actions/test/stopImpersonatingAccount.test.ts
+++ b/src/actions/test/stopImpersonatingAccount.test.ts
@@ -11,7 +11,7 @@ test('stops impersonating account', async () => {
 
   expect(
     await sendTransaction(walletClient, {
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       to: accounts[0].address,
       value: parseEther('1'),
     }),
@@ -21,7 +21,7 @@ test('stops impersonating account', async () => {
 
   await expect(
     sendTransaction(walletClient, {
-      account: getAccount(address.vitalik),
+      account: address.vitalik,
       to: accounts[0].address,
       value: parseEther('1'),
     }),

--- a/src/actions/wallet/deployContract.test.ts
+++ b/src/actions/wallet/deployContract.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'vitest'
-import { accounts, testClient, walletClient } from '../../_test'
+import {
+  walletClientWithAccount,
+  accounts,
+  testClient,
+  walletClient,
+} from '../../_test'
 import { baycContractConfig } from '../../_test/abis'
 import { getAccount, parseEther } from '../../utils'
 import { mine, setBalance } from '../test'
@@ -10,7 +15,17 @@ test('default', async () => {
   const hash = await deployContract(walletClient, {
     ...baycContractConfig,
     args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
+  })
+  expect(hash).toBeDefined()
+
+  await mine(testClient, { blocks: 1 })
+})
+
+test('inferred account', async () => {
+  const hash = await deployContract(walletClientWithAccount, {
+    ...baycContractConfig,
+    args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
   })
   expect(hash).toBeDefined()
 
@@ -27,7 +42,7 @@ test('no funds', async () => {
     deployContract(walletClient, {
       ...baycContractConfig,
       args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
     }),
   ).rejects.toThrowErrorMatchingSnapshot()
 

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -1,7 +1,12 @@
 import type { Abi, Narrow } from 'abitype'
 
 import type { WalletClient } from '../../clients'
-import type { Chain, ExtractConstructorArgsFromAbi, Hex } from '../../types'
+import type {
+  Account,
+  Chain,
+  ExtractConstructorArgsFromAbi,
+  Hex,
+} from '../../types'
 import { encodeDeployData } from '../../utils'
 import {
   sendTransaction,
@@ -12,8 +17,9 @@ import {
 export type DeployContractParameters<
   TChain extends Chain = Chain,
   TAbi extends Abi | readonly unknown[] = Abi,
+  TAccount extends Account | undefined = undefined,
 > = Omit<
-  SendTransactionParameters<TChain>,
+  SendTransactionParameters<TChain, TAccount>,
   'accessList' | 'to' | 'data' | 'value'
 > & {
   abi: Narrow<TAbi>
@@ -25,9 +31,15 @@ export type DeployContractReturnType = SendTransactionReturnType
 export function deployContract<
   TChain extends Chain,
   TAbi extends Abi | readonly unknown[],
+  TAccount extends Account | undefined,
 >(
-  walletClient: WalletClient,
-  { abi, args, bytecode, ...request }: DeployContractParameters<TChain, TAbi>,
+  walletClient: WalletClient<any, any, TAccount>,
+  {
+    abi,
+    args,
+    bytecode,
+    ...request
+  }: DeployContractParameters<TChain, TAbi, TAccount>,
 ): Promise<DeployContractReturnType> {
   const calldata = encodeDeployData({
     abi,
@@ -37,5 +49,5 @@ export function deployContract<
   return sendTransaction(walletClient, {
     ...request,
     data: calldata,
-  } as unknown as SendTransactionParameters<TChain>)
+  } as unknown as SendTransactionParameters<TChain, TAccount>)
 }

--- a/src/actions/wallet/sendTransaction.bench.ts
+++ b/src/actions/wallet/sendTransaction.bench.ts
@@ -14,7 +14,7 @@ import { JsonRpcSigner } from 'ethers@6'
 describe('Send Transaction', () => {
   bench('viem: `sendTransaction`', async () => {
     await sendTransaction(walletClient, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     })

--- a/src/actions/wallet/signMessage.test.ts
+++ b/src/actions/wallet/signMessage.test.ts
@@ -1,28 +1,47 @@
 import { expect, test } from 'vitest'
 
-import { accounts, getLocalAccount, walletClient } from '../../_test'
+import {
+  walletClientWithAccount,
+  accounts,
+  getLocalAccount,
+  walletClient,
+} from '../../_test'
 import { getAccount } from '../../utils'
 import { signMessage } from './signMessage'
 
 test('default', async () => {
   expect(
     await signMessage(walletClient!, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       message: 'hello world',
     }),
   ).toMatchInlineSnapshot(
     '"0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"',
   )
+})
 
+test('inferred account', async () => {
+  expect(
+    await signMessage(walletClientWithAccount!, {
+      message: 'hello world',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"',
+  )
+})
+
+test('emoji', async () => {
   expect(
     await signMessage(walletClient!, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       message: '🥵',
     }),
   ).toMatchInlineSnapshot(
     '"0x05c99bbbe9fac3ad61721a815d19d6771ad39f3e8dffa7ae7561358f20431d8e7f9e1d487c77355790c79c6eb0b0d63690f690615ef99ee3e4f25eef0317d0701b"',
   )
+})
 
+test('local account', async () => {
   const account = getLocalAccount(accounts[0].privateKey)
   expect(
     await signMessage(walletClient!, {
@@ -32,13 +51,32 @@ test('default', async () => {
   ).toMatchInlineSnapshot(
     '"0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"',
   )
+})
 
+test('args: data', async () => {
   expect(
     await signMessage(walletClient!, {
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       data: 'hello world',
     }),
   ).toMatchInlineSnapshot(
     '"0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"',
+  )
+})
+
+test('error: no account', async () => {
+  await expect(
+    // @ts-expect-error
+    signMessage(walletClient!, {
+      message: 'hello world',
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(
+    `
+    "Could not find an Account to execute with this Action.
+    Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the WalletClient.
+
+    Docs: https://viem.sh/docs/actions/wallet/signMessage.html#account
+    Version: viem@1.0.2"
+  `,
   )
 })

--- a/src/actions/wallet/signMessage.ts
+++ b/src/actions/wallet/signMessage.ts
@@ -1,27 +1,38 @@
 import type { WalletClient } from '../../clients'
-import type { Account, Hex } from '../../types'
-import { toHex } from '../../utils'
+import { AccountNotFoundError } from '../../errors'
+import type { Account, GetAccountParameter, Hex } from '../../types'
+import { parseAccount, toHex } from '../../utils'
 
-export type SignMessageParameters = {
-  account: Account
-} & (
-  | {
-      /** @deprecated – `data` will be removed in 0.2.0; use `message` instead. */
-      data: string
-      message?: never
-    }
-  | {
-      data?: never
-      message: string
-    }
-)
+export type SignMessageParameters<
+  TAccount extends Account | undefined = undefined,
+> = GetAccountParameter<TAccount> &
+  (
+    | {
+        /** @deprecated – `data` will be removed in 0.2.0; use `message` instead. */
+        data: string
+        message?: never
+      }
+    | {
+        data?: never
+        message: string
+      }
+  )
 
 export type SignMessageReturnType = Hex
 
-export async function signMessage(
-  client: WalletClient,
-  { account, data, message }: SignMessageParameters,
+export async function signMessage<TAccount extends Account | undefined>(
+  client: WalletClient<any, any, TAccount>,
+  {
+    account: account_ = client.account,
+    data,
+    message,
+  }: SignMessageParameters<TAccount>,
 ): Promise<SignMessageReturnType> {
+  if (!account_)
+    throw new AccountNotFoundError({
+      docsPath: '/docs/actions/wallet/signMessage',
+    })
+  const account = parseAccount(account_)
   const message_ = message || data
   if (account.type === 'local') return account.signMessage(message_!)
   return client.request({

--- a/src/actions/wallet/signTypedData.test.ts
+++ b/src/actions/wallet/signTypedData.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, test } from 'vitest'
 import { getAccount } from '../../utils'
-import { accounts, getLocalAccount, walletClient } from '../../_test'
+import {
+  walletClientWithAccount,
+  accounts,
+  getLocalAccount,
+  walletClient,
+} from '../../_test'
 
 import { signTypedData, validateTypedData } from './signTypedData'
 
 const localAccount = getLocalAccount(accounts[0].privateKey)
-const jsonRpcAccount = getAccount(accounts[0].address)
+const jsonRpcAccount = accounts[0].address
 
 const basic = {
   domain: {
@@ -116,6 +121,17 @@ describe('default', async () => {
       '0x32f3d5975ba38d6c2fba9b95d5cbed1febaa68003d3d588d51f2de522ad54117760cfc249470a75232552e43991f53953a3d74edf6944553c6bef2469bb9e5921b',
     )
   })
+})
+
+test('inferred account', async () => {
+  expect(
+    await signTypedData(walletClientWithAccount, {
+      ...basic,
+      primaryType: 'Mail',
+    }),
+  ).toEqual(
+    '0x32f3d5975ba38d6c2fba9b95d5cbed1febaa68003d3d588d51f2de522ad54117760cfc249470a75232552e43991f53953a3d74edf6944553c6bef2469bb9e5921b',
+  )
 })
 
 describe('minimal', () => {
@@ -634,4 +650,20 @@ describe('validateTypedData', () => {
       Version: viem@1.0.2"
     `)
   })
+})
+
+test('no account', async () => {
+  await expect(() =>
+    // @ts-expect-error
+    signTypedData(walletClient, {
+      ...basic,
+      primaryType: 'Mail',
+    }),
+  ).rejects.toThrowErrorMatchingInlineSnapshot(`
+    "Could not find an Account to execute with this Action.
+    Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the WalletClient.
+
+    Docs: https://viem.sh/docs/actions/wallet/signTypedData.html#account
+    Version: viem@1.0.2"
+  `)
 })

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -23,7 +23,7 @@ test('default', async () => {
   ).toBeDefined()
 })
 
-test.only('inferred account', async () => {
+test('inferred account', async () => {
   expect(
     await writeContract(walletClientWithAccount, {
       ...wagmiContractConfig,

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { getAccount } from '../../utils'
 import {
+  walletClientWithAccount,
   accounts,
   publicClient,
   testClient,
@@ -16,7 +17,16 @@ test('default', async () => {
   expect(
     await writeContract(walletClient, {
       ...wagmiContractConfig,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
+      functionName: 'mint',
+    }),
+  ).toBeDefined()
+})
+
+test.only('inferred account', async () => {
+  expect(
+    await writeContract(walletClientWithAccount, {
+      ...wagmiContractConfig,
       functionName: 'mint',
     }),
   ).toBeDefined()
@@ -26,7 +36,7 @@ test('overloaded function', async () => {
   expect(
     await writeContract(walletClient, {
       ...wagmiContractConfig,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       functionName: 'mint',
       args: [69420n],
     }),
@@ -36,7 +46,7 @@ test('overloaded function', async () => {
 test('w/ simulateContract', async () => {
   const { request } = await simulateContract(publicClient, {
     ...wagmiContractConfig,
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     functionName: 'mint',
   })
   expect(await writeContract(walletClient, request)).toBeDefined()
@@ -46,7 +56,7 @@ test('w/ simulateContract', async () => {
   expect(
     await simulateContract(publicClient, {
       ...wagmiContractConfig,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       functionName: 'mint',
     }),
   ).toBeDefined()
@@ -55,7 +65,7 @@ test('w/ simulateContract', async () => {
 test('w/ simulateContract (overloaded)', async () => {
   const { request } = await simulateContract(publicClient, {
     ...wagmiContractConfig,
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     functionName: 'mint',
     args: [69421n],
   })
@@ -66,7 +76,7 @@ test('w/ simulateContract (overloaded)', async () => {
   await expect(() =>
     simulateContract(publicClient, {
       ...wagmiContractConfig,
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       functionName: 'mint',
       args: [69421n],
     }),

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -1,7 +1,7 @@
 import type { Abi } from 'abitype'
 
 import type { WalletClient } from '../../clients'
-import type { Chain, ContractConfig, GetValue } from '../../types'
+import type { Account, Chain, ContractConfig, GetValue } from '../../types'
 import { encodeFunctionData, EncodeFunctionDataParameters } from '../../utils'
 import {
   sendTransaction,
@@ -13,7 +13,11 @@ export type WriteContractParameters<
   TChain extends Chain = Chain,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-> = Omit<SendTransactionParameters<TChain>, 'to' | 'data' | 'value'> & {
+  TAccount extends Account | undefined = undefined,
+> = Omit<
+  SendTransactionParameters<TChain, TAccount>,
+  'to' | 'data' | 'value'
+> & {
   value?: GetValue<
     TAbi,
     TFunctionName,
@@ -27,15 +31,16 @@ export async function writeContract<
   TChain extends Chain,
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
+  TAccount extends Account | undefined,
 >(
-  client: WalletClient,
+  client: WalletClient<any, any, TAccount>,
   {
     abi,
     address,
     args,
     functionName,
     ...request
-  }: WriteContractParameters<TChain, TAbi, TFunctionName>,
+  }: WriteContractParameters<TChain, TAbi, TFunctionName, TAccount>,
 ): Promise<WriteContractReturnType> {
   const data = encodeFunctionData({
     abi,
@@ -46,6 +51,6 @@ export async function writeContract<
     data,
     to: address,
     ...request,
-  } as unknown as SendTransactionParameters<TChain>)
+  } as unknown as SendTransactionParameters<TChain, TAccount>)
   return hash
 }

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -1,13 +1,14 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
+import { localhost } from '../chains'
+import type { JsonRpcAccount, LocalAccount } from '../types'
+import type { SignableRequests, WalletRequests } from '../types/eip1193'
+import { accounts, getLocalAccount, localWsUrl } from '../_test'
 import { createWalletClient } from './createWalletClient'
 import { createTransport } from './transports/createTransport'
+import { custom } from './transports/custom'
 import { http } from './transports/http'
 import { webSocket } from './transports/webSocket'
-import { localhost } from '../chains'
-import type { SignableRequests, WalletRequests } from '../types/eip1193'
-import { custom } from './transports/custom'
-import { localWsUrl } from '../_test'
 
 const mockTransport = () =>
   createTransport({
@@ -23,9 +24,13 @@ test('creates', () => {
   assertType<SignableRequests['request'] & WalletRequests['request']>(
     client.request,
   )
+  assertType<{
+    account: undefined
+  }>(client)
   expect(uid).toBeDefined()
   expect(client).toMatchInlineSnapshot(`
     {
+      "account": undefined,
       "addChain": [Function],
       "chain": undefined,
       "deployContract": [Function],
@@ -58,7 +63,106 @@ test('creates', () => {
   `)
 })
 
-describe('transports', () => {
+describe('args: account', () => {
+  test('json-rpc account', () => {
+    const { uid, ...client } = createWalletClient({
+      account: accounts[0].address,
+      transport: mockTransport,
+    })
+    assertType<{
+      account: JsonRpcAccount
+    }>(client)
+    expect(uid).toBeDefined()
+    expect(client).toMatchInlineSnapshot(`
+      {
+        "account": {
+          "address": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+          "type": "json-rpc",
+        },
+        "addChain": [Function],
+        "chain": undefined,
+        "deployContract": [Function],
+        "getAddresses": [Function],
+        "getChainId": [Function],
+        "getPermissions": [Function],
+        "key": "wallet",
+        "name": "Wallet Client",
+        "pollingInterval": 4000,
+        "request": [Function],
+        "requestAddresses": [Function],
+        "requestPermissions": [Function],
+        "sendTransaction": [Function],
+        "signMessage": [Function],
+        "signTypedData": [Function],
+        "switchChain": [Function],
+        "transport": {
+          "key": "mock",
+          "name": "Mock Transport",
+          "request": [MockFunction spy],
+          "retryCount": 3,
+          "retryDelay": 150,
+          "timeout": undefined,
+          "type": "mock",
+        },
+        "type": "walletClient",
+        "watchAsset": [Function],
+        "writeContract": [Function],
+      }
+    `)
+  })
+
+  test('local account', () => {
+    const { uid, ...client } = createWalletClient({
+      account: getLocalAccount(accounts[0].privateKey),
+      transport: mockTransport,
+    })
+    assertType<{
+      account: LocalAccount
+    }>(client)
+    expect(uid).toBeDefined()
+    expect(client).toMatchInlineSnapshot(`
+      {
+        "account": {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "signMessage": [Function],
+          "signTransaction": [Function],
+          "signTypedData": [Function],
+          "type": "local",
+        },
+        "addChain": [Function],
+        "chain": undefined,
+        "deployContract": [Function],
+        "getAddresses": [Function],
+        "getChainId": [Function],
+        "getPermissions": [Function],
+        "key": "wallet",
+        "name": "Wallet Client",
+        "pollingInterval": 4000,
+        "request": [Function],
+        "requestAddresses": [Function],
+        "requestPermissions": [Function],
+        "sendTransaction": [Function],
+        "signMessage": [Function],
+        "signTypedData": [Function],
+        "switchChain": [Function],
+        "transport": {
+          "key": "mock",
+          "name": "Mock Transport",
+          "request": [MockFunction spy],
+          "retryCount": 3,
+          "retryDelay": 150,
+          "timeout": undefined,
+          "type": "mock",
+        },
+        "type": "walletClient",
+        "watchAsset": [Function],
+        "writeContract": [Function],
+      }
+    `)
+  })
+})
+
+describe('args: transport', () => {
   test('custom', () => {
     const { uid, ...client } = createWalletClient({
       transport: custom({ request: async () => null }),
@@ -67,6 +171,7 @@ describe('transports', () => {
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
+        "account": undefined,
         "addChain": [Function],
         "chain": undefined,
         "deployContract": [Function],
@@ -107,6 +212,7 @@ describe('transports', () => {
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
+        "account": undefined,
         "addChain": [Function],
         "chain": undefined,
         "deployContract": [Function],
@@ -149,6 +255,7 @@ describe('transports', () => {
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
+        "account": undefined,
         "addChain": [Function],
         "chain": {
           "id": 1337,

--- a/src/clients/decorators/public.test.ts
+++ b/src/clients/decorators/public.test.ts
@@ -58,7 +58,7 @@ describe('smoke test', () => {
   test('call', async () => {
     const { data } = await publicClient.call({
       data: '0x06fdde03',
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: wagmiContractConfig.address,
     })
     expect(data).toMatchInlineSnapshot(
@@ -90,7 +90,7 @@ describe('smoke test', () => {
     expect(
       await publicClient.estimateContractGas({
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69436n],
       }),
@@ -100,7 +100,7 @@ describe('smoke test', () => {
   test('estimateGas', async () => {
     expect(
       await publicClient.estimateGas({
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
         to: accounts[1].address,
         value: parseEther('1'),
       }),
@@ -203,7 +203,7 @@ describe('smoke test', () => {
 
   test('getTransactionConfirmations', async () => {
     const hash = await walletClient.sendTransaction({
-      account: getAccount(accounts[0].address),
+      account: accounts[0].address,
       to: accounts[1].address,
       value: parseEther('1'),
     })
@@ -268,7 +268,7 @@ describe('smoke test', () => {
     expect(
       await publicClient.simulateContract({
         ...wagmiContractConfig,
-        account: getAccount('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'),
+        account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
         functionName: 'mint',
         args: [69435n],
       }),
@@ -282,7 +282,7 @@ describe('smoke test', () => {
 
   test('waitForTransactionReceipt', async () => {
     const hash = await walletClient.sendTransaction({
-      account: getAccount(accounts[6].address),
+      account: accounts[6].address,
       to: accounts[7].address,
       value: parseEther('1'),
     })

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -51,7 +51,7 @@ test('default', async () => {
 describe('smoke test', () => {
   test('dropTransaction', async () => {
     const hash = await walletClient.sendTransaction({
-      account: getAccount(accounts[6].address),
+      account: accounts[6].address,
       to: accounts[7].address,
       value: parseEther('2'),
     })

--- a/src/clients/decorators/wallet.test.ts
+++ b/src/clients/decorators/wallet.test.ts
@@ -3,6 +3,7 @@ import { avalanche } from '../../chains'
 import { getAccount, parseEther } from '../../utils'
 import { accounts, walletClient } from '../../_test'
 import { baycContractConfig, wagmiContractConfig } from '../../_test/abis'
+import { walletClientWithAccount } from '../../_test/utils'
 import { walletActions } from './wallet'
 
 test('default', async () => {
@@ -35,7 +36,16 @@ describe('smoke test', () => {
       await walletClient.deployContract({
         ...baycContractConfig,
         args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
+      }),
+    ).toBeDefined()
+  })
+
+  test('deployContract (inferred account)', async () => {
+    expect(
+      await walletClientWithAccount.deployContract({
+        ...baycContractConfig,
+        args: ['Bored Ape Wagmi Club', 'BAYC', 69420n, 0n],
       }),
     ).toBeDefined()
   })
@@ -61,7 +71,16 @@ describe('smoke test', () => {
   test('sendTransaction', async () => {
     expect(
       await walletClient.sendTransaction({
-        account: getAccount(accounts[6].address),
+        account: accounts[6].address,
+        to: accounts[7].address,
+        value: parseEther('1'),
+      }),
+    ).toBeDefined()
+  })
+
+  test('sendTransaction (inferred account)', async () => {
+    expect(
+      await walletClientWithAccount.sendTransaction({
         to: accounts[7].address,
         value: parseEther('1'),
       }),
@@ -71,7 +90,15 @@ describe('smoke test', () => {
   test('signMessage', async () => {
     expect(
       await walletClient.signMessage({
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
+        message: '0xdeadbeaf',
+      }),
+    ).toBeDefined()
+  })
+
+  test('signMessage (inferred account)', async () => {
+    expect(
+      await walletClientWithAccount.signMessage({
         message: '0xdeadbeaf',
       }),
     ).toBeDefined()
@@ -80,7 +107,63 @@ describe('smoke test', () => {
   test('signTypedData', async () => {
     expect(
       await walletClient.signTypedData({
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
+        domain: {
+          name: 'Ether Mail',
+          version: '1',
+          chainId: 1,
+          verifyingContract: '0x0000000000000000000000000000000000000000',
+        },
+        types: {
+          Name: [
+            { name: 'first', type: 'string' },
+            { name: 'last', type: 'string' },
+          ],
+          Person: [
+            { name: 'name', type: 'Name' },
+            { name: 'wallet', type: 'address' },
+            { name: 'favoriteColors', type: 'string[3]' },
+            { name: 'age', type: 'uint8' },
+            { name: 'isCool', type: 'bool' },
+          ],
+          Mail: [
+            { name: 'timestamp', type: 'uint256' },
+            { name: 'from', type: 'Person' },
+            { name: 'to', type: 'Person' },
+            { name: 'contents', type: 'string' },
+            { name: 'hash', type: 'bytes' },
+          ],
+        },
+        primaryType: 'Mail',
+        message: {
+          timestamp: 1234567890n,
+          contents: 'Hello, Bob! 🖤',
+          hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+          from: {
+            name: {
+              first: 'Cow',
+              last: 'Burns',
+            },
+            wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+            age: 69,
+            favoriteColors: ['red', 'green', 'blue'],
+            isCool: false,
+          },
+          to: {
+            name: { first: 'Bob', last: 'Builder' },
+            wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+            age: 70,
+            favoriteColors: ['orange', 'yellow', 'green'],
+            isCool: true,
+          },
+        },
+      }),
+    ).toBeDefined()
+  })
+
+  test('signTypedData (inferred account)', async () => {
+    expect(
+      await walletClientWithAccount.signTypedData({
         domain: {
           name: 'Ether Mail',
           version: '1',
@@ -156,7 +239,16 @@ describe('smoke test', () => {
     expect(
       await walletClient.writeContract({
         ...wagmiContractConfig,
-        account: getAccount(accounts[0].address),
+        account: accounts[0].address,
+        functionName: 'mint',
+      }),
+    ).toBeTruthy()
+  })
+
+  test('writeContract (inferred account)', async () => {
+    expect(
+      await walletClientWithAccount.writeContract({
+        ...wagmiContractConfig,
         functionName: 'mint',
       }),
     ).toBeTruthy()

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -36,13 +36,16 @@ import {
   watchAsset,
   writeContract,
 } from '../../actions/wallet'
-import type { Chain } from '../../types'
+import type { Account, Chain } from '../../types'
 import type { WalletClient } from '../createWalletClient'
 
-export type WalletActions<TChain extends Chain = Chain> = {
+export type WalletActions<
+  TChain extends Chain = Chain,
+  TAccount extends Account | undefined = undefined,
+> = {
   addChain: (args: AddChainParameters) => Promise<void>
   deployContract: <TAbi extends Abi | readonly unknown[]>(
-    args: DeployContractParameters<TChain, TAbi>,
+    args: DeployContractParameters<TChain, TAbi, TAccount>,
   ) => Promise<DeployContractReturnType>
   getAddresses: () => Promise<GetAddressesReturnType>
   getChainId: () => Promise<GetChainIdReturnType>
@@ -52,11 +55,16 @@ export type WalletActions<TChain extends Chain = Chain> = {
     args: RequestPermissionsParameters,
   ) => Promise<RequestPermissionsReturnType>
   sendTransaction: <TChainOverride extends Chain>(
-    args: SendTransactionParameters<TChainOverride>,
+    args: SendTransactionParameters<TChainOverride, TAccount>,
   ) => Promise<SendTransactionReturnType>
-  signMessage: (args: SignMessageParameters) => Promise<SignMessageReturnType>
-  signTypedData: <TTypedData extends TypedData | { [key: string]: unknown }>(
-    args: SignTypedDataParameters<TTypedData>,
+  signMessage: (
+    args: SignMessageParameters<TAccount>,
+  ) => Promise<SignMessageReturnType>
+  signTypedData: <
+    TTypedData extends TypedData | { [key: string]: unknown },
+    TPrimaryType extends string = string,
+  >(
+    args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>,
   ) => Promise<SignTypedDataReturnType>
   switchChain: (args: SwitchChainParameters) => Promise<void>
   watchAsset: (args: WatchAssetParameters) => Promise<WatchAssetReturnType>
@@ -65,13 +73,18 @@ export type WalletActions<TChain extends Chain = Chain> = {
     TFunctionName extends string,
     TChainOverride extends Chain,
   >(
-    args: WriteContractParameters<TChainOverride, TAbi, TFunctionName>,
+    args: WriteContractParameters<
+      TChainOverride,
+      TAbi,
+      TFunctionName,
+      TAccount
+    >,
   ) => Promise<WriteContractReturnType>
 }
 
 export const walletActions = <
   TChain extends Chain,
-  TClient extends WalletClient<any, any>,
+  TClient extends WalletClient<any, any, any>,
 >(
   client: TClient,
 ): WalletActions<TChain> => ({

--- a/src/errors/account.ts
+++ b/src/errors/account.ts
@@ -1,0 +1,17 @@
+import { BaseError } from './base'
+
+export class AccountNotFoundError extends BaseError {
+  name = 'AccountNotFoundError'
+  constructor({ docsPath }: { docsPath?: string } = {}) {
+    super(
+      [
+        'Could not find an Account to execute with this Action.',
+        'Please provide an Account with the `account` argument on the Action, or by supplying an `account` to the WalletClient.',
+      ].join('\n'),
+      {
+        docsPath,
+        docsSlug: 'account',
+      },
+    )
+  }
+}

--- a/src/errors/base.test.ts
+++ b/src/errors/base.test.ts
@@ -60,6 +60,19 @@ test('BaseError (w/ docsPath)', () => {
     Docs: https://viem.sh/lol.html
     Version: viem@1.0.2]
   `)
+  expect(
+    new BaseError('An error occurred.', {
+      details: 'details',
+      docsPath: '/lol',
+      docsSlug: 'test',
+    }),
+  ).toMatchInlineSnapshot(`
+    [ViemError: An error occurred.
+
+    Docs: https://viem.sh/lol.html#test
+    Details: details
+    Version: viem@1.0.2]
+  `)
 })
 
 test('BaseError (w/ metaMessages)', () => {

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -2,6 +2,7 @@ import { getVersion } from './utils'
 
 type BaseErrorParameters = {
   docsPath?: string
+  docsSlug?: string
   metaMessages?: string[]
 } & (
   | {
@@ -37,7 +38,13 @@ export class BaseError extends Error {
       shortMessage || 'An error occurred.',
       '',
       ...(args.metaMessages ? [...args.metaMessages, ''] : []),
-      ...(docsPath ? [`Docs: https://viem.sh${docsPath}.html`] : []),
+      ...(docsPath
+        ? [
+            `Docs: https://viem.sh${docsPath}.html${
+              args.docsSlug ? `#${args.docsSlug}` : ''
+            }`,
+          ]
+        : []),
       ...(details ? [`Details: ${details}`] : []),
       `Version: ${getVersion()}`,
     ].join('\n')

--- a/src/errors/contract.test.ts
+++ b/src/errors/contract.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'vitest'
 import { polygon } from '../chains'
-import { getAccount } from '../utils'
 import { address } from '../_test'
 import { baycContractConfig } from '../_test/abis'
 import { errorsExampleABI } from '../_test/generated'
@@ -15,7 +14,7 @@ describe('CallExecutionError', () => {
   test('no args', async () => {
     expect(
       new CallExecutionError(new BaseError('error'), {
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
       }),
     ).toMatchInlineSnapshot(`
       [CallExecutionError: error
@@ -30,7 +29,7 @@ describe('CallExecutionError', () => {
   test('w/ base args', async () => {
     expect(
       new CallExecutionError(new BaseError('error'), {
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
         to: address.usdcHolder,
         data: '0x123',
         gas: 420n,
@@ -55,7 +54,7 @@ describe('CallExecutionError', () => {
   test('w/ eip1559 args', async () => {
     expect(
       new CallExecutionError(new BaseError('error'), {
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
         to: address.usdcHolder,
         data: '0x123',
         gas: 420n,
@@ -82,7 +81,7 @@ describe('CallExecutionError', () => {
   test('w/ legacy args', async () => {
     expect(
       new CallExecutionError(new BaseError('error'), {
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
         to: address.usdcHolder,
         data: '0x123',
         gas: 420n,
@@ -108,7 +107,7 @@ describe('CallExecutionError', () => {
     expect(
       new CallExecutionError(new BaseError('error'), {
         chain: polygon,
-        account: getAccount(address.vitalik),
+        account: address.vitalik,
         to: address.usdcHolder,
         data: '0x123',
         gas: 420n,
@@ -136,7 +135,7 @@ describe('CallExecutionError', () => {
         new BaseError('error', { metaMessages: ['omggg!'] }),
         {
           chain: polygon,
-          account: getAccount(address.vitalik),
+          account: address.vitalik,
           to: address.usdcHolder,
           data: '0x123',
           gas: 420n,

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -10,6 +10,7 @@ import {
   formatEther,
   formatGwei,
   getAbiItem,
+  parseAccount,
 } from '../utils'
 import { BaseError } from './base'
 import { prettyPrint } from './transaction'
@@ -23,7 +24,7 @@ export class CallExecutionError extends BaseError {
   constructor(
     cause: BaseError,
     {
-      account,
+      account: account_,
       docsPath,
       chain,
       data,
@@ -36,6 +37,7 @@ export class CallExecutionError extends BaseError {
       value,
     }: CallParameters & { chain?: Chain; docsPath?: string },
   ) {
+    const account = account_ ? parseAccount(account_) : undefined
     const prettyArgs = prettyPrint({
       from: account?.address,
       to,

--- a/src/errors/estimateGas.ts
+++ b/src/errors/estimateGas.ts
@@ -1,5 +1,5 @@
 import type { EstimateGasParameters } from '../actions'
-import type { Chain } from '../types'
+import type { Account, Chain } from '../types'
 import { formatEther, formatGwei } from '../utils'
 import { BaseError } from './base'
 import { prettyPrint } from './transaction'
@@ -23,10 +23,14 @@ export class EstimateGasExecutionError extends BaseError {
       nonce,
       to,
       value,
-    }: EstimateGasParameters & { chain?: Chain; docsPath?: string },
+    }: Omit<EstimateGasParameters<any, any>, 'account'> & {
+      account?: Account
+      chain?: Chain
+      docsPath?: string
+    },
   ) {
     const prettyArgs = prettyPrint({
-      from: account.address,
+      from: account?.address,
       to,
       value:
         typeof value !== 'undefined' &&

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -24,6 +24,8 @@ export {
   UnsupportedPackedAbiType,
 } from './abi'
 
+export { AccountNotFoundError } from './account'
+
 export { InvalidAddressError } from './address'
 
 export { BaseError } from './base'

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -1,4 +1,4 @@
-import type { BlockTag, Hash } from '../types'
+import type { Account, BlockTag, Hash } from '../types'
 import { formatEther, formatGwei } from '../utils'
 import type { SendTransactionParameters } from '../wallet'
 import { BaseError } from './base'
@@ -49,11 +49,14 @@ export class TransactionExecutionError extends BaseError {
       nonce,
       to,
       value,
-    }: SendTransactionParameters & { docsPath?: string },
+    }: Omit<SendTransactionParameters, 'account'> & {
+      account: Account
+      docsPath?: string
+    },
   ) {
     const prettyArgs = prettyPrint({
       chain: chain && `${chain?.name} (id: ${chain?.id})`,
-      from: account.address,
+      from: account?.address,
       to,
       value:
         typeof value !== 'undefined' &&

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -35,8 +35,6 @@ export type LocalAccount = {
 }
 
 export type ParseAccount<TAccount extends Account | Address | undefined> =
-  TAccount extends Account
-    ? TAccount
-    : TAccount extends Address
-    ? JsonRpcAccount
-    : undefined
+  | (TAccount extends Account ? TAccount : never)
+  | (TAccount extends Address ? JsonRpcAccount : never)
+  | (TAccount extends undefined ? undefined : never)

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -5,6 +5,12 @@ import type { TransactionRequest } from './transaction'
 
 export type Account = JsonRpcAccount | LocalAccount
 
+export type GetAccountParameter<
+  TAccount extends Account | undefined = undefined,
+> = TAccount extends undefined
+  ? { account: Account | Address }
+  : { account?: Account | Address }
+
 export type JsonRpcAccount = {
   address: Address
   type: 'json-rpc'
@@ -27,3 +33,10 @@ export type LocalAccount = {
   ) => Promise<Hash>
   type: 'local'
 }
+
+export type ParseAccount<TAccount extends Account | Address | undefined> =
+  TAccount extends Account
+    ? TAccount
+    : TAccount extends Address
+    ? JsonRpcAccount
+    : undefined

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,12 @@
 export type { Address } from 'abitype'
 
-export type { Account, LocalAccount, JsonRpcAccount } from './account'
+export type {
+  Account,
+  GetAccountParameter,
+  LocalAccount,
+  JsonRpcAccount,
+  ParseAccount,
+} from './account'
 
 export type {
   Block,

--- a/src/utils/account.test.ts
+++ b/src/utils/account.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest'
-import { accounts } from '../_test'
-import { getAccount } from './account'
+import { accounts, getLocalAccount } from '../_test'
+import { getAccount, parseAccount } from './account'
 
-describe('account', () => {
+describe('getAccount', () => {
   test('json-rpc account', () => {
     expect(getAccount(accounts[0].address)).toMatchInlineSnapshot(`
       {
@@ -63,6 +63,33 @@ describe('account', () => {
       "Address \\"0x1\\" is invalid.
 
       Version: viem@1.0.2"
+    `)
+  })
+})
+
+describe('parseAccount', () => {
+  test('address', () => {
+    expect(
+      parseAccount('0x0000000000000000000000000000000000000000'),
+    ).toMatchInlineSnapshot(`
+      {
+        "address": "0x0000000000000000000000000000000000000000",
+        "type": "json-rpc",
+      }
+    `)
+  })
+
+  test('account', () => {
+    expect(
+      parseAccount(getLocalAccount(accounts[0].privateKey)),
+    ).toMatchInlineSnapshot(`
+      {
+        "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "signMessage": [Function],
+        "signTransaction": [Function],
+        "signTypedData": [Function],
+        "type": "local",
+      }
     `)
   })
 })

--- a/src/utils/errors/getEstimateGasError.ts
+++ b/src/utils/errors/getEstimateGasError.ts
@@ -1,6 +1,6 @@
 import type { EstimateGasParameters } from '../../actions'
 import { BaseError, EstimateGasExecutionError } from '../../errors'
-import type { Chain } from '../../types'
+import type { Account, Chain } from '../../types'
 import { containsNodeError, getNodeError } from './getNodeError'
 
 export function getEstimateGasError(
@@ -8,7 +8,8 @@ export function getEstimateGasError(
   {
     docsPath,
     ...args
-  }: EstimateGasParameters & {
+  }: Omit<EstimateGasParameters, 'account'> & {
+    account?: Account
     chain?: Chain
     docsPath?: string
   },

--- a/src/utils/errors/getNodeError.test.ts
+++ b/src/utils/errors/getNodeError.test.ts
@@ -29,7 +29,7 @@ test('FeeCapTooHigh', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 1,
     maxFeePerGas: parseGwei(
       '1231287389123781293712897312893791283921738912378912',
@@ -55,7 +55,7 @@ test('FeeCapTooLow', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 1,
     maxFeePerGas: parseGwei('1'),
   })
@@ -79,7 +79,7 @@ test('NonceTooHigh', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 1123123213,
   })
   expect(result).toMatchInlineSnapshot(`
@@ -99,7 +99,7 @@ test('NonceTooLow', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 1,
   })
   expect(result).toMatchInlineSnapshot(`
@@ -120,7 +120,7 @@ test('NonceMaxValue', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 12222222,
   })
   expect(result).toMatchInlineSnapshot(`
@@ -140,7 +140,7 @@ test('InsufficientFundsError', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     nonce: 1,
     value: parseEther('10'),
   })
@@ -170,7 +170,7 @@ test('IntrinsicGasTooHigh', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     gas: 8912738912731289n,
   })
   expect(result).toMatchInlineSnapshot(`
@@ -190,7 +190,7 @@ test('IntrinsicGasTooLowError', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     gas: 1n,
   })
   expect(result).toMatchInlineSnapshot(`
@@ -210,7 +210,7 @@ test('TransactionTypeNotSupported', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     maxFeePerGas: parseGwei('10'),
   })
   expect(result).toMatchInlineSnapshot(`
@@ -233,7 +233,7 @@ test('TipAboveFeeCap', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     maxFeePerGas: parseGwei('10'),
     maxPriorityFeePerGas: parseGwei('11'),
   })
@@ -257,7 +257,7 @@ test('ExecutionRevertedError', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     maxFeePerGas: parseGwei('10'),
     maxPriorityFeePerGas: parseGwei('11'),
   })
@@ -281,7 +281,7 @@ test('ExecutionRevertedError', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
     maxFeePerGas: parseGwei('10'),
     maxPriorityFeePerGas: parseGwei('11'),
   })
@@ -302,7 +302,7 @@ test('Unknown node error', () => {
     }),
   )
   const result = getNodeError(error, {
-    account: getAccount(address.vitalik),
+    account: address.vitalik,
   })
   expect(result).toMatchInlineSnapshot(`
     [UnknownNodeError: An error occurred while executing: oh no

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -1,4 +1,5 @@
 import { BaseError, TransactionExecutionError } from '../../errors'
+import type { Account } from '../../types'
 import type { SendTransactionParameters } from '../../wallet'
 import { containsNodeError, getNodeError } from './getNodeError'
 
@@ -7,7 +8,8 @@ export function getTransactionError(
   {
     docsPath,
     ...args
-  }: SendTransactionParameters & {
+  }: Omit<SendTransactionParameters, 'account'> & {
+    account: Account
     docsPath?: string
   },
 ) {

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -91,6 +91,7 @@ test('exports utils', () => {
       "parseAbiItem": [Function],
       "parseAbiParameter": [Function],
       "parseAbiParameters": [Function],
+      "parseAccount": [Function],
       "parseEther": [Function],
       "parseGwei": [Function],
       "parseUnits": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,7 +41,7 @@ export {
   parseAbiParameters,
 } from './abi'
 
-export { getAccount } from './account'
+export { getAccount, parseAccount } from './account'
 
 export type {
   GetContractAddressOptions,

--- a/src/utils/signature/verifyMessage.test.ts
+++ b/src/utils/signature/verifyMessage.test.ts
@@ -7,7 +7,7 @@ import { verifyMessage } from './verifyMessage'
 
 test('default', async () => {
   let signature = await signMessage(walletClient!, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     message: 'hello world',
   })
   expect(
@@ -19,7 +19,7 @@ test('default', async () => {
   ).toBeTruthy()
 
   signature = await signMessage(walletClient!, {
-    account: getAccount(accounts[0].address),
+    account: accounts[0].address,
     message: 'wagmi 🥵',
   })
   expect(

--- a/src/utils/transaction/assertRequest.test.ts
+++ b/src/utils/transaction/assertRequest.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest'
-import { getAccount } from '../account'
 import { parseGwei } from '../unit'
 
 import { assertRequest } from './assertRequest'
@@ -26,7 +25,7 @@ test('fee cap too high', () => {
 
 test('invalid from address', () => {
   expect(() =>
-    assertRequest({ account: getAccount('0x123') }),
+    assertRequest({ account: '0x123' }),
   ).toThrowErrorMatchingInlineSnapshot(`
     "Address \\"0x123\\" is invalid.
 

--- a/src/utils/transaction/assertRequest.ts
+++ b/src/utils/transaction/assertRequest.ts
@@ -6,10 +6,18 @@ import {
 } from '../../errors'
 import { FeeConflictError } from '../../errors/transaction'
 import type { Chain } from '../../types'
+import { parseAccount } from '../account'
 import { isAddress } from '../address'
 
 export function assertRequest(args: Partial<SendTransactionParameters<Chain>>) {
-  const { account, gasPrice, maxFeePerGas, maxPriorityFeePerGas, to } = args
+  const {
+    account: account_,
+    gasPrice,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    to,
+  } = args
+  const account = account_ ? parseAccount(account_) : undefined
   if (account && !isAddress(account.address))
     throw new InvalidAddressError({ address: account.address })
   if (to && !isAddress(to)) throw new InvalidAddressError({ address: to })

--- a/src/utils/transaction/prepareRequest.test.ts
+++ b/src/utils/transaction/prepareRequest.test.ts
@@ -349,4 +349,21 @@ describe('prepareRequest', () => {
       }
     `)
   })
+
+  test('no account', async () => {
+    await setup()
+
+    await expect(() =>
+      prepareRequest(walletClient, {
+        // @ts-expect-error
+        to: targetAccount.address,
+        value: parseEther('1'),
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Could not find an Account to execute with this Action.
+      Please provide an Account with the \`account\` argument on the Action, or by supplying an \`account\` to the WalletClient.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -1,22 +1,31 @@
 import {
   estimateGas,
+  EstimateGasParameters,
   getBlock,
   getGasPrice,
   getTransactionCount,
   SendTransactionParameters,
 } from '../../actions'
 import type { PublicClient, WalletClient } from '../../clients'
-import { BaseError } from '../../errors'
-import type { Address } from '../../types'
+import { AccountNotFoundError, BaseError } from '../../errors'
+import type { Account, Address, GetAccountParameter } from '../../types'
+import { parseAccount } from '../account'
 import { parseGwei } from '../unit/parseGwei'
 import { assertRequest } from './assertRequest'
 
 export type PrepareRequestParameters<
-  TParameters extends SendTransactionParameters = SendTransactionParameters,
-> = TParameters
+  TAccount extends Account | undefined = undefined,
+> = GetAccountParameter<TAccount> & {
+  gas?: SendTransactionParameters['gas']
+  gasPrice?: SendTransactionParameters['gasPrice']
+  maxFeePerGas?: SendTransactionParameters['maxFeePerGas']
+  maxPriorityFeePerGas?: SendTransactionParameters['maxPriorityFeePerGas']
+  nonce?: SendTransactionParameters['nonce']
+}
 
 export type PrepareRequestReturnType<
-  TParameters extends SendTransactionParameters = SendTransactionParameters,
+  TAccount extends Account | undefined = undefined,
+  TParameters extends PrepareRequestParameters<TAccount> = PrepareRequestParameters<TAccount>,
 > = TParameters & {
   from: Address
   gas: SendTransactionParameters['gas']
@@ -29,13 +38,22 @@ export type PrepareRequestReturnType<
 export const defaultTip = parseGwei('1.5')
 
 export async function prepareRequest<
-  TParameters extends SendTransactionParameters,
+  TAccount extends Account | undefined,
+  TParameters extends PrepareRequestParameters<TAccount>,
 >(
-  client: WalletClient<any, any> | PublicClient<any, any>,
-  args: PrepareRequestParameters<TParameters>,
-): Promise<PrepareRequestReturnType<TParameters>> {
-  const { account, gas, gasPrice, maxFeePerGas, maxPriorityFeePerGas, nonce } =
-    args
+  client: WalletClient<any, any, TAccount> | PublicClient<any, any>,
+  args: TParameters,
+): Promise<PrepareRequestReturnType<TAccount, TParameters>> {
+  const {
+    account: account_,
+    gas,
+    gasPrice,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+  } = args
+  if (!account_) throw new AccountNotFoundError()
+  const account = parseAccount(account_)
 
   const block = await getBlock(client, { blockTag: 'latest' })
 
@@ -85,9 +103,9 @@ export async function prepareRequest<
     request.gas = await estimateGas(client, {
       ...request,
       account: { address: account.address, type: 'json-rpc' },
-    })
+    } as EstimateGasParameters)
 
   assertRequest(request)
 
-  return request as PrepareRequestReturnType<TParameters>
+  return request as PrepareRequestReturnType<TAccount, TParameters>
 }


### PR DESCRIPTION
Added the ability to hoist an Account to the Wallet Client.

```diff
import { createWalletClient, http } from 'viem'
import { mainnnet } from 'viem/chains'

const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })

const client = createWalletClient({
+ account,
  chain: mainnet,
  transport: http()
})
const hash = await client.sendTransaction({
- account,
  to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
  value: parseEther('0.001')
})
```