### PR TITLE
feat: automated `fallback` ranking

### DIFF
--- a/.changeset/cyan-rice-listen.md
+++ b/.changeset/cyan-rice-listen.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added automatic ranking to `fallback` Transport.

--- a/site/docs/clients/transports/fallback.md
+++ b/site/docs/clients/transports/fallback.md
@@ -41,7 +41,127 @@ const client = createPublicClient({
 })
 ```
 
+### Transport Ranking
+
+By default, each of the Transports passed to the `fallback` Transport are automatically ranked based on their **latency** & **stability** via a weighted moving score algorithm. 
+
+Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on.
+
+The Transport that has the best latency & stability score over the sample period is prioritized first. 
+
+You can modify the default rank config using the `rank` parameter:
+
+```ts
+const client = createPublicClient({
+  chain: mainnet,
+  transport: fallback(
+    [alchemy, infura],
+    { // [!code focus:9]
+      rank: {
+        interval: 60_000,
+        latencyWeight: 0.4,
+        sampleCount: 5,
+        stabilityWeight: 0.6,
+        timeout: 500
+      }
+    }
+  ),
+})
+```
+
+Or you can turn it off automated ranking by passing `false` to `rank`:
+
+```ts
+const client = createPublicClient({
+  chain: mainnet,
+  transport: fallback(
+    [alchemy, infura],
+    { rank: false } // [!code focus]
+  ),
+})
+```
+
 ## Parameters
+
+### rank (optional)
+
+- **Type:** `boolean | RankOptions`
+- **Default:** `true`
+
+### rank.interval (optional)
+
+- **Type:** `number`
+- **Default:** `client.pollingInterval`
+
+The polling interval (in ms) at which the ranker should ping the RPC URL.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: { // [!code focus:3]
+    interval: 5_000
+  },
+})
+```
+
+### rank.latencyWeight (optional)
+
+- **Type:** `number`
+- **Default:** `0.3`
+
+The weight to apply to the latency score.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: { // [!code focus:3]
+    latencyWeight: 0.4
+  },
+})
+```
+
+### rank.sampleCount (optional)
+
+- **Type:** `number`
+- **Default:** `10`
+
+The number of previous samples to perform ranking on.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: { // [!code focus:3]
+    sampleCount: 10
+  },
+})
+```
+
+### rank.stabilityWeight (optional)
+
+- **Type:** `number`
+- **Default:** `0.7`
+
+The weight to apply to the stability score.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: { // [!code focus:3]
+    stabilityWeight: 0.6
+  },
+})
+```
+
+### rank.timeout (optional)
+
+- **Type:** `number`
+- **Default:** `1_000`
+
+Timeout when sampling transports.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: { // [!code focus:3]
+    timeout: 500
+  },
+})
+```
 
 ### retryCount (optional)
 

--- a/site/docs/clients/transports/fallback.md
+++ b/site/docs/clients/transports/fallback.md
@@ -45,7 +45,7 @@ const client = createPublicClient({
 
 By default, each of the Transports passed to the `fallback` Transport are automatically ranked based on their **latency** & **stability** via a weighted moving score algorithm. 
 
-Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on.
+Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on. 
 
 The Transport that has the best latency & stability score over the sample period is prioritized first. 
 
@@ -59,10 +59,12 @@ const client = createPublicClient({
     { // [!code focus:9]
       rank: {
         interval: 60_000,
-        latencyWeight: 0.4,
         sampleCount: 5,
-        stabilityWeight: 0.6,
-        timeout: 500
+        timeout: 500,
+        weights: {
+          latency: 0.3,
+          stability: 0.7
+        }
       }
     }
   ),
@@ -88,6 +90,14 @@ const client = createPublicClient({
 - **Type:** `boolean | RankOptions`
 - **Default:** `true`
 
+Whether or not to automatically rank the Transports based on their latency & stability. Set to `false` to disable automatic ranking.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: false, // [!code focus]
+})
+```
+
 ### rank.interval (optional)
 
 - **Type:** `number`
@@ -99,21 +109,6 @@ The polling interval (in ms) at which the ranker should ping the RPC URL.
 const transport = fallback([alchemy, infura], {
   rank: { // [!code focus:3]
     interval: 5_000
-  },
-})
-```
-
-### rank.latencyWeight (optional)
-
-- **Type:** `number`
-- **Default:** `0.3`
-
-The weight to apply to the latency score.
-
-```ts
-const transport = fallback([alchemy, infura], {
-  rank: { // [!code focus:3]
-    latencyWeight: 0.4
   },
 })
 ```
@@ -133,21 +128,6 @@ const transport = fallback([alchemy, infura], {
 })
 ```
 
-### rank.stabilityWeight (optional)
-
-- **Type:** `number`
-- **Default:** `0.7`
-
-The weight to apply to the stability score.
-
-```ts
-const transport = fallback([alchemy, infura], {
-  rank: { // [!code focus:3]
-    stabilityWeight: 0.6
-  },
-})
-```
-
 ### rank.timeout (optional)
 
 - **Type:** `number`
@@ -159,6 +139,42 @@ Timeout when sampling transports.
 const transport = fallback([alchemy, infura], {
   rank: { // [!code focus:3]
     timeout: 500
+  },
+})
+```
+
+### rank.weights.latency (optional)
+
+- **Type:** `number`
+- **Default:** `0.3`
+
+The weight to apply to the latency score. The weight is proportional to the other values in the `weights` object.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: {
+    weights: {
+      latency: 0.4, // [!code focus:3]
+      stability: 0.6
+    }
+  },
+})
+```
+
+### rank.weights.stability (optional)
+
+- **Type:** `number`
+- **Default:** `0.7`
+
+The weight to apply to the stability score. The weight is proportional to the other values in the `weights` object.
+
+```ts
+const transport = fallback([alchemy, infura], {
+  rank: {
+    weights: {
+      latency: 0.4,
+      stability: 0.6 // [!code focus:3]
+    }
   },
 })
 ```

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -58,7 +58,7 @@ export function createClient<
   TChain,
   TRequests
 > {
-  const { config, request, value } = transport({ chain })
+  const { config, request, value } = transport({ chain, pollingInterval })
   return {
     chain,
     key,

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -1,7 +1,7 @@
 import type { Chain } from '../../types'
 import type { Requests } from '../../types/eip1193'
 import { buildRequest } from '../../utils'
-import { ClientConfig } from '../createClient'
+import type { ClientConfig } from '../createClient'
 
 export type BaseRpcRequests = {
   request(...args: any): Promise<any>

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -1,6 +1,7 @@
 import type { Chain } from '../../types'
 import type { Requests } from '../../types/eip1193'
 import { buildRequest } from '../../utils'
+import { ClientConfig } from '../createClient'
 
 export type BaseRpcRequests = {
   request(...args: any): Promise<any>
@@ -34,7 +35,9 @@ export type Transport<
   chain,
 }: {
   chain?: TChain
+  pollingInterval?: ClientConfig['pollingInterval']
   retryCount?: TransportConfig['retryCount']
+  timeout?: TransportConfig['timeout']
 }) => {
   config: TransportConfig<TType>
   request: TRequests

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -1,13 +1,13 @@
 import { assertType, describe, expect, test } from 'vitest'
-import { createHttpServer } from '../../_test'
 import { localhost } from '../../chains'
+import { createHttpServer } from '../../_test'
 import { createClient } from '../createClient'
 
 import { getBlockNumber } from '../../actions'
-import { createTransportsRanker, fallback, FallbackTransport } from './fallback'
-import { http } from './http'
 import { wait } from '../../utils/wait'
-import { Transport } from './createTransport'
+import type { Transport } from './createTransport'
+import { fallback, FallbackTransport, rankTransports } from './fallback'
+import { http } from './http'
 
 test('default', () => {
   const alchemy = http('https://alchemy.com/rpc')
@@ -507,7 +507,7 @@ describe('client', () => {
   })
 })
 
-describe('createTransportsRanker', () => {
+describe('rankTransports', () => {
   const samples: [responseTime: number, success: boolean][][] = [
     [
       [100, true],
@@ -607,7 +607,7 @@ describe('createTransportsRanker', () => {
 
     let rankedTransports: Transport[][] = []
 
-    createTransportsRanker({
+    rankTransports({
       chain: localhost,
       interval: 10,
       sampleCount: 5,

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -1,12 +1,44 @@
+import { Chain } from '../../types'
 import { isDeterministicError } from '../../utils/buildRequest'
+import { wait } from '../../utils/wait'
 import type { Transport, TransportConfig } from './createTransport'
 import { createTransport } from './createTransport'
+
+type RankOptions = {
+  /**
+   * The polling interval (in ms) at which the ranker should ping the RPC URL.
+   * @default client.pollingInterval
+   */
+  interval?: number
+  /**
+   * The weight to apply to the latency score.
+   * @default 0.3
+   */
+  latencyWeight?: number
+  /**
+   * The number of previous samples to perform ranking on.
+   * @default 10
+   */
+  sampleCount?: number
+  /**
+   * The weight to apply to the stability score.
+   * @default 0.7
+   */
+  stabilityWeight?: number
+  /**
+   * Timeout when sampling transports.
+   * @default 1_000
+   */
+  timeout?: number
+}
 
 export type FallbackTransportConfig = {
   /** The key of the Fallback transport. */
   key?: TransportConfig['key']
   /** The name of the Fallback transport. */
   name?: TransportConfig['name']
+  /** Toggle to enable ranking, or rank options. */
+  rank?: boolean | RankOptions
   /** The max number of times to retry. */
   retryCount?: TransportConfig['retryCount']
   /** The base delay (in ms) between retries. */
@@ -19,18 +51,26 @@ export type FallbackTransport = Transport<
 >
 
 export function fallback(
-  transports: Transport[],
+  transports_: Transport[],
   config: FallbackTransportConfig = {},
 ): FallbackTransport {
-  const { key = 'fallback', name = 'Fallback', retryCount, retryDelay } = config
-  return ({ chain }) =>
-    createTransport(
+  const {
+    key = 'fallback',
+    name = 'Fallback',
+    rank = true,
+    retryCount,
+    retryDelay,
+  } = config
+  return ({ chain, pollingInterval = 4_000, timeout }) => {
+    let transports = transports_
+
+    const transport = createTransport(
       {
         key,
         name,
         async request({ method, params }) {
           const fetch = async (i: number = 0): Promise<any> => {
-            const transport = transports[i]({ chain, retryCount: 0 })
+            const transport = transports[i]({ chain, retryCount: 0, timeout })
             try {
               return await transport.request({
                 method,
@@ -60,4 +100,104 @@ export function fallback(
         ),
       },
     )
+
+    if (rank) {
+      const rankOptions = typeof rank === 'object' ? rank : {}
+      rankTransports({
+        chain,
+        interval: rankOptions.interval ?? pollingInterval,
+        latencyWeight: rankOptions.latencyWeight,
+        onTransports: (transports_) => (transports = transports_),
+        sampleCount: rankOptions.sampleCount,
+        stabilityWeight: rankOptions.stabilityWeight,
+        timeout: rankOptions.timeout,
+        transports,
+      })
+    }
+
+    return transport
+  }
+}
+
+type SampleData = [latency: number, success: number]
+type Sample = SampleData[]
+
+export function rankTransports({
+  chain,
+  interval = 4_000,
+  latencyWeight = 0.3,
+  onTransports,
+  sampleCount = 10,
+  stabilityWeight = 0.7,
+  timeout = 1_000,
+  transports,
+}: {
+  chain?: Chain
+  interval: number
+  latencyWeight?: number
+  onTransports: (transports: Transport[]) => void
+  sampleCount?: number
+  stabilityWeight?: number
+  timeout?: number
+  transports: Transport[]
+}) {
+  let samples: Sample[] = []
+
+  const rankTransports_ = async () => {
+    const sample: Sample = await Promise.all(
+      transports.map(async (transport) => {
+        const transport_ = transport({ chain, retryCount: 0, timeout })
+
+        const start = Date.now()
+        let end
+        let success
+        try {
+          await transport_.request({ method: 'net_listening' })
+          success = 1
+        } catch {
+          success = 0
+        } finally {
+          end = Date.now()
+        }
+        const latency = end - start
+        return [latency, success]
+      }),
+    )
+
+    samples.push(sample)
+    if (samples.length > sampleCount) samples.shift()
+
+    const maxLatency = Math.max(
+      ...samples.map((sample) =>
+        Math.max(...sample.map(([latency]) => latency)),
+      ),
+    )
+
+    const scores = transports
+      .map((_, i) => {
+        const latencies = samples.map((sample) => sample[i][0])
+        const meanLatency =
+          latencies.reduce((acc, latency) => acc + latency, 0) /
+          latencies.length
+        const latencyScore = 1 - meanLatency / maxLatency
+
+        const successes = samples.map((sample) => sample[i][1])
+        const stabilityScore =
+          successes.reduce((acc, success) => acc + success, 0) /
+          successes.length
+
+        if (stabilityScore === 0) return [0, i]
+        return [
+          latencyWeight * latencyScore + stabilityWeight * stabilityScore,
+          i,
+        ]
+      })
+      .sort((a, b) => b[0] - a[0])
+
+    onTransports(scores.map(([, i]) => transports[i]))
+
+    await wait(interval)
+    rankTransports_()
+  }
+  rankTransports_()
 }

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -1,4 +1,4 @@
-import { Chain } from '../../types'
+import type { Chain } from '../../types'
 import { isDeterministicError } from '../../utils/buildRequest'
 import { wait } from '../../utils/wait'
 import type { Transport, TransportConfig } from './createTransport'

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -42,10 +42,10 @@ export function http(
     key = 'http',
     name = 'HTTP JSON-RPC',
     retryDelay,
-    timeout = 10_000,
   } = config
-  return ({ chain, retryCount: defaultRetryCount }) => {
-    const retryCount = config.retryCount ?? defaultRetryCount
+  return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
+    const retryCount = config.retryCount ?? retryCount_
+    const timeout = timeout_ ?? config.timeout ?? 10_000
     const url_ = url || chain?.rpcUrls.default.http[0]
     if (!url_) throw new UrlRequiredError()
     return createTransport(

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -57,14 +57,10 @@ export function webSocket(
   url?: string,
   config: WebSocketTransportConfig = {},
 ): WebSocketTransport {
-  const {
-    key = 'webSocket',
-    name = 'WebSocket JSON-RPC',
-    retryDelay,
-    timeout = 10_000,
-  } = config
-  return ({ chain, retryCount: defaultRetryCount }) => {
-    const retryCount = config.retryCount ?? defaultRetryCount
+  const { key = 'webSocket', name = 'WebSocket JSON-RPC', retryDelay } = config
+  return ({ chain, retryCount: retryCount_, timeout: timeout_ }) => {
+    const retryCount = config.retryCount ?? retryCount_
+    const timeout = timeout_ ?? config.timeout ?? 10_000
     const url_ = url || chain?.rpcUrls.default.webSocket?.[0]
     if (!url_) throw new UrlRequiredError()
     return createTransport(


### PR DESCRIPTION
Adds an automated ranking algorithm to rank Transports provided to the `fallback` Transport.

By default, each of the Transports passed to the `fallback` Transport are automatically ranked based on their **latency** & **stability** via a weighted moving score algorithm. 

Every 10 seconds (`interval`), the `fallback` Transport will ping each transport in the list. For the past 10 pings (`sampleCount`), they will be ranked based on if they responded (stability) and how fast they responded (latency). The algorithm applies a weight of `0.7` to the stability score, and a weight of `0.3` to the latency score to derive the final score which it is ranked on.

The Transport that has the best latency & stability score over the sample period is prioritized first. 