### PR TITLE
refactor: client types

### DIFF
--- a/.changeset/orange-crabs-brake.md
+++ b/.changeset/orange-crabs-brake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Client types.

--- a/src/_test/index.ts
+++ b/src/_test/index.ts
@@ -16,6 +16,7 @@ export {
 } from './constants'
 
 export {
+  anvilChain,
   createHttpServer,
   deploy,
   deployBAYC,

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -147,9 +147,9 @@ export function createHttpServer(
 
 export async function deploy<TAbi extends Abi | readonly unknown[],>(
   args: DeployContractParameters<
+    TAbi,
     typeof walletClientWithAccount['chain'],
-    typeof walletClientWithAccount['account'],
-    TAbi
+    typeof walletClientWithAccount['account']
   >,
 ) {
   const hash = await deployContract(walletClientWithAccount, args)

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -18,7 +18,7 @@ import {
   webSocket,
 } from '../clients'
 import { getAccount as getEthersAccount } from '../ethers'
-import type { Hex } from '../types'
+import type { Account, Hex } from '../types'
 import { RpcError } from '../types/eip1193'
 import { rpc } from '../utils'
 import { baycContractConfig } from './abis'
@@ -145,9 +145,11 @@ export function createHttpServer(
   })
 }
 
-export async function deploy<TAbi extends Abi = Abi>(
-  args: DeployContractParameters<any, TAbi>,
-) {
+export async function deploy<
+  TAbi extends Abi | readonly unknown[],
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(args: DeployContractParameters<TAbi, TChain, TAccount>) {
   const hash = await deployContract(walletClientWithAccount, args)
   await mine(testClient, { blocks: 1 })
   const { contractAddress } = await getTransactionReceipt(publicClient, {

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -18,7 +18,7 @@ import {
   webSocket,
 } from '../clients'
 import { getAccount as getEthersAccount } from '../ethers'
-import type { Account, Hex } from '../types'
+import type { Hex } from '../types'
 import { RpcError } from '../types/eip1193'
 import { rpc } from '../utils'
 import { baycContractConfig } from './abis'
@@ -145,11 +145,13 @@ export function createHttpServer(
   })
 }
 
-export async function deploy<
-  TAbi extends Abi | readonly unknown[],
-  TChain extends Chain | undefined,
-  TAccount extends Account | undefined,
->(args: DeployContractParameters<TAbi, TChain, TAccount>) {
+export async function deploy<TAbi extends Abi | readonly unknown[],>(
+  args: DeployContractParameters<
+    typeof walletClientWithAccount['chain'],
+    typeof walletClientWithAccount['account'],
+    TAbi
+  >,
+) {
   const hash = await deployContract(walletClientWithAccount, args)
   await mine(testClient, { blocks: 1 })
   const { contractAddress } = await getTransactionReceipt(publicClient, {

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { Address, Prettify } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Address, Chain, Prettify } from '../../types'
 import {
   decodeFunctionResult,
   encodeFunctionData,
@@ -25,17 +25,9 @@ export type GetEnsAddressReturnType = Address
  *
  * - Calls `resolve(bytes, bytes)` on ENS Universal Resolver Contract.
  * - Since ENS names prohibit certain forbidden characters (e.g. underscore) and have other validation rules, you likely want to [normalize ENS names](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names) with [UTS-46 normalization](https://unicode.org/reports/tr46) before passing them to `getEnsAddress`. You can use the built-in [`normalize`](https://viem.sh/docs/ens/utilities/normalize.html) function for this.
- *
- * @example
- * import { normalize } from 'viem/ens'
- *
- * const ensAddress = await getEnsAddress(publicClient, {
- *   name: normalize('wagmi-dev.eth'),
- * })
- * // '0xd2135CfB216b74109775236E36d4b433F1DF507B'
  */
-export async function getEnsAddress(
-  client: PublicClientArg,
+export async function getEnsAddress<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   {
     blockNumber,
     blockTag,

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -1,10 +1,10 @@
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import { panicReasons } from '../../constants'
 import {
   ContractFunctionExecutionError,
   ContractFunctionRevertedError,
 } from '../../errors'
-import type { Address, Prettify } from '../../types'
+import type { Address, Chain, Prettify } from '../../types'
 import { getChainContractAddress, toHex } from '../../utils'
 import { packetToBytes } from '../../utils/ens'
 import { readContract, ReadContractParameters } from '../public'
@@ -31,8 +31,8 @@ export type GetEnsNameReturnType = string | null
  * })
  * // 'wagmi-dev.eth'
  */
-export async function getEnsName(
-  client: PublicClientArg,
+export async function getEnsName<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   {
     address,
     blockNumber,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -93,10 +93,15 @@ export type {
   WaitForTransactionReceiptParameters,
   WaitForTransactionReceiptReturnType,
   WatchBlockNumberParameters,
+  WatchBlockNumberReturnType,
   WatchBlocksParameters,
+  WatchBlocksReturnType,
   WatchContractEventParameters,
+  WatchContractEventReturnType,
   WatchEventParameters,
+  WatchEventReturnType,
   WatchPendingTransactionsParameters,
+  WatchPendingTransactionsReturnType,
 } from './public'
 
 export {

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -29,21 +29,22 @@ export type FormattedCall<
   TransactionRequest
 >
 
-export type CallParameters<TChain extends Chain | undefined = Chain> =
-  FormattedCall<TransactionRequestFormatter<TChain>> & {
-    account?: Account | Address
-  } & (
-      | {
-          /** The balance of the account at a block number. */
-          blockNumber?: bigint
-          blockTag?: never
-        }
-      | {
-          blockNumber?: never
-          /** The balance of the account at a block tag. */
-          blockTag?: BlockTag
-        }
-    )
+export type CallParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+> = FormattedCall<TransactionRequestFormatter<TChain>> & {
+  account?: Account | Address
+} & (
+    | {
+        /** The balance of the account at a block number. */
+        blockNumber?: bigint
+        blockTag?: never
+      }
+    | {
+        blockNumber?: never
+        /** The balance of the account at a block tag. */
+        blockTag?: BlockTag
+      }
+  )
 
 export type CallReturnType = { data: Hex | undefined }
 

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
   Address,
@@ -48,7 +48,7 @@ export type CallParameters<TChain extends Chain | undefined = Chain> =
 export type CallReturnType = { data: Hex | undefined }
 
 export async function call<TChain extends Chain | undefined>(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   args: CallParameters<TChain>,
 ): Promise<CallReturnType> {
   const {

--- a/src/actions/public/createBlockFilter.ts
+++ b/src/actions/public/createBlockFilter.ts
@@ -1,11 +1,10 @@
-import type { PublicClientArg } from '../../clients'
-
-import type { Filter } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain, Filter } from '../../types'
 
 export type CreateBlockFilterReturnType = Filter<'block'>
 
-export async function createBlockFilter(
-  client: PublicClientArg,
+export async function createBlockFilter<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
 ): Promise<CreateBlockFilterReturnType> {
   const id = await client.request({
     method: 'eth_newBlockFilter',

--- a/src/actions/public/createContractEventFilter.ts
+++ b/src/actions/public/createContractEventFilter.ts
@@ -1,10 +1,11 @@
 import type { Abi, Narrow } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 
 import type {
   Address,
   BlockNumber,
   BlockTag,
+  Chain,
   ExtractEventNameFromAbi,
   Filter,
   MaybeExtractEventArgsFromAbi,
@@ -51,11 +52,12 @@ export type CreateContractEventFilterReturnType<
 > = Filter<'event', TAbi, TEventName, TArgs>
 
 export async function createContractEventFilter<
+  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
   TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     address,
     abi,

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -1,10 +1,11 @@
 import type { Abi, AbiEvent } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 
 import type {
   Address,
   BlockNumber,
   BlockTag,
+  Chain,
   Filter,
   LogTopic,
   MaybeAbiEventName,
@@ -61,14 +62,15 @@ export type CreateEventFilterReturnType<
 > = Filter<'event', TAbi, TEventName, TArgs>
 
 export async function createEventFilter<
+  TChain extends Chain | undefined,
   TAbiEvent extends AbiEvent | undefined,
-  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
-  TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
-  TArgs extends
-    | MaybeExtractEventArgsFromAbi<TAbi, TEventName>
+  _Abi extends Abi | readonly unknown[] = [TAbiEvent],
+  _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
+  _Args extends
+    | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
     | undefined = undefined,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     address,
     args,
@@ -77,11 +79,11 @@ export async function createEventFilter<
     toBlock,
   }: CreateEventFilterParameters<
     TAbiEvent,
-    TAbi,
-    TEventName,
-    TArgs
+    _Abi,
+    _EventName,
+    _Args
   > = {} as any,
-): Promise<CreateEventFilterReturnType<TAbiEvent, TAbi, TEventName, TArgs>> {
+): Promise<CreateEventFilterReturnType<TAbiEvent, _Abi, _EventName, _Args>> {
   let topics: LogTopic[] = []
   if (event)
     topics = encodeEventTopics({
@@ -110,8 +112,8 @@ export async function createEventFilter<
     type: 'event',
   } as unknown as CreateEventFilterReturnType<
     TAbiEvent,
-    TAbi,
-    TEventName,
-    TArgs
+    _Abi,
+    _EventName,
+    _Args
   >
 }

--- a/src/actions/public/createPendingTransactionFilter.ts
+++ b/src/actions/public/createPendingTransactionFilter.ts
@@ -1,11 +1,12 @@
-import type { PublicClientArg } from '../../clients'
-
-import type { Filter } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain, Filter } from '../../types'
 
 export type CreatePendingTransactionFilterReturnType = Filter<'transaction'>
 
-export async function createPendingTransactionFilter(
-  client: PublicClientArg,
+export async function createPendingTransactionFilter<
+  TChain extends Chain | undefined,
+>(
+  client: PublicClient<Transport, TChain>,
 ): Promise<CreatePendingTransactionFilterReturnType> {
   const id = await client.request({
     method: 'eth_newPendingTransactionFilter',

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BaseError } from '../../errors'
 import type { Chain, ContractConfig, GetValue } from '../../types'
 import {
@@ -30,7 +30,7 @@ export async function estimateContractGas<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     abi,
     address,

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -12,9 +12,9 @@ import {
 import { estimateGas, EstimateGasParameters } from './estimateGas'
 
 export type EstimateContractGasParameters<
-  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = any,
+  TFunctionName extends string = string,
+  TChain extends Chain | undefined = Chain | undefined,
 > = Omit<EstimateGasParameters<TChain>, 'data' | 'to' | 'value'> &
   ContractConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> & {
     value?: GetValue<
@@ -26,9 +26,9 @@ export type EstimateContractGasParameters<
 export type EstimateContractGasReturnType = bigint
 
 export async function estimateContractGas<
-  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
+  TChain extends Chain | undefined,
 >(
   client: PublicClient<Transport, TChain>,
   {
@@ -37,7 +37,7 @@ export async function estimateContractGas<
     args,
     functionName,
     ...request
-  }: EstimateContractGasParameters<TChain, TAbi, TFunctionName>,
+  }: EstimateContractGasParameters<TAbi, TFunctionName, TChain>,
 ): Promise<EstimateContractGasReturnType> {
   const account = parseAccount(request.account)
   const data = encodeFunctionData({

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -12,7 +12,7 @@ import {
 import { estimateGas, EstimateGasParameters } from './estimateGas'
 
 export type EstimateContractGasParameters<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = any,
 > = Omit<EstimateGasParameters<TChain>, 'data' | 'to' | 'value'> &

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -30,7 +30,7 @@ export type FormattedEstimateGas<
 >
 
 export type EstimateGasParameters<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = undefined,
 > = FormattedEstimateGas<TransactionRequestFormatter<TChain>> &
   GetAccountParameter<TAccount> &

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, WalletClientArg, Transport } from '../../clients'
+import type { PublicClient, WalletClient, Transport } from '../../clients'
 import type { BaseError } from '../../errors'
 import { AccountNotFoundError } from '../../errors'
 import type {
@@ -57,8 +57,8 @@ export async function estimateGas<
   TAccount extends Account | undefined = undefined,
 >(
   client:
-    | PublicClientArg<Transport, TChain>
-    | WalletClientArg<Transport, TChain, TAccount>,
+    | PublicClient<Transport, TChain>
+    | WalletClient<Transport, TChain, TAccount>,
   args: EstimateGasParameters<TChain, TAccount>,
 ): Promise<EstimateGasReturnType> {
   if (!args.account)

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { Address, BlockTag } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Address, BlockTag, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type GetBalanceParameters = {
@@ -23,8 +23,8 @@ export type GetBalanceReturnType = bigint
 /**
  * @description Returns the balance of an address in wei.
  */
-export async function getBalance(
-  client: PublicClientArg,
+export async function getBalance<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   { address, blockNumber, blockTag = 'latest' }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -1,6 +1,6 @@
-import type { PublicClientArg, WalletClientArg, Transport } from '../../clients'
+import type { PublicClient, WalletClient, Transport } from '../../clients'
 import { BlockNotFoundError } from '../../errors'
-import type { BlockTag, Chain, Hash, RpcBlock } from '../../types'
+import type { Account, BlockTag, Chain, Hash, RpcBlock } from '../../types'
 import type { BlockFormatter, FormattedBlock } from '../../utils'
 import { format, formatBlock, numberToHex } from '../../utils'
 
@@ -31,10 +31,13 @@ export type GetBlockParameters = {
 export type GetBlockReturnType<TChain extends Chain | undefined = Chain> =
   FormattedBlock<BlockFormatter<TChain>>
 
-export async function getBlock<TChain extends Chain | undefined>(
+export async function getBlock<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
   client:
-    | PublicClientArg<Transport, TChain>
-    | WalletClientArg<Transport, TChain>,
+    | PublicClient<Transport, TChain>
+    | WalletClient<Transport, TChain, TAccount>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -28,8 +28,9 @@ export type GetBlockParameters = {
     }
 )
 
-export type GetBlockReturnType<TChain extends Chain | undefined = Chain> =
-  FormattedBlock<BlockFormatter<TChain>>
+export type GetBlockReturnType<
+  TChain extends Chain | undefined = Chain | undefined,
+> = FormattedBlock<BlockFormatter<TChain>>
 
 export async function getBlock<
   TChain extends Chain | undefined,

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -1,4 +1,5 @@
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { getCache, withCache } from '../../utils/promise'
 
 export type GetBlockNumberParameters = {
@@ -17,8 +18,8 @@ export function getBlockNumberCache(id: string) {
 /**
  * @description Returns the number of the most recent block seen.
  */
-export async function getBlockNumber(
-  client: PublicClientArg,
+export async function getBlockNumber<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   { maxAge = client.pollingInterval }: GetBlockNumberParameters = {},
 ): Promise<GetBlockNumberReturnType> {
   const blockNumberHex = await withCache(

--- a/src/actions/public/getBlockTransactionCount.ts
+++ b/src/actions/public/getBlockTransactionCount.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BlockTag, Chain, Hash, Quantity } from '../../types'
 import { hexToNumber, numberToHex } from '../../utils'
 
@@ -27,7 +27,7 @@ export type GetBlockTransactionCountReturnType = number
 export async function getBlockTransactionCount<
   TChain extends Chain | undefined,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getBytecode.ts
+++ b/src/actions/public/getBytecode.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { Address, BlockTag, Hex } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Address, BlockTag, Chain, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type GetBytecodeParameters = {
@@ -17,8 +17,8 @@ export type GetBytecodeParameters = {
 
 export type GetBytecodeReturnType = Hex | undefined
 
-export async function getBytecode(
-  client: PublicClientArg,
+export async function getBytecode<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   { address, blockNumber, blockTag = 'latest' }: GetBytecodeParameters,
 ): Promise<GetBytecodeReturnType> {
   const blockNumberHex =

--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -1,10 +1,16 @@
-import type { PublicClientArg, WalletClientArg } from '../../clients'
+import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import { hexToNumber } from '../../utils'
 
 export type GetChainIdReturnType = number
 
-export async function getChainId(
-  client: PublicClientArg | WalletClientArg,
+export async function getChainId<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client:
+    | PublicClient<Transport, TChain>
+    | WalletClient<Transport, TChain, TAccount>,
 ): Promise<GetChainIdReturnType> {
   const chainIdHex = await client.request({ method: 'eth_chainId' })
   return hexToNumber(chainIdHex)

--- a/src/actions/public/getFeeHistory.ts
+++ b/src/actions/public/getFeeHistory.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { BlockTag, FeeHistory } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { BlockTag, Chain, FeeHistory } from '../../types'
 
 import { numberToHex } from '../../utils'
 import { formatFeeHistory } from '../../utils/formatters'
@@ -22,8 +22,8 @@ export type GetFeeHistoryReturnType = FeeHistory
 /**
  * @description Returns a collection of historical gas information.
  */
-export async function getFeeHistory(
-  client: PublicClientArg,
+export async function getFeeHistory<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   {
     blockCount,
     blockNumber,

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -1,6 +1,7 @@
 import type { Abi, AbiEvent } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type {
+  Chain,
   Filter,
   FilterType,
   Hash,
@@ -30,12 +31,13 @@ export type GetFilterChangesReturnType<
   : Hash[]
 
 export async function getFilterChanges<
+  TChain extends Chain | undefined,
   TFilterType extends FilterType,
   TAbiEvent extends AbiEvent | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     filter,
   }: GetFilterChangesParameters<TFilterType, TAbiEvent, TAbi, TEventName>,

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -1,6 +1,6 @@
 import type { Abi, AbiEvent } from 'abitype'
-import type { PublicClientArg } from '../../clients'
-import type { Filter, Log, MaybeAbiEventName } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain, Filter, Log, MaybeAbiEventName } from '../../types'
 import { decodeEventLog } from '../../utils'
 
 import { formatLog } from '../../utils/formatters/log'
@@ -19,11 +19,12 @@ export type GetFilterLogsReturnType<
 > = Log<bigint, number, TAbiEvent, TAbi, TEventName>[]
 
 export async function getFilterLogs<
+  TChain extends Chain | undefined,
   TAbiEvent extends AbiEvent | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   { filter }: GetFilterLogsParameters<TAbiEvent, TAbi, TEventName>,
 ): Promise<GetFilterLogsReturnType<TAbiEvent, TAbi, TEventName>> {
   const logs = await client.request({

--- a/src/actions/public/getGasPrice.ts
+++ b/src/actions/public/getGasPrice.ts
@@ -1,12 +1,18 @@
-import type { PublicClientArg, WalletClientArg } from '../../clients'
+import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 
 export type GetGasPriceReturnType = bigint
 
 /**
  * @description Returns the current price of gas (in wei).
  */
-export async function getGasPrice(
-  client: PublicClientArg | WalletClientArg,
+export async function getGasPrice<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client:
+    | PublicClient<Transport, TChain>
+    | WalletClient<Transport, TChain, TAccount>,
 ): Promise<GetGasPriceReturnType> {
   const gasPrice = await client.request({
     method: 'eth_gasPrice',

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -1,9 +1,10 @@
 import type { AbiEvent } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type {
   Address,
   BlockNumber,
   BlockTag,
+  Chain,
   Hash,
   Log,
   LogTopic,
@@ -55,8 +56,11 @@ export type GetLogsReturnType<
 /**
  * @description Returns a collection of event logs.
  */
-export async function getLogs<TAbiEvent extends AbiEvent | undefined>(
-  client: PublicClientArg,
+export async function getLogs<
+  TChain extends Chain | undefined,
+  TAbiEvent extends AbiEvent | undefined,
+>(
+  client: PublicClient<Transport, TChain>,
   {
     address,
     blockHash,

--- a/src/actions/public/getStorageAt.ts
+++ b/src/actions/public/getStorageAt.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { Address, BlockTag, Hex } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Address, BlockTag, Chain, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type GetStorageAtParameters = {
@@ -18,8 +18,8 @@ export type GetStorageAtParameters = {
 
 export type GetStorageAtReturnType = Hex | undefined
 
-export async function getStorageAt(
-  client: PublicClientArg,
+export async function getStorageAt<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   { address, blockNumber, blockTag = 'latest', slot }: GetStorageAtParameters,
 ): Promise<GetStorageAtReturnType> {
   const blockNumberHex =

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import { TransactionNotFoundError } from '../../errors/transaction'
 import type { BlockTag, Chain, Hash, RpcTransaction } from '../../types'
 import { format, numberToHex } from '../../utils'
@@ -50,7 +50,7 @@ export type GetTransactionReturnType<TChain extends Chain | undefined = Chain> =
 
 /** @description Returns information about a transaction given a hash or block identifier. */
 export async function getTransaction<TChain extends Chain | undefined>(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { Chain, Hash } from '../../types'
 import type {
   FormattedTransactionReceipt,
@@ -28,7 +28,7 @@ export type GetTransactionConfirmationsReturnType = bigint
 export async function getTransactionConfirmations<
   TChain extends Chain | undefined,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   { hash, transactionReceipt }: GetTransactionConfirmationsParameters<TChain>,
 ): Promise<GetTransactionConfirmationsReturnType> {
   const [blockNumber, transaction] = await Promise.all([

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg, WalletClientArg } from '../../clients'
-import type { Address, BlockTag } from '../../types'
+import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Account, Address, BlockTag, Chain } from '../../types'
 import { hexToNumber, numberToHex } from '../../utils'
 
 export type GetTransactionCountParameters = {
@@ -22,8 +22,13 @@ export type GetTransactionCountReturnType = number
 /**
  * @description Returns the number of transactions an account has broadcast / sent.
  */
-export async function getTransactionCount(
-  client: PublicClientArg | WalletClientArg,
+export async function getTransactionCount<
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client:
+    | PublicClient<Transport, TChain>
+    | WalletClient<Transport, TChain, TAccount>,
   { address, blockTag = 'latest', blockNumber }: GetTransactionCountParameters,
 ): Promise<GetTransactionCountReturnType> {
   const count = await client.request({

--- a/src/actions/public/getTransactionReceipt.ts
+++ b/src/actions/public/getTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import { TransactionReceiptNotFoundError } from '../../errors'
 import type { Chain, Hash } from '../../types'
 import { format } from '../../utils'
@@ -18,7 +18,7 @@ export type GetTransactionReceiptReturnType<
 > = FormattedTransactionReceipt<TransactionReceiptFormatter<TChain>>
 
 export async function getTransactionReceipt<TChain extends Chain | undefined>(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   { hash }: GetTransactionReceiptParameters,
 ) {
   const receipt = await client.request({

--- a/src/actions/public/getTransactionReceipt.ts
+++ b/src/actions/public/getTransactionReceipt.ts
@@ -14,7 +14,7 @@ export type GetTransactionReceiptParameters = {
 }
 
 export type GetTransactionReceiptReturnType<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
 > = FormattedTransactionReceipt<TransactionReceiptFormatter<TChain>>
 
 export async function getTransactionReceipt<TChain extends Chain | undefined>(

--- a/src/actions/public/index.ts
+++ b/src/actions/public/index.ts
@@ -143,26 +143,32 @@ export type {
 
 export { watchBlockNumber } from './watchBlockNumber'
 export type {
-  WatchBlockNumberParameters,
   OnBlockNumberFn,
   OnBlockNumberParameter,
+  WatchBlockNumberParameters,
+  WatchBlockNumberReturnType,
 } from './watchBlockNumber'
 
 export { watchBlocks } from './watchBlocks'
 export type {
-  WatchBlocksParameters,
   OnBlock,
   OnBlockParameter,
+  WatchBlocksParameters,
+  WatchBlocksReturnType,
 } from './watchBlocks'
 
 export { watchContractEvent } from './watchContractEvent'
-export type { WatchContractEventParameters } from './watchContractEvent'
+export type {
+  WatchContractEventParameters,
+  WatchContractEventReturnType,
+} from './watchContractEvent'
 
 export { watchEvent } from './watchEvent'
 export type {
-  WatchEventParameters,
   OnLogsParameter,
   OnLogsFn,
+  WatchEventParameters,
+  WatchEventReturnType,
 } from './watchEvent'
 
 export { watchPendingTransactions } from './watchPendingTransactions'
@@ -170,4 +176,5 @@ export type {
   OnTransactionsFn,
   OnTransactionsParameter,
   WatchPendingTransactionsParameters,
+  WatchPendingTransactionsReturnType,
 } from './watchPendingTransactions'

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -1,5 +1,5 @@
 import type { Narrow } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import { multicall3Abi } from '../../constants'
 import {
   AbiDecodingZeroDataError,
@@ -8,6 +8,7 @@ import {
 } from '../../errors'
 import type {
   Address,
+  Chain,
   ContractConfig,
   Hex,
   MulticallContracts,
@@ -38,10 +39,11 @@ export type MulticallReturnType<
 > = MulticallResults<TContracts, TAllowFailure>
 
 export async function multicall<
+  TChain extends Chain | undefined,
   TContracts extends ContractConfig[],
   TAllowFailure extends boolean = true,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   args: MulticallParameters<TContracts, TAllowFailure>,
 ): Promise<MulticallReturnType<TContracts, TAllowFailure>> {
   const {

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -1,8 +1,8 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BaseError } from '../../errors'
-import type { ContractConfig, ExtractResultFromAbi } from '../../types'
+import type { Chain, ContractConfig, ExtractResultFromAbi } from '../../types'
 import {
   decodeFunctionResult,
   DecodeFunctionResultParameters,
@@ -24,10 +24,11 @@ export type ReadContractReturnType<
 > = ExtractResultFromAbi<TAbi, TFunctionName>
 
 export async function readContract<
+  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     abi,
     address,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
   Chain,
@@ -37,14 +37,14 @@ export type SimulateContractReturnType<
   TChain extends Chain | undefined = Chain,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = undefined,
 > = {
   result: ExtractResultFromAbi<TAbi, TFunctionName>
   request: Omit<
     WriteContractParameters<
-      TChain,
       TAbi,
       TFunctionName,
+      TChain,
       undefined,
       TChainOverride
     >,
@@ -60,7 +60,7 @@ export async function simulateContract<
   TFunctionName extends string,
   TChainOverride extends Chain | undefined,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     abi,
     address,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -20,7 +20,7 @@ import type { WriteContractParameters } from '../wallet'
 import { call, CallParameters } from './call'
 
 export type SimulateContractParameters<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = any,
   TChainOverride extends Chain | undefined = undefined,
@@ -34,7 +34,7 @@ export type SimulateContractParameters<
   }
 
 export type SimulateContractReturnType<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
   TChainOverride extends Chain | undefined = undefined,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -20,9 +20,9 @@ import type { WriteContractParameters } from '../wallet'
 import { call, CallParameters } from './call'
 
 export type SimulateContractParameters<
-  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = any,
+  TChain extends Chain | undefined = Chain | undefined,
   TChainOverride extends Chain | undefined = undefined,
 > = Omit<
   CallParameters<TChainOverride extends Chain ? TChainOverride : TChain>,
@@ -34,9 +34,9 @@ export type SimulateContractParameters<
   }
 
 export type SimulateContractReturnType<
-  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
+  TChain extends Chain | undefined = Chain | undefined,
   TChainOverride extends Chain | undefined = undefined,
 > = {
   result: ExtractResultFromAbi<TAbi, TFunctionName>
@@ -67,9 +67,9 @@ export async function simulateContract<
     args,
     functionName,
     ...callRequest
-  }: SimulateContractParameters<TChain, TAbi, TFunctionName, TChainOverride>,
+  }: SimulateContractParameters<TAbi, TFunctionName, TChain, TChainOverride>,
 ): Promise<
-  SimulateContractReturnType<TChain, TAbi, TFunctionName, TChainOverride>
+  SimulateContractReturnType<TAbi, TFunctionName, TChain, TChainOverride>
 > {
   const account = callRequest.account
     ? parseAccount(callRequest.account)
@@ -101,9 +101,9 @@ export async function simulateContract<
         ...callRequest,
       },
     } as unknown as SimulateContractReturnType<
-      TChain,
       TAbi,
       TFunctionName,
+      TChain,
       TChainOverride
     >
   } catch (err) {

--- a/src/actions/public/uninstallFilter.ts
+++ b/src/actions/public/uninstallFilter.ts
@@ -1,13 +1,13 @@
-import type { PublicClientArg } from '../../clients'
-import type { Filter } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain, Filter } from '../../types'
 
 export type UninstallFilterParameters = {
   filter: Filter<any>
 }
 export type UninstallFilterReturnType = boolean
 
-export async function uninstallFilter(
-  client: PublicClientArg,
+export async function uninstallFilter<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   { filter }: UninstallFilterParameters,
 ): Promise<UninstallFilterReturnType> {
   return client.request({

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -14,7 +14,9 @@ import type { GetTransactionReceiptReturnType } from './getTransactionReceipt'
 import { getTransactionReceipt } from './getTransactionReceipt'
 
 export type ReplacementReason = 'cancelled' | 'replaced' | 'repriced'
-export type ReplacementReturnType<TChain extends Chain | undefined = Chain> = {
+export type ReplacementReturnType<
+  TChain extends Chain | undefined = Chain | undefined,
+> = {
   reason: ReplacementReason
   replacedTransaction: Transaction
   transaction: Transaction
@@ -22,11 +24,11 @@ export type ReplacementReturnType<TChain extends Chain | undefined = Chain> = {
 }
 
 export type WaitForTransactionReceiptReturnType<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
 > = GetTransactionReceiptReturnType<TChain>
 
 export type WaitForTransactionReceiptParameters<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
 > = {
   /** The number of confirmations (blocks that have passed) to wait before resolving. */
   confirmations?: number

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import {
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
@@ -42,7 +42,7 @@ export type WaitForTransactionReceiptParameters<
 export async function waitForTransactionReceipt<
   TChain extends Chain | undefined,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     confirmations = 1,
     hash,

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -1,4 +1,5 @@
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
 import type { GetBlockNumberReturnType } from './getBlockNumber'
@@ -23,9 +24,11 @@ export type WatchBlockNumberParameters = {
   pollingInterval?: number
 }
 
+export type WatchBlockNumberReturnType = () => void
+
 /** @description Watches and returns incoming block numbers. */
-export function watchBlockNumber(
-  client: PublicClientArg,
+export function watchBlockNumber<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   {
     emitOnBegin = false,
     emitMissed = false,
@@ -33,7 +36,7 @@ export function watchBlockNumber(
     onError,
     pollingInterval = client.pollingInterval,
   }: WatchBlockNumberParameters,
-) {
+): WatchBlockNumberReturnType {
   const observerId = JSON.stringify([
     'watchBlockNumber',
     client.uid,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -6,21 +6,23 @@ import type { GetBlockReturnType } from './getBlock'
 import { getBlock } from './getBlock'
 
 export type OnBlockParameter<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TIncludeTransactions = false,
 > = Omit<
   GetBlockReturnType<TChain>,
   TIncludeTransactions extends false ? 'transactions' : ''
 >
 export type OnBlock<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TIncludeTransactions = false,
 > = (
   block: OnBlockParameter<TChain, TIncludeTransactions>,
   prevBlock: OnBlockParameter<TChain, TIncludeTransactions> | undefined,
 ) => void
 
-export type WatchBlocksParameters<TChain extends Chain | undefined = Chain> = {
+export type WatchBlocksParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+> = {
   /** The block tag. Defaults to "latest". */
   blockTag?: BlockTag
   /** Whether or not to emit the missed blocks to the callback. */

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -1,4 +1,4 @@
-import type { PublicClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type { BlockTag, Chain } from '../../types'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
@@ -46,12 +46,16 @@ export type WatchBlocksParameters<TChain extends Chain | undefined = Chain> = {
     }
 )
 
-/** @description Watches and returns information for incoming blocks. */
+export type WatchBlocksReturnType = () => void
+
+/**
+ * @description Watches and returns information for incoming blocks.
+ */
 export function watchBlocks<
   TChain extends Chain | undefined,
   TWatchBlocksParameters extends WatchBlocksParameters<TChain>,
 >(
-  client: PublicClientArg<Transport, TChain>,
+  client: PublicClient<Transport, TChain>,
   {
     blockTag = 'latest',
     emitMissed = false,
@@ -61,7 +65,7 @@ export function watchBlocks<
     includeTransactions = false,
     pollingInterval = client.pollingInterval,
   }: TWatchBlocksParameters,
-) {
+): WatchBlocksReturnType {
   const observerId = JSON.stringify([
     'watchBlocks',
     client.uid,

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -1,7 +1,8 @@
 import type { Abi, ExtractAbiEvent, Narrow } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type {
   Address,
+  Chain,
   ExtractEventArgsFromAbi,
   ExtractEventNameFromAbi,
   Filter,
@@ -52,11 +53,14 @@ export type WatchContractEventParameters<
   pollingInterval?: number
 }
 
+export type WatchContractEventReturnType = () => void
+
 export function watchContractEvent<
+  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     abi,
     address,
@@ -67,7 +71,7 @@ export function watchContractEvent<
     onLogs,
     pollingInterval = client.pollingInterval,
   }: WatchContractEventParameters<TAbi, TEventName>,
-) {
+): WatchContractEventReturnType {
   const observerId = JSON.stringify([
     'watchContractEvent',
     address,

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -1,7 +1,8 @@
 import type { AbiEvent } from 'abitype'
-import type { PublicClientArg } from '../../clients'
+import type { PublicClient, Transport } from '../../clients'
 import type {
   Address,
+  Chain,
   Filter,
   Log,
   MaybeAbiEventName,
@@ -52,11 +53,14 @@ export type WatchEventParameters<
     }
 )
 
+export type WatchEventReturnType = () => void
+
 export function watchEvent<
+  TChain extends Chain | undefined,
   TAbiEvent extends AbiEvent | undefined,
   TEventName extends string | undefined,
 >(
-  client: PublicClientArg,
+  client: PublicClient<Transport, TChain>,
   {
     address,
     args,
@@ -66,7 +70,7 @@ export function watchEvent<
     onLogs,
     pollingInterval = client.pollingInterval,
   }: WatchEventParameters<TAbiEvent>,
-) {
+): WatchEventReturnType {
   const observerId = JSON.stringify([
     'watchEvent',
     address,

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -1,5 +1,5 @@
-import type { PublicClientArg } from '../../clients'
-import type { Filter, Hash } from '../../types'
+import type { PublicClient, Transport } from '../../clients'
+import type { Chain, Filter, Hash } from '../../types'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
 import { createPendingTransactionFilter } from './createPendingTransactionFilter'
@@ -20,15 +20,17 @@ export type WatchPendingTransactionsParameters = {
   pollingInterval?: number
 }
 
-export function watchPendingTransactions(
-  client: PublicClientArg,
+export type WatchPendingTransactionsReturnType = () => void
+
+export function watchPendingTransactions<TChain extends Chain | undefined>(
+  client: PublicClient<Transport, TChain>,
   {
     batch = true,
     onError,
     onTransactions,
     pollingInterval = client.pollingInterval,
   }: WatchPendingTransactionsParameters,
-) {
+): WatchPendingTransactionsReturnType {
   const observerId = JSON.stringify([
     'watchPendingTransactions',
     client.uid,

--- a/src/actions/test/dropTransaction.ts
+++ b/src/actions/test/dropTransaction.ts
@@ -1,13 +1,13 @@
-import type { TestClientArg } from '../../clients'
-import type { Hash } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain, Hash } from '../../types'
 
 export type DropTransactionParameters = {
   /** The hash of the transaction to drop. */
   hash: Hash
 }
 
-export async function dropTransaction(
-  client: TestClientArg,
+export async function dropTransaction<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { hash }: DropTransactionParameters,
 ) {
   return await client.request({

--- a/src/actions/test/getAutomine.ts
+++ b/src/actions/test/getAutomine.ts
@@ -1,9 +1,10 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
 export type GetAutomineReturnType = boolean
 
-export async function getAutomine(
-  client: TestClientArg,
+export async function getAutomine<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<GetAutomineReturnType> {
   return await client.request({
     method: `${client.mode}_getAutomine`,

--- a/src/actions/test/getTxpoolContent.ts
+++ b/src/actions/test/getTxpoolContent.ts
@@ -1,14 +1,14 @@
 import type { Address } from 'abitype'
-import type { TestClientArg } from '../../clients'
-import type { RpcTransaction } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain, RpcTransaction } from '../../types'
 
 export type GetTxpoolContentReturnType = {
   pending: Record<Address, Record<string, RpcTransaction>>
   queued: Record<Address, Record<string, RpcTransaction>>
 }
 
-export async function getTxpoolContent(
-  client: TestClientArg,
+export async function getTxpoolContent<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<GetTxpoolContentReturnType> {
   return await client.request({
     method: 'txpool_content',

--- a/src/actions/test/getTxpoolStatus.ts
+++ b/src/actions/test/getTxpoolStatus.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { Chain } from '@wagmi/chains'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
 import { hexToNumber } from '../../utils'
 
 export type GetTxpoolStatusReturnType = {
@@ -6,8 +7,8 @@ export type GetTxpoolStatusReturnType = {
   queued: number
 }
 
-export async function getTxpoolStatus(
-  client: TestClientArg,
+export async function getTxpoolStatus<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<GetTxpoolStatusReturnType> {
   const { pending, queued } = await client.request({
     method: 'txpool_status',

--- a/src/actions/test/impersonateAccount.ts
+++ b/src/actions/test/impersonateAccount.ts
@@ -1,13 +1,13 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 
 export type ImpersonateAccountParameters = {
   /** The account to impersonate. */
   address: Address
 }
 
-export async function impersonateAccount(
-  client: TestClientArg,
+export async function impersonateAccount<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address }: ImpersonateAccountParameters,
 ) {
   return await client.request({

--- a/src/actions/test/increaseTime.ts
+++ b/src/actions/test/increaseTime.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { Chain } from '@wagmi/chains'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
 import { numberToHex } from '../../utils'
 
 export type IncreaseTimeParameters = {
@@ -6,8 +7,8 @@ export type IncreaseTimeParameters = {
   seconds: number
 }
 
-export async function increaseTime(
-  client: TestClientArg,
+export async function increaseTime<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { seconds }: IncreaseTimeParameters,
 ) {
   return await client.request({

--- a/src/actions/test/inspectTxpool.ts
+++ b/src/actions/test/inspectTxpool.ts
@@ -1,13 +1,13 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 
 export type InspectTxpoolReturnType = {
   pending: Record<Address, Record<string, string>>
   queued: Record<Address, Record<string, string>>
 }
 
-export async function inspectTxpool(
-  client: TestClientArg,
+export async function inspectTxpool<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<InspectTxpoolReturnType> {
   return await client.request({
     method: 'txpool_inspect',

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type MineParameters = {
@@ -8,8 +9,8 @@ export type MineParameters = {
   interval?: number
 }
 
-export async function mine(
-  client: TestClientArg,
+export async function mine<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { blocks, interval }: MineParameters,
 ) {
   return await client.request({

--- a/src/actions/test/removeBlockTimestampInterval.ts
+++ b/src/actions/test/removeBlockTimestampInterval.ts
@@ -1,6 +1,9 @@
-import type { TestClientArg } from '../../clients'
+import type { Chain } from '@wagmi/chains'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
 
-export async function removeBlockTimestampInterval(client: TestClientArg) {
+export async function removeBlockTimestampInterval<
+  TChain extends Chain | undefined,
+>(client: TestClient<TestClientMode, Transport, TChain>) {
   return await client.request({
     method: `${client.mode}_removeBlockTimestampInterval`,
   })

--- a/src/actions/test/reset.ts
+++ b/src/actions/test/reset.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
 export type ResetParameters = {
   /** The block number to reset from. */
@@ -7,8 +8,8 @@ export type ResetParameters = {
   jsonRpcUrl?: string
 }
 
-export async function reset(
-  client: TestClientArg,
+export async function reset<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { blockNumber, jsonRpcUrl }: ResetParameters = {},
 ) {
   return await client.request({

--- a/src/actions/test/revert.ts
+++ b/src/actions/test/revert.ts
@@ -1,12 +1,15 @@
-import type { TestClientArg } from '../../clients'
-import type { Quantity } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain, Quantity } from '../../types'
 
 export type RevertParameters = {
   /** The snapshot ID to revert to. */
   id: Quantity
 }
 
-export async function revert(client: TestClientArg, { id }: RevertParameters) {
+export async function revert<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
+  { id }: RevertParameters,
+) {
   return await client.request({
     method: 'evm_revert',
     params: [id],

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -1,13 +1,15 @@
-import type { TestClientArg } from '../../clients'
-import type { Hash, TransactionRequest } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain, Hash, TransactionRequest } from '../../types'
 import { formatTransactionRequest } from '../../utils'
 
 export type SendUnsignedTransactionParameters = TransactionRequest
 
 export type SendUnsignedTransactionReturnType = Hash
 
-export async function sendUnsignedTransaction(
-  client: TestClientArg,
+export async function sendUnsignedTransaction<
+  TChain extends Chain | undefined,
+>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
   const request_ = formatTransactionRequest(request)

--- a/src/actions/test/setAutomine.ts
+++ b/src/actions/test/setAutomine.ts
@@ -1,6 +1,10 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
-export async function setAutomine(client: TestClientArg, enabled: boolean) {
+export async function setAutomine<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
+  enabled: boolean,
+) {
   return await client.request({
     method: 'evm_setAutomine',
     params: [enabled],

--- a/src/actions/test/setBalance.ts
+++ b/src/actions/test/setBalance.ts
@@ -1,5 +1,5 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetBalanceParameters = {
@@ -9,8 +9,8 @@ export type SetBalanceParameters = {
   value: bigint
 }
 
-export async function setBalance(
-  client: TestClientArg,
+export async function setBalance<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address, value }: SetBalanceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setBlockGasLimit.ts
+++ b/src/actions/test/setBlockGasLimit.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetBlockGasLimitParameters = {
@@ -6,8 +7,8 @@ export type SetBlockGasLimitParameters = {
   gasLimit: bigint
 }
 
-export async function setBlockGasLimit(
-  client: TestClientArg,
+export async function setBlockGasLimit<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { gasLimit }: SetBlockGasLimitParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setBlockTimestampInterval.ts
+++ b/src/actions/test/setBlockTimestampInterval.ts
@@ -1,12 +1,15 @@
-import type { TestClientArg } from '../../clients'
+import type { Chain } from '@wagmi/chains'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
 
 export type SetBlockTimestampIntervalParameters = {
   /** The interval (in seconds). */
   interval: number
 }
 
-export async function setBlockTimestampInterval(
-  client: TestClientArg,
+export async function setBlockTimestampInterval<
+  TChain extends Chain | undefined,
+>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { interval }: SetBlockTimestampIntervalParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setCode.ts
+++ b/src/actions/test/setCode.ts
@@ -1,5 +1,5 @@
-import type { TestClientArg } from '../../clients'
-import type { Address, Hex } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain, Hex } from '../../types'
 
 export type SetCodeParameters = {
   /** The account address. */
@@ -8,8 +8,8 @@ export type SetCodeParameters = {
   bytecode: Hex
 }
 
-export async function setCode(
-  client: TestClientArg,
+export async function setCode<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address, bytecode }: SetCodeParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setCoinbase.ts
+++ b/src/actions/test/setCoinbase.ts
@@ -1,13 +1,13 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 
 export type SetCoinbaseParameters = {
   /** The coinbase address. */
   address: Address
 }
 
-export async function setCoinbase(
-  client: TestClientArg,
+export async function setCoinbase<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address }: SetCoinbaseParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setIntervalMining.ts
+++ b/src/actions/test/setIntervalMining.ts
@@ -1,12 +1,13 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
 export type SetIntervalMiningParameters = {
   /** The mining interval. */
   interval: number
 }
 
-export async function setIntervalMining(
-  client: TestClientArg,
+export async function setIntervalMining<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { interval }: SetIntervalMiningParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setLoggingEnabled.ts
+++ b/src/actions/test/setLoggingEnabled.ts
@@ -1,7 +1,8 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
-export async function setLoggingEnabled(
-  client: TestClientArg,
+export async function setLoggingEnabled<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   enabled: boolean,
 ) {
   return await client.request({

--- a/src/actions/test/setMinGasPrice.ts
+++ b/src/actions/test/setMinGasPrice.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetMinGasPriceParameters = {
@@ -6,8 +7,8 @@ export type SetMinGasPriceParameters = {
   gasPrice: bigint
 }
 
-export async function setMinGasPrice(
-  client: TestClientArg,
+export async function setMinGasPrice<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { gasPrice }: SetMinGasPriceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNextBlockBaseFeePerGas.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetNextBlockBaseFeePerGasParameters = {
@@ -6,8 +7,10 @@ export type SetNextBlockBaseFeePerGasParameters = {
   baseFeePerGas: bigint
 }
 
-export async function setNextBlockBaseFeePerGas(
-  client: TestClientArg,
+export async function setNextBlockBaseFeePerGas<
+  TChain extends Chain | undefined,
+>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { baseFeePerGas }: SetNextBlockBaseFeePerGasParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNextBlockTimestamp.ts
+++ b/src/actions/test/setNextBlockTimestamp.ts
@@ -1,4 +1,5 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetNextBlockTimestampParameters = {
@@ -6,8 +7,8 @@ export type SetNextBlockTimestampParameters = {
   timestamp: bigint
 }
 
-export async function setNextBlockTimestamp(
-  client: TestClientArg,
+export async function setNextBlockTimestamp<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { timestamp }: SetNextBlockTimestampParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNonce.ts
+++ b/src/actions/test/setNonce.ts
@@ -1,5 +1,5 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetNonceParameters = {
@@ -9,8 +9,8 @@ export type SetNonceParameters = {
   nonce: number
 }
 
-export async function setNonce(
-  client: TestClientArg,
+export async function setNonce<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address, nonce }: SetNonceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setRpcUrl.ts
+++ b/src/actions/test/setRpcUrl.ts
@@ -1,6 +1,10 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
-export async function setRpcUrl(client: TestClientArg, jsonRpcUrl: string) {
+export async function setRpcUrl<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
+  jsonRpcUrl: string,
+) {
   return await client.request({
     method: `${client.mode}_setRpcUrl`,
     params: [jsonRpcUrl],

--- a/src/actions/test/setStorageAt.ts
+++ b/src/actions/test/setStorageAt.ts
@@ -1,5 +1,5 @@
-import type { TestClientArg } from '../../clients'
-import type { Address, Hash, Hex } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain, Hash, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SetStorageAtParameters = {
@@ -11,8 +11,8 @@ export type SetStorageAtParameters = {
   value: Hex
 }
 
-export async function setStorageAt(
-  client: TestClientArg,
+export async function setStorageAt<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address, index, value }: SetStorageAtParameters,
 ) {
   return await client.request({

--- a/src/actions/test/snapshot.ts
+++ b/src/actions/test/snapshot.ts
@@ -1,6 +1,9 @@
-import type { TestClientArg } from '../../clients'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Chain } from '../../types'
 
-export async function snapshot(client: TestClientArg) {
+export async function snapshot<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
+) {
   return await client.request({
     method: 'evm_snapshot',
   })

--- a/src/actions/test/stopImpersonatingAccount.ts
+++ b/src/actions/test/stopImpersonatingAccount.ts
@@ -1,13 +1,15 @@
-import type { TestClientArg } from '../../clients'
-import type { Address } from '../../types'
+import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { Address, Chain } from '../../types'
 
 export type StopImpersonatingAccountParameters = {
   /** The account to impersonate. */
   address: Address
 }
 
-export async function stopImpersonatingAccount(
-  client: TestClientArg,
+export async function stopImpersonatingAccount<
+  TChain extends Chain | undefined,
+>(
+  client: TestClient<TestClientMode, Transport, TChain>,
   { address }: StopImpersonatingAccountParameters,
 ) {
   return await client.request({

--- a/src/actions/wallet/addChain.ts
+++ b/src/actions/wallet/addChain.ts
@@ -7,11 +7,10 @@ export type AddChainParameters = {
 }
 
 export async function addChain<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
-  TAccount extends Account | undefined = undefined,
+  TAccount extends Account | undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   { chain }: AddChainParameters,
 ) {
   const { id, name, nativeCurrency, rpcUrls, blockExplorers } = chain

--- a/src/actions/wallet/addChain.ts
+++ b/src/actions/wallet/addChain.ts
@@ -1,13 +1,17 @@
-import type { WalletClientArg } from '../../clients'
-import type { Chain } from '../../types'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type AddChainParameters = {
   chain: Chain
 }
 
-export async function addChain(
-  client: WalletClientArg,
+export async function addChain<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
   { chain }: AddChainParameters,
 ) {
   const { id, name, nativeCurrency, rpcUrls, blockExplorers } = chain

--- a/src/actions/wallet/deployContract.test.ts
+++ b/src/actions/wallet/deployContract.test.ts
@@ -10,6 +10,7 @@ import { parseEther } from '../../utils'
 import { mine, setBalance } from '../test'
 
 import { deployContract } from './deployContract'
+import { arbitrum } from '../../chains'
 
 test('default', async () => {
   const hash = await deployContract(walletClient, {

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -16,9 +16,9 @@ import {
 } from '../wallet'
 
 export type DeployContractParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends Account | undefined = Account | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
-  TChain extends Chain | undefined = Chain,
-  TAccount extends Account | undefined = undefined,
   TChainOverride extends Chain | undefined = undefined,
 > = Omit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
@@ -32,28 +32,27 @@ export type DeployContractParameters<
 export type DeployContractReturnType = SendTransactionReturnType
 
 export function deployContract<
-  TAbi extends Abi | readonly unknown[],
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
+  TAbi extends Abi | readonly unknown[],
   TChainOverride extends Chain | undefined,
 >(
-  walletClient: WalletClient<TTransport, TChain, TAccount>,
+  walletClient: WalletClient<Transport, TChain, TAccount>,
   {
     abi,
     args,
     bytecode,
     ...request
-  }: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
+  }: DeployContractParameters<TChain, TAccount, TAbi, TChainOverride>,
 ): Promise<DeployContractReturnType> {
   const calldata = encodeDeployData({
     abi,
     args,
     bytecode,
   } as unknown as DeployContractParameters<
-    TAbi,
     TChain,
     TAccount,
+    TAbi,
     TChainOverride
   >)
   return sendTransaction(walletClient, {

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -16,9 +16,9 @@ import {
 } from '../wallet'
 
 export type DeployContractParameters<
+  TAbi extends Abi | readonly unknown[] = Abi,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
-  TAbi extends Abi | readonly unknown[] = Abi,
   TChainOverride extends Chain | undefined = undefined,
 > = Omit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
@@ -32,9 +32,9 @@ export type DeployContractParameters<
 export type DeployContractReturnType = SendTransactionReturnType
 
 export function deployContract<
+  TAbi extends Abi | readonly unknown[],
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TAbi extends Abi | readonly unknown[],
   TChainOverride extends Chain | undefined,
 >(
   walletClient: WalletClient<Transport, TChain, TAccount>,
@@ -43,16 +43,16 @@ export function deployContract<
     args,
     bytecode,
     ...request
-  }: DeployContractParameters<TChain, TAccount, TAbi, TChainOverride>,
+  }: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
 ): Promise<DeployContractReturnType> {
   const calldata = encodeDeployData({
     abi,
     args,
     bytecode,
   } as unknown as DeployContractParameters<
+    TAbi,
     TChain,
     TAccount,
-    TAbi,
     TChainOverride
   >)
   return sendTransaction(walletClient, {

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -1,6 +1,6 @@
 import type { Abi, Narrow } from 'abitype'
 
-import type { WalletClientArg, Transport } from '../../clients'
+import type { WalletClient, Transport } from '../../clients'
 import type {
   Account,
   Chain,
@@ -16,10 +16,10 @@ import {
 } from '../wallet'
 
 export type DeployContractParameters<
-  TChain extends Chain | undefined = Chain | undefined,
   TAbi extends Abi | readonly unknown[] = Abi,
+  TChain extends Chain | undefined = Chain,
   TAccount extends Account | undefined = undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = undefined,
 > = Omit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
   'accessList' | 'chain' | 'to' | 'data' | 'value'
@@ -32,26 +32,27 @@ export type DeployContractParameters<
 export type DeployContractReturnType = SendTransactionReturnType
 
 export function deployContract<
-  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined,
 >(
-  walletClient: WalletClientArg<Transport, TChain, TAccount>,
+  walletClient: WalletClient<TTransport, TChain, TAccount>,
   {
     abi,
     args,
     bytecode,
     ...request
-  }: DeployContractParameters<TChain, TAbi, TAccount, TChainOverride>,
+  }: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
 ): Promise<DeployContractReturnType> {
   const calldata = encodeDeployData({
     abi,
     args,
     bytecode,
   } as unknown as DeployContractParameters<
-    TChain,
     TAbi,
+    TChain,
     TAccount,
     TChainOverride
   >)

--- a/src/actions/wallet/getAddresses.ts
+++ b/src/actions/wallet/getAddresses.ts
@@ -7,11 +7,10 @@ import { checksumAddress } from '../../utils/address'
 export type GetAddressesReturnType = Address[]
 
 export async function getAddresses<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
 ): Promise<GetAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_accounts' })
   return addresses.map((address) => checksumAddress(address))

--- a/src/actions/wallet/getAddresses.ts
+++ b/src/actions/wallet/getAddresses.ts
@@ -1,12 +1,17 @@
 import type { Address } from 'abitype'
 
-import type { WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import { checksumAddress } from '../../utils/address'
 
 export type GetAddressesReturnType = Address[]
 
-export async function getAddresses(
-  client: WalletClientArg,
+export async function getAddresses<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
 ): Promise<GetAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_accounts' })
   return addresses.map((address) => checksumAddress(address))

--- a/src/actions/wallet/getPermissions.ts
+++ b/src/actions/wallet/getPermissions.ts
@@ -1,9 +1,14 @@
-import type { WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import type { WalletPermission } from '../../types/eip1193'
 
 export type GetPermissionsReturnType = WalletPermission[]
 
-export async function getPermissions(client: WalletClientArg) {
+export async function getPermissions<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(client: WalletClient<TTransport, TChain, TAccount>) {
   const permissions = await client.request({ method: 'wallet_getPermissions' })
   return permissions
 }

--- a/src/actions/wallet/getPermissions.ts
+++ b/src/actions/wallet/getPermissions.ts
@@ -5,10 +5,9 @@ import type { WalletPermission } from '../../types/eip1193'
 export type GetPermissionsReturnType = WalletPermission[]
 
 export async function getPermissions<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
->(client: WalletClient<TTransport, TChain, TAccount>) {
+>(client: WalletClient<Transport, TChain, TAccount>) {
   const permissions = await client.request({ method: 'wallet_getPermissions' })
   return permissions
 }

--- a/src/actions/wallet/requestAddresses.ts
+++ b/src/actions/wallet/requestAddresses.ts
@@ -1,12 +1,17 @@
 import type { Address } from 'abitype'
 
-import type { WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import { getAddress } from '../../utils'
 
 export type RequestAddressesReturnType = Address[]
 
-export async function requestAddresses(
-  client: WalletClientArg,
+export async function requestAddresses<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
 ): Promise<RequestAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_requestAccounts' })
   return addresses.map((address) => getAddress(address))

--- a/src/actions/wallet/requestAddresses.ts
+++ b/src/actions/wallet/requestAddresses.ts
@@ -7,11 +7,10 @@ import { getAddress } from '../../utils'
 export type RequestAddressesReturnType = Address[]
 
 export async function requestAddresses<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
 ): Promise<RequestAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_requestAccounts' })
   return addresses.map((address) => getAddress(address))

--- a/src/actions/wallet/requestPermissions.ts
+++ b/src/actions/wallet/requestPermissions.ts
@@ -1,4 +1,5 @@
-import type { WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import type { WalletPermission } from '../../types/eip1193'
 
 export type RequestPermissionsParameters = {
@@ -8,8 +9,12 @@ export type RequestPermissionsParameters = {
 }
 export type RequestPermissionsReturnType = WalletPermission[]
 
-export async function requestPermissions(
-  client: WalletClientArg,
+export async function requestPermissions<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
   permissions: RequestPermissionsParameters,
 ) {
   return client.request({

--- a/src/actions/wallet/requestPermissions.ts
+++ b/src/actions/wallet/requestPermissions.ts
@@ -10,11 +10,10 @@ export type RequestPermissionsParameters = {
 export type RequestPermissionsReturnType = WalletPermission[]
 
 export async function requestPermissions<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   permissions: RequestPermissionsParameters,
 ) {
   return client.request({

--- a/src/actions/wallet/sendTransaction.test-d.ts
+++ b/src/actions/wallet/sendTransaction.test-d.ts
@@ -1,0 +1,43 @@
+import type { Address } from 'abitype'
+import { test } from 'vitest'
+
+import { createWalletClient, http } from '../../clients'
+import type { Account, Chain } from '../../types'
+import { anvilChain, localHttpUrl } from '../../_test'
+import { sendTransaction } from './sendTransaction'
+
+const walletClient = createWalletClient({
+  account: '0x',
+  chain: anvilChain,
+  transport: http(localHttpUrl),
+})
+const walletClientWithoutAccount = createWalletClient({
+  chain: anvilChain,
+  transport: http(localHttpUrl),
+})
+const walletClientWithoutChain = createWalletClient({
+  account: '0x',
+  transport: http(localHttpUrl),
+})
+
+test('with and without `account`', () => {
+  sendTransaction(walletClient, {
+    account: '0x' as Account | Address | undefined,
+    // ^?
+  })
+  sendTransaction(walletClientWithoutAccount, {
+    account: '0x' as Account | Address,
+    // ^?
+  })
+})
+
+test('with and without `account`', () => {
+  sendTransaction(walletClient, {
+    chain: anvilChain as Chain | undefined,
+    // ^?
+  })
+  sendTransaction(walletClientWithoutChain, {
+    chain: anvilChain as Chain,
+    // ^?
+  })
+})

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -36,8 +36,8 @@ export type FormattedTransactionRequest<
 >
 
 export type SendTransactionParameters<
-  TChain extends Chain | undefined = Chain,
-  TAccount extends Account | undefined = undefined,
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain,
 > = FormattedTransactionRequest<TransactionRequestFormatter<TChainOverride>> &
   GetAccountParameter<TAccount> &
@@ -46,12 +46,11 @@ export type SendTransactionParameters<
 export type SendTransactionReturnType = Hash
 
 export async function sendTransaction<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
 ): Promise<SendTransactionReturnType> {
   const {

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
 import {
   AccountNotFoundError,
   BaseError,
@@ -6,6 +6,8 @@ import {
   ChainNotFoundError,
 } from '../../errors'
 import type {
+  Account,
+  GetAccountParameter,
   Chain,
   Formatter,
   GetChain,
@@ -13,7 +15,6 @@ import type {
   MergeIntersectionProperties,
   TransactionRequest,
 } from '../../types'
-import type { Account, GetAccountParameter } from '../../types/account'
 import {
   assertRequest,
   extract,
@@ -37,7 +38,7 @@ export type FormattedTransactionRequest<
 export type SendTransactionParameters<
   TChain extends Chain | undefined = Chain,
   TAccount extends Account | undefined = undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = Chain,
 > = FormattedTransactionRequest<TransactionRequestFormatter<TChainOverride>> &
   GetAccountParameter<TAccount> &
   GetChain<TChain, TChainOverride>
@@ -45,11 +46,12 @@ export type SendTransactionParameters<
 export type SendTransactionReturnType = Hash
 
 export async function sendTransaction<
+  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined,
 >(
-  client: WalletClientArg<Transport, TChain, TAccount>,
+  client: WalletClient<TTransport, TChain, TAccount>,
   args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
 ): Promise<SendTransactionReturnType> {
   const {

--- a/src/actions/wallet/signMessage.ts
+++ b/src/actions/wallet/signMessage.ts
@@ -4,7 +4,7 @@ import type { Account, Chain, GetAccountParameter, Hex } from '../../types'
 import { parseAccount, toHex } from '../../utils'
 
 export type SignMessageParameters<
-  TAccount extends Account | undefined = undefined,
+  TAccount extends Account | undefined = Account | undefined,
 > = GetAccountParameter<TAccount> &
   (
     | {
@@ -21,11 +21,10 @@ export type SignMessageParameters<
 export type SignMessageReturnType = Hex
 
 export async function signMessage<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   {
     account: account_ = client.account,
     data,

--- a/src/actions/wallet/signMessage.ts
+++ b/src/actions/wallet/signMessage.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
 import { AccountNotFoundError } from '../../errors'
 import type { Account, Chain, GetAccountParameter, Hex } from '../../types'
 import { parseAccount, toHex } from '../../utils'
@@ -20,8 +20,12 @@ export type SignMessageParameters<
 
 export type SignMessageReturnType = Hex
 
-export async function signMessage<TAccount extends Account | undefined>(
-  client: WalletClientArg<Transport, Chain | undefined, TAccount>,
+export async function signMessage<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
   {
     account: account_ = client.account,
     data,

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -33,10 +33,10 @@ export type SignTypedDataParameters<
 export type SignTypedDataReturnType = Hex
 
 export async function signTypedData<
+  TTypedData extends TypedData | { [key: string]: unknown },
+  TPrimaryType extends string,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
 >(
   client: WalletClient<Transport, TChain, TAccount>,
   {

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -1,5 +1,5 @@
 import type { TypedData, TypedDataParameter, TypedDataType } from 'abitype'
-import type { Transport, WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
 import {
   AccountNotFoundError,
   BytesSizeMismatchError,
@@ -33,11 +33,13 @@ export type SignTypedDataParameters<
 export type SignTypedDataReturnType = Hex
 
 export async function signTypedData<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined,
   TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
-  TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClientArg<Transport, Chain | undefined, TAccount>,
+  client: WalletClient<TTransport, TChain, TAccount>,
   {
     account: account_ = client.account,
     domain,

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -33,13 +33,12 @@ export type SignTypedDataParameters<
 export type SignTypedDataReturnType = Hex
 
 export async function signTypedData<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TTypedData extends TypedData | { [key: string]: unknown },
   TPrimaryType extends string = string,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   {
     account: account_ = client.account,
     domain,

--- a/src/actions/wallet/switchChain.ts
+++ b/src/actions/wallet/switchChain.ts
@@ -5,11 +5,10 @@ import { numberToHex } from '../../utils'
 export type SwitchChainParameters = { id: Chain['id'] }
 
 export async function switchChain<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   { id }: SwitchChainParameters,
 ) {
   await client.request({

--- a/src/actions/wallet/switchChain.ts
+++ b/src/actions/wallet/switchChain.ts
@@ -1,11 +1,15 @@
-import type { WalletClientArg } from '../../clients'
-import type { Chain } from '../../types'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type SwitchChainParameters = { id: Chain['id'] }
 
-export async function switchChain(
-  client: WalletClientArg,
+export async function switchChain<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
   { id }: SwitchChainParameters,
 ) {
   await client.request({

--- a/src/actions/wallet/watchAsset.ts
+++ b/src/actions/wallet/watchAsset.ts
@@ -6,11 +6,10 @@ export type WatchAssetParameters = WatchAssetParams
 export type WatchAssetReturnType = boolean
 
 export async function watchAsset<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   params: WatchAssetParameters,
 ): Promise<WatchAssetReturnType> {
   const added = await client.request({

--- a/src/actions/wallet/watchAsset.ts
+++ b/src/actions/wallet/watchAsset.ts
@@ -1,11 +1,16 @@
-import type { WalletClientArg } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
+import type { Account, Chain } from '../../types'
 import type { WatchAssetParams } from '../../types/eip1193'
 
 export type WatchAssetParameters = WatchAssetParams
 export type WatchAssetReturnType = boolean
 
-export async function watchAsset(
-  client: WalletClientArg,
+export async function watchAsset<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TAccount extends Account | undefined = undefined,
+>(
+  client: WalletClient<TTransport, TChain, TAccount>,
   params: WatchAssetParameters,
 ): Promise<WatchAssetReturnType> {
   const added = await client.request({

--- a/src/actions/wallet/writeContract.test-d.ts
+++ b/src/actions/wallet/writeContract.test-d.ts
@@ -1,0 +1,65 @@
+import { assertType, expectTypeOf, test } from 'vitest'
+import { seaportAbi } from 'abitype/test'
+
+import type { WriteContractParameters } from './writeContract'
+import { getAccount } from '../../utils'
+
+test('WriteContractParameters', async () => {
+  type Result = WriteContractParameters<typeof seaportAbi, 'cancel'>
+  expectTypeOf<Result['functionName']>().toEqualTypeOf<
+    | 'cancel'
+    | 'fulfillAdvancedOrder'
+    | 'fulfillAvailableAdvancedOrders'
+    | 'fulfillAvailableOrders'
+    | 'fulfillBasicOrder'
+    | 'fulfillBasicOrder_efficient_6GL6yc'
+    | 'fulfillOrder'
+    | 'incrementCounter'
+    | 'matchAdvancedOrders'
+    | 'matchOrders'
+    | 'validate'
+  >()
+
+  const address = '0x' as const
+  assertType<WriteContractParameters<typeof seaportAbi, 'cancel'>>({
+    abi: seaportAbi,
+    account: getAccount(address),
+    address,
+    functionName: 'cancel',
+    // ^?
+    args: [
+      [
+        {
+          offerer: address,
+          zone: address,
+          offer: [
+            {
+              itemType: 1,
+              token: address,
+              identifierOrCriteria: 1n,
+              startAmount: 1n,
+              endAmount: 1n,
+            },
+          ],
+          consideration: [
+            {
+              itemType: 1,
+              token: address,
+              identifierOrCriteria: 1n,
+              startAmount: 1n,
+              endAmount: 1n,
+              recipient: address,
+            },
+          ],
+          counter: 1n,
+          orderType: 1,
+          startTime: 1n,
+          endTime: 1n,
+          salt: 1n,
+          conduitKey: address,
+          zoneHash: address,
+        },
+      ],
+    ],
+  })
+})

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -36,10 +36,10 @@ export type WriteContractParameters<
 export type WriteContractReturnType = SendTransactionReturnType
 
 export async function writeContract<
-  TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
+  TAbi extends Abi | readonly unknown[],
+  TFunctionName extends string,
   TChainOverride extends Chain | undefined = undefined,
 >(
   client: WalletClient<Transport, TChain, TAccount>,

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { WalletClientArg, Transport } from '../../clients'
+import type { Transport, WalletClient } from '../../clients'
 import type {
   Account,
   Chain,
@@ -16,11 +16,11 @@ import {
 } from './sendTransaction'
 
 export type WriteContractParameters<
-  TChain extends Chain | undefined = Chain,
   TAbi extends Abi | readonly unknown[] = Abi,
   TFunctionName extends string = string,
+  TChain extends Chain | undefined = Chain,
   TAccount extends Account | undefined = undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = undefined,
 > = Omit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
   'chain' | 'to' | 'data' | 'value'
@@ -36,13 +36,13 @@ export type WriteContractParameters<
 export type WriteContractReturnType = SendTransactionReturnType
 
 export async function writeContract<
-  TChain extends Chain | undefined,
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
+  TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = undefined,
 >(
-  client: WalletClientArg<Transport, TChain, TAccount>,
+  client: WalletClient<Transport, TChain, TAccount>,
   {
     abi,
     address,
@@ -50,9 +50,9 @@ export async function writeContract<
     functionName,
     ...request
   }: WriteContractParameters<
-    TChain,
     TAbi,
     TFunctionName,
+    TChain,
     TAccount,
     TChainOverride
   >,

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -1,0 +1,20 @@
+import { localhost } from '@wagmi/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import { createClient } from './createClient'
+import { http } from './transports'
+
+test('with chain', () => {
+  const client = createClient({
+    chain: localhost,
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(localhost)
+})
+
+test('without chain', () => {
+  const client = createClient({
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(undefined)
+})

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -1,7 +1,7 @@
 import { localhost } from '@wagmi/chains'
 import { expectTypeOf, test } from 'vitest'
 
-import { createClient } from './createClient'
+import { Client, createClient } from './createClient'
 import { http } from './transports'
 
 test('with chain', () => {
@@ -9,6 +9,7 @@ test('with chain', () => {
     chain: localhost,
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<Client>()
   expectTypeOf(client.chain).toEqualTypeOf(localhost)
 })
 
@@ -16,5 +17,6 @@ test('without chain', () => {
   const client = createClient({
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<Client>()
   expectTypeOf(client.chain).toEqualTypeOf(undefined)
 })

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -1,4 +1,4 @@
-import type { Chain, IsUndefined } from '../types'
+import type { Chain } from '../types'
 import type { Requests } from '../types/eip1193'
 import { uid } from '../utils/uid'
 import type { BaseRpcRequests, Transport } from './transports/createTransport'
@@ -26,11 +26,11 @@ export type ClientConfig<
 
 export type Client<
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined,
   TRequests extends BaseRpcRequests = Requests,
+  TChain extends Chain | undefined = Chain | undefined,
 > = {
   /** Chain for the client. */
-  chain: TChain & (IsUndefined<TChain> extends true ? undefined : TChain)
+  chain: TChain
   /** A key for the client. */
   key: string
   /** A name for the client. */
@@ -52,8 +52,8 @@ export type Client<
  */
 export function createClient<
   TTransport extends Transport,
-  TChain extends Chain | undefined,
   TRequests extends BaseRpcRequests,
+  TChain extends Chain | undefined = undefined,
 >({
   chain,
   key = 'base',
@@ -61,10 +61,10 @@ export function createClient<
   pollingInterval = 4_000,
   transport,
   type = 'base',
-}: ClientConfig<TTransport, TChain>): Client<TTransport, TChain, TRequests> {
+}: ClientConfig<TTransport, TChain>): Client<TTransport, TRequests, TChain> {
   const { config, request, value } = transport({ chain })
   return {
-    chain,
+    chain: chain as TChain,
     key,
     name,
     pollingInterval,
@@ -72,5 +72,5 @@ export function createClient<
     transport: { ...config, ...value },
     type,
     uid: uid(),
-  } as Client<TTransport, TChain, TRequests>
+  }
 }

--- a/src/clients/createPublicClient.test-d.ts
+++ b/src/clients/createPublicClient.test-d.ts
@@ -11,9 +11,6 @@ test('with chain', () => {
   })
   expectTypeOf(client).toMatchTypeOf<PublicClient>()
   expectTypeOf(client.chain).toEqualTypeOf(localhost)
-
-  const foo = (c: PublicClient) => c
-  foo(client)
 })
 
 test('without chain', () => {

--- a/src/clients/createPublicClient.test-d.ts
+++ b/src/clients/createPublicClient.test-d.ts
@@ -1,0 +1,20 @@
+import { localhost } from '@wagmi/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import { createPublicClient } from './createPublicClient'
+import { http } from './transports'
+
+test('with chain', () => {
+  const client = createPublicClient({
+    chain: localhost,
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(localhost)
+})
+
+test('without chain', () => {
+  const client = createPublicClient({
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(undefined)
+})

--- a/src/clients/createPublicClient.test-d.ts
+++ b/src/clients/createPublicClient.test-d.ts
@@ -1,7 +1,7 @@
 import { localhost } from '@wagmi/chains'
 import { expectTypeOf, test } from 'vitest'
 
-import { createPublicClient } from './createPublicClient'
+import { createPublicClient, PublicClient } from './createPublicClient'
 import { http } from './transports'
 
 test('with chain', () => {
@@ -9,12 +9,17 @@ test('with chain', () => {
     chain: localhost,
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<PublicClient>()
   expectTypeOf(client.chain).toEqualTypeOf(localhost)
+
+  const foo = (c: PublicClient) => c
+  foo(client)
 })
 
 test('without chain', () => {
   const client = createPublicClient({
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<PublicClient>()
   expectTypeOf(client.chain).toEqualTypeOf(undefined)
 })

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -3,11 +3,11 @@ import type { Transport } from './transports/createTransport'
 import type { Client, ClientConfig } from './createClient'
 import { createClient } from './createClient'
 import { publicActions, PublicActions } from './decorators'
-import type { Chain } from '../types'
+import type { Chain, Prettify } from '../types'
 
 export type PublicClientConfig<
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = undefined,
+  TChain extends Chain | undefined = Chain | undefined,
 > = Pick<
   ClientConfig<TTransport, TChain>,
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
@@ -17,15 +17,17 @@ export type PublicClient<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TIncludeActions extends boolean = true,
-> = Client<TTransport, TChain, PublicRequests> &
-  (TIncludeActions extends true ? PublicActions<TChain> : unknown)
+> = Prettify<
+  Client<TTransport, PublicRequests, TChain> &
+    (TIncludeActions extends true ? PublicActions<TChain> : unknown)
+>
 
 /**
  * @description Creates a public client with a given transport.
  */
 export function createPublicClient<
   TTransport extends Transport,
-  TChain extends Chain | undefined,
+  TChain extends Chain | undefined = undefined,
 >({
   chain,
   key = 'public',

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -7,7 +7,7 @@ import type { Chain } from '../types'
 
 export type PublicClientConfig<
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = undefined,
 > = Pick<
   ClientConfig<TTransport, TChain>,
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
@@ -15,16 +15,10 @@ export type PublicClientConfig<
 
 export type PublicClient<
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = Chain | undefined,
   TIncludeActions extends boolean = true,
 > = Client<TTransport, TChain, PublicRequests> &
-  (TIncludeActions extends true ? PublicActions<TChain> : {})
-
-export type PublicClientArg<
-  TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain | undefined,
-  TIncludeActions extends boolean = boolean,
-> = PublicClient<TTransport, TChain, TIncludeActions>
+  (TIncludeActions extends true ? PublicActions<TChain> : unknown)
 
 /**
  * @description Creates a public client with a given transport.
@@ -50,9 +44,9 @@ export function createPublicClient<
     pollingInterval,
     transport,
     type: 'publicClient',
-  })
+  }) as PublicClient<TTransport, TChain>
   return {
     ...client,
-    ...publicActions(client as PublicClient),
+    ...publicActions(client),
   }
 }

--- a/src/clients/createTestClient.test-d.ts
+++ b/src/clients/createTestClient.test-d.ts
@@ -1,7 +1,7 @@
 import { localhost } from '@wagmi/chains'
 import { expectTypeOf, test } from 'vitest'
 
-import { createTestClient } from './createTestClient'
+import { createTestClient, TestClient } from './createTestClient'
 import { http } from './transports'
 
 test('with chain', () => {
@@ -10,6 +10,7 @@ test('with chain', () => {
     mode: 'anvil',
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<TestClient>()
   expectTypeOf(client.mode).toEqualTypeOf<'anvil'>()
   expectTypeOf(client.chain).toEqualTypeOf(localhost)
 })
@@ -19,5 +20,6 @@ test('without chain', () => {
     mode: 'anvil',
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<TestClient>()
   expectTypeOf(client.chain).toEqualTypeOf(undefined)
 })

--- a/src/clients/createTestClient.test-d.ts
+++ b/src/clients/createTestClient.test-d.ts
@@ -1,0 +1,23 @@
+import { localhost } from '@wagmi/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import { createTestClient } from './createTestClient'
+import { http } from './transports'
+
+test('with chain', () => {
+  const client = createTestClient({
+    chain: localhost,
+    mode: 'anvil',
+    transport: http(),
+  })
+  expectTypeOf(client.mode).toEqualTypeOf<'anvil'>()
+  expectTypeOf(client.chain).toEqualTypeOf(localhost)
+})
+
+test('without chain', () => {
+  const client = createTestClient({
+    mode: 'anvil',
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(undefined)
+})

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -5,48 +5,37 @@ import { createClient } from './createClient'
 import { testActions, TestActions } from './decorators'
 import type { Transport } from './transports/createTransport'
 
-type TestClientModes = 'anvil' | 'hardhat'
+export type TestClientMode = 'anvil' | 'hardhat'
 
 export type TestClientConfig<
+  TMode extends TestClientMode = TestClientMode,
   TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain,
-  TMode extends TestClientModes = TestClientModes,
-> = {
-  chain?: ClientConfig<TTransport, TChain>['chain']
-  /** The key of the client. */
-  key?: ClientConfig['key']
+  TChain extends Chain | undefined = Chain | undefined,
+> = Pick<
+  ClientConfig<TTransport, TChain>,
+  'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
+> & {
   /** Mode of the test client. Available: "anvil" | "hardhat" */
   mode: TMode
-  /** The name of the client. */
-  name?: ClientConfig['name']
-  /** Frequency (in ms) for polling enabled actions & events. Defaults to 4_000 milliseconds. */
-  pollingInterval?: ClientConfig['pollingInterval']
-  transport: ClientConfig<TTransport, TChain>['transport']
 }
 
 export type TestClient<
-  TTransport extends Transport = Transport,
-  TChain extends Chain | undefined = Chain,
-  TMode extends TestClientModes = TestClientModes,
-  TIncludeActions extends boolean = true,
-> = Client<TTransport, TChain, TestRequests<TMode>> & {
-  mode: TMode
-} & (TIncludeActions extends true ? TestActions : {})
-
-export type TestClientArg<
+  TMode extends TestClientMode = TestClientMode,
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TMode extends TestClientModes = TestClientModes,
-  TIncludeActions extends boolean = boolean,
-> = TestClient<TTransport, TChain, TMode, TIncludeActions>
+  TIncludeActions extends boolean = true,
+> = Client<TTransport, TChain, TestRequests<TMode>> &
+  (TIncludeActions extends true ? TestActions : unknown) & {
+    mode: TMode
+  }
 
 /**
  * @description Creates a test client with a given transport.
  */
 export function createTestClient<
+  TMode extends TestClientMode,
   TTransport extends Transport,
   TChain extends Chain | undefined,
-  TMode extends TestClientModes,
 >({
   chain,
   key = 'test',
@@ -54,10 +43,10 @@ export function createTestClient<
   mode,
   pollingInterval,
   transport,
-}: TestClientConfig<TTransport, TChain, TMode>): TestClient<
+}: TestClientConfig<TMode, TTransport, TChain>): TestClient<
+  TMode,
   TTransport,
   TChain,
-  TMode,
   true
 > {
   const client = {
@@ -70,9 +59,9 @@ export function createTestClient<
       type: 'testClient',
     }),
     mode,
-  }
+  } as TestClient<TMode, TTransport, TChain>
   return {
     ...client,
-    ...testActions(client as TestClient<any, any, any>),
+    ...testActions(client),
   }
 }

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -24,7 +24,7 @@ export type TestClient<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TIncludeActions extends boolean = true,
-> = Client<TTransport, TChain, TestRequests<TMode>> &
+> = Client<TTransport, TestRequests<TMode>, TChain> &
   (TIncludeActions extends true ? TestActions : unknown) & {
     mode: TMode
   }
@@ -35,7 +35,7 @@ export type TestClient<
 export function createTestClient<
   TMode extends TestClientMode,
   TTransport extends Transport,
-  TChain extends Chain | undefined,
+  TChain extends Chain | undefined = undefined,
 >({
   chain,
   key = 'test',

--- a/src/clients/createWalletClient.test-d.ts
+++ b/src/clients/createWalletClient.test-d.ts
@@ -2,7 +2,7 @@ import { localhost } from '@wagmi/chains'
 import { expectTypeOf, test } from 'vitest'
 
 import type { JsonRpcAccount } from '../types'
-import { createWalletClient } from './createWalletClient'
+import { createWalletClient, WalletClient } from './createWalletClient'
 import { http } from './transports'
 
 test('with chain', () => {
@@ -10,6 +10,7 @@ test('with chain', () => {
     chain: localhost,
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<WalletClient>()
   expectTypeOf(client.chain).toEqualTypeOf(localhost)
 })
 
@@ -17,6 +18,7 @@ test('without chain', () => {
   const client = createWalletClient({
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<WalletClient>()
   expectTypeOf(client.chain).toEqualTypeOf(undefined)
 })
 
@@ -25,6 +27,7 @@ test('with account', () => {
     account: '0x',
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<WalletClient>()
   expectTypeOf(client.account).toEqualTypeOf<JsonRpcAccount>()
 })
 
@@ -32,5 +35,6 @@ test('without account', () => {
   const client = createWalletClient({
     transport: http(),
   })
+  expectTypeOf(client).toMatchTypeOf<WalletClient>()
   expectTypeOf(client.account).toEqualTypeOf(undefined)
 })

--- a/src/clients/createWalletClient.test-d.ts
+++ b/src/clients/createWalletClient.test-d.ts
@@ -1,0 +1,36 @@
+import { localhost } from '@wagmi/chains'
+import { expectTypeOf, test } from 'vitest'
+
+import type { JsonRpcAccount } from '../types'
+import { createWalletClient } from './createWalletClient'
+import { http } from './transports'
+
+test('with chain', () => {
+  const client = createWalletClient({
+    chain: localhost,
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(localhost)
+})
+
+test('without chain', () => {
+  const client = createWalletClient({
+    transport: http(),
+  })
+  expectTypeOf(client.chain).toEqualTypeOf(undefined)
+})
+
+test('with account', () => {
+  const client = createWalletClient({
+    account: '0x',
+    transport: http(),
+  })
+  expectTypeOf(client.account).toEqualTypeOf<JsonRpcAccount>()
+})
+
+test('without account', () => {
+  const client = createWalletClient({
+    transport: http(),
+  })
+  expectTypeOf(client.account).toEqualTypeOf(undefined)
+})

--- a/src/clients/createWalletClient.test-d.ts
+++ b/src/clients/createWalletClient.test-d.ts
@@ -28,7 +28,10 @@ test('with account', () => {
     transport: http(),
   })
   expectTypeOf(client).toMatchTypeOf<WalletClient>()
-  expectTypeOf(client.account).toEqualTypeOf<JsonRpcAccount>()
+  expectTypeOf(client.account).toEqualTypeOf<JsonRpcAccount<'0x'>>({
+    address: '0x',
+    type: 'json-rpc',
+  })
 })
 
 test('without account', () => {

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -25,7 +25,7 @@ test('creates', () => {
     client.request,
   )
   assertType<{
-    account: undefined
+    account?: undefined
   }>(client)
   expect(uid).toBeDefined()
   expect(client).toMatchInlineSnapshot(`

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -59,7 +59,9 @@ export function createWalletClient<
 }: WalletClientConfig<TTransport, TChain, TAccountOrAddress>): WalletClient<
   TTransport,
   TChain,
-  TAccountOrAddress extends Address ? JsonRpcAccount : TAccountOrAddress,
+  TAccountOrAddress extends Address
+    ? Prettify<JsonRpcAccount<TAccountOrAddress>>
+    : TAccountOrAddress,
   true
 > {
   const client = {
@@ -75,7 +77,9 @@ export function createWalletClient<
   } as WalletClient<
     TTransport,
     TChain,
-    TAccountOrAddress extends Address ? JsonRpcAccount : TAccountOrAddress
+    TAccountOrAddress extends Address
+      ? JsonRpcAccount<TAccountOrAddress>
+      : TAccountOrAddress
   >
   return {
     ...client,

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -114,7 +114,9 @@ import type {
 import type { PublicClient } from '../createPublicClient'
 import type { Transport } from '../transports'
 
-export type PublicActions<TChain extends Chain | undefined = undefined> = {
+export type PublicActions<
+  TChain extends Chain | undefined = Chain | undefined,
+> = {
   call: (args: CallParameters<TChain>) => Promise<CallReturnType>
   createBlockFilter: () => Promise<CreateBlockFilterReturnType>
   createContractEventFilter: <
@@ -248,7 +250,7 @@ export type PublicActions<TChain extends Chain | undefined = undefined> = {
 
 export const publicActions = <
   TTransport extends Transport,
-  TChain extends Chain | undefined,
+  TChain extends Chain | undefined = Chain | undefined,
 >(
   client: PublicClient<TTransport, TChain>,
 ): PublicActions<TChain> => ({

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -60,10 +60,15 @@ import type {
   WaitForTransactionReceiptParameters,
   WaitForTransactionReceiptReturnType,
   WatchBlockNumberParameters,
+  WatchBlockNumberReturnType,
   WatchBlocksParameters,
+  WatchBlocksReturnType,
   WatchContractEventParameters,
+  WatchContractEventReturnType,
   WatchEventParameters,
+  WatchEventReturnType,
   WatchPendingTransactionsParameters,
+  WatchPendingTransactionsReturnType,
 } from '../../actions/public'
 import {
   call,
@@ -107,8 +112,9 @@ import type {
   MaybeExtractEventArgsFromAbi,
 } from '../../types'
 import type { PublicClient } from '../createPublicClient'
+import type { Transport } from '../transports'
 
-export type PublicActions<TChain extends Chain | undefined = Chain> = {
+export type PublicActions<TChain extends Chain | undefined = undefined> = {
   call: (args: CallParameters<TChain>) => Promise<CallReturnType>
   createBlockFilter: () => Promise<CreateBlockFilterReturnType>
   createContractEventFilter: <
@@ -224,32 +230,27 @@ export type PublicActions<TChain extends Chain | undefined = Chain> = {
   ) => Promise<WaitForTransactionReceiptReturnType<TChain>>
   watchBlockNumber: (
     args: WatchBlockNumberParameters,
-  ) => ReturnType<typeof watchBlockNumber>
-  watchBlocks: (
-    args: WatchBlocksParameters<TChain>,
-  ) => ReturnType<typeof watchBlocks>
+  ) => WatchBlockNumberReturnType
+  watchBlocks: (args: WatchBlocksParameters<TChain>) => WatchBlocksReturnType
   watchContractEvent: <
     TAbi extends Abi | readonly unknown[],
     TEventName extends string,
   >(
     args: WatchContractEventParameters<TAbi, TEventName>,
-  ) => ReturnType<typeof watchContractEvent>
-  watchEvent: <
-    TAbiEvent extends AbiEvent | undefined,
-    TEventName extends string | undefined,
-  >(
+  ) => WatchContractEventReturnType
+  watchEvent: <TAbiEvent extends AbiEvent | undefined>(
     args: WatchEventParameters<TAbiEvent>,
-  ) => ReturnType<typeof watchEvent>
+  ) => WatchEventReturnType
   watchPendingTransactions: (
     args: WatchPendingTransactionsParameters,
-  ) => ReturnType<typeof watchPendingTransactions>
+  ) => WatchPendingTransactionsReturnType
 }
 
 export const publicActions = <
+  TTransport extends Transport,
   TChain extends Chain | undefined,
-  TClient extends PublicClient<any, any>,
 >(
-  client: TClient,
+  client: PublicClient<TTransport, TChain>,
 ): PublicActions<TChain> => ({
   call: (args) => call(client, args),
   createBlockFilter: () => createBlockFilter(client),

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -140,7 +140,7 @@ export type PublicActions<
     TAbi extends Abi | readonly unknown[],
     TFunctionName extends string,
   >(
-    args: EstimateContractGasParameters<TChain, TAbi, TFunctionName>,
+    args: EstimateContractGasParameters<TAbi, TFunctionName, TChain>,
   ) => Promise<EstimateContractGasReturnType>
   estimateGas: (
     args: EstimateGasParameters<TChain>,
@@ -216,13 +216,13 @@ export type PublicActions<
     TChainOverride extends Chain | undefined = undefined,
   >(
     args: SimulateContractParameters<
-      TChain,
       TAbi,
       TFunctionName,
+      TChain,
       TChainOverride
     >,
   ) => Promise<
-    SimulateContractReturnType<TChain, TAbi, TFunctionName, TChainOverride>
+    SimulateContractReturnType<TAbi, TFunctionName, TChain, TChainOverride>
   >
   uninstallFilter: (
     args: UninstallFilterParameters,

--- a/src/clients/decorators/test.ts
+++ b/src/clients/decorators/test.ts
@@ -54,8 +54,9 @@ import {
   snapshot,
   stopImpersonatingAccount,
 } from '../../actions/test'
-import type { Quantity } from '../../types'
-import type { TestClient } from '../createTestClient'
+import type { Chain, Quantity } from '../../types'
+import type { TestClient, TestClientMode } from '../createTestClient'
+import type { Transport } from '../transports'
 
 export type TestActions = {
   dropTransaction: (args: DropTransactionParameters) => Promise<void>
@@ -98,35 +99,39 @@ export type TestActions = {
   ) => Promise<void>
 }
 
-export const testActions = <TClient extends TestClient<any, any>>(
-  client: TClient,
-): TestActions => ({
-  dropTransaction: (args) => dropTransaction(client, args),
-  getAutomine: () => getAutomine(client),
-  getTxpoolContent: () => getTxpoolContent(client),
-  getTxpoolStatus: () => getTxpoolStatus(client),
-  impersonateAccount: (args) => impersonateAccount(client, args),
-  increaseTime: (args) => increaseTime(client, args),
-  inspectTxpool: () => inspectTxpool(client),
-  mine: (args) => mine(client, args),
-  removeBlockTimestampInterval: () => removeBlockTimestampInterval(client),
-  reset: (args) => reset(client, args),
-  revert: (args) => revert(client, args),
-  sendUnsignedTransaction: (args) => sendUnsignedTransaction(client, args),
-  setAutomine: (args) => setAutomine(client, args),
-  setBalance: (args) => setBalance(client, args),
-  setBlockGasLimit: (args) => setBlockGasLimit(client, args),
-  setBlockTimestampInterval: (args) => setBlockTimestampInterval(client, args),
-  setCode: (args) => setCode(client, args),
-  setCoinbase: (args) => setCoinbase(client, args),
-  setIntervalMining: (args) => setIntervalMining(client, args),
-  setLoggingEnabled: (args) => setLoggingEnabled(client, args),
-  setMinGasPrice: (args) => setMinGasPrice(client, args),
-  setNextBlockBaseFeePerGas: (args) => setNextBlockBaseFeePerGas(client, args),
-  setNextBlockTimestamp: (args) => setNextBlockTimestamp(client, args),
-  setNonce: (args) => setNonce(client, args),
-  setRpcUrl: (args) => setRpcUrl(client, args),
-  setStorageAt: (args) => setStorageAt(client, args),
-  snapshot: () => snapshot(client),
-  stopImpersonatingAccount: (args) => stopImpersonatingAccount(client, args),
-})
+export function testActions<TChain extends Chain | undefined>(
+  client: TestClient<TestClientMode, Transport, TChain>,
+): TestActions {
+  return {
+    dropTransaction: (args) => dropTransaction(client, args),
+    getAutomine: () => getAutomine(client),
+    getTxpoolContent: () => getTxpoolContent(client),
+    getTxpoolStatus: () => getTxpoolStatus(client),
+    impersonateAccount: (args) => impersonateAccount(client, args),
+    increaseTime: (args) => increaseTime(client, args),
+    inspectTxpool: () => inspectTxpool(client),
+    mine: (args) => mine(client, args),
+    removeBlockTimestampInterval: () => removeBlockTimestampInterval(client),
+    reset: (args) => reset(client, args),
+    revert: (args) => revert(client, args),
+    sendUnsignedTransaction: (args) => sendUnsignedTransaction(client, args),
+    setAutomine: (args) => setAutomine(client, args),
+    setBalance: (args) => setBalance(client, args),
+    setBlockGasLimit: (args) => setBlockGasLimit(client, args),
+    setBlockTimestampInterval: (args) =>
+      setBlockTimestampInterval(client, args),
+    setCode: (args) => setCode(client, args),
+    setCoinbase: (args) => setCoinbase(client, args),
+    setIntervalMining: (args) => setIntervalMining(client, args),
+    setLoggingEnabled: (args) => setLoggingEnabled(client, args),
+    setMinGasPrice: (args) => setMinGasPrice(client, args),
+    setNextBlockBaseFeePerGas: (args) =>
+      setNextBlockBaseFeePerGas(client, args),
+    setNextBlockTimestamp: (args) => setNextBlockTimestamp(client, args),
+    setNonce: (args) => setNonce(client, args),
+    setRpcUrl: (args) => setRpcUrl(client, args),
+    setStorageAt: (args) => setStorageAt(client, args),
+    snapshot: () => snapshot(client),
+    stopImpersonatingAccount: (args) => stopImpersonatingAccount(client, args),
+  }
+}

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -41,15 +41,15 @@ import type { WalletClient } from '../createWalletClient'
 import type { Transport } from '../transports'
 
 export type WalletActions<
-  TChain extends Chain | undefined = undefined,
-  TAccount extends Account | undefined = undefined,
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends Account | undefined = Account | undefined,
 > = {
   addChain: (args: AddChainParameters) => Promise<void>
   deployContract: <
     TAbi extends Abi | readonly unknown[],
     TChainOverride extends Chain | undefined,
   >(
-    args: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
+    args: DeployContractParameters<TChain, TAccount, TAbi, TChainOverride>,
   ) => Promise<DeployContractReturnType>
   getAddresses: () => Promise<GetAddressesReturnType>
   getChainId: () => Promise<GetChainIdReturnType>
@@ -66,7 +66,7 @@ export type WalletActions<
   ) => Promise<SignMessageReturnType>
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
-    TPrimaryType extends string = string,
+    TPrimaryType extends string,
   >(
     args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>,
   ) => Promise<SignTypedDataReturnType>
@@ -75,7 +75,7 @@ export type WalletActions<
   writeContract: <
     TAbi extends Abi | readonly unknown[],
     TFunctionName extends string,
-    TChainOverride extends Chain | undefined = undefined,
+    TChainOverride extends Chain | undefined,
   >(
     args: WriteContractParameters<
       TAbi,
@@ -89,8 +89,8 @@ export type WalletActions<
 
 export const walletActions = <
   TTransport extends Transport,
-  TChain extends Chain | undefined,
-  TAccount extends Account | undefined,
+  TChain extends Chain | undefined = Chain | undefined,
+  TAccount extends Account | undefined = Account | undefined,
 >(
   client: WalletClient<TTransport, TChain, TAccount>,
 ): WalletActions<TChain, TAccount> => ({

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -49,7 +49,7 @@ export type WalletActions<
     TAbi extends Abi | readonly unknown[],
     TChainOverride extends Chain | undefined,
   >(
-    args: DeployContractParameters<TChain, TAccount, TAbi, TChainOverride>,
+    args: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
   ) => Promise<DeployContractReturnType>
   getAddresses: () => Promise<GetAddressesReturnType>
   getChainId: () => Promise<GetChainIdReturnType>

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -38,9 +38,10 @@ import {
 } from '../../actions/wallet'
 import type { Account, Chain } from '../../types'
 import type { WalletClient } from '../createWalletClient'
+import type { Transport } from '../transports'
 
 export type WalletActions<
-  TChain extends Chain | undefined = Chain,
+  TChain extends Chain | undefined = undefined,
   TAccount extends Account | undefined = undefined,
 > = {
   addChain: (args: AddChainParameters) => Promise<void>
@@ -48,7 +49,7 @@ export type WalletActions<
     TAbi extends Abi | readonly unknown[],
     TChainOverride extends Chain | undefined,
   >(
-    args: DeployContractParameters<TChain, TAbi, TAccount, TChainOverride>,
+    args: DeployContractParameters<TAbi, TChain, TAccount, TChainOverride>,
   ) => Promise<DeployContractReturnType>
   getAddresses: () => Promise<GetAddressesReturnType>
   getChainId: () => Promise<GetChainIdReturnType>
@@ -74,12 +75,12 @@ export type WalletActions<
   writeContract: <
     TAbi extends Abi | readonly unknown[],
     TFunctionName extends string,
-    TChainOverride extends Chain | undefined,
+    TChainOverride extends Chain | undefined = undefined,
   >(
     args: WriteContractParameters<
-      TChainOverride,
       TAbi,
       TFunctionName,
+      TChain,
       TAccount,
       TChainOverride
     >,
@@ -87,11 +88,12 @@ export type WalletActions<
 }
 
 export const walletActions = <
+  TTransport extends Transport,
   TChain extends Chain | undefined,
-  TClient extends WalletClient<any, any, any>,
+  TAccount extends Account | undefined,
 >(
-  client: TClient,
-): WalletActions<TChain> => ({
+  client: WalletClient<TTransport, TChain, TAccount>,
+): WalletActions<TChain, TAccount> => ({
   addChain: (args) => addChain(client, args),
   deployContract: (args) => deployContract(client, args),
   getAddresses: () => getAddresses(client),

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -24,20 +24,18 @@ export type { Client, ClientConfig } from './createClient'
 export { createPublicClient } from './createPublicClient'
 export type {
   PublicClient,
-  PublicClientArg,
   PublicClientConfig,
 } from './createPublicClient'
 
 export { createTestClient } from './createTestClient'
 export type {
   TestClient,
-  TestClientArg,
   TestClientConfig,
+  TestClientMode,
 } from './createTestClient'
 
 export { createWalletClient } from './createWalletClient'
 export type {
   WalletClient,
-  WalletClientArg,
   WalletClientConfig,
 } from './createWalletClient'

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -45,8 +45,8 @@ export type Transport<
  * @description Creates an transport intended to be used with a client.
  */
 export function createTransport<
-  TType extends string = string,
-  TRpcAttributes = any,
+  TType extends string,
+  TRpcAttributes extends Record<string, any>,
 >(
   {
     key,

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -4,7 +4,9 @@ import type { TransactionRequest } from './transaction'
 import type { TypedDataDefinition } from './typedData'
 import type { IsUndefined } from './utils'
 
-export type Account = JsonRpcAccount | LocalAccount
+export type Account<TAddress extends Address = Address> =
+  | JsonRpcAccount<TAddress>
+  | LocalAccount<TAddress>
 
 export type GetAccountParameter<
   TAccount extends Account | undefined = Account | undefined,
@@ -12,13 +14,13 @@ export type GetAccountParameter<
   ? { account: Account | Address }
   : { account?: Account | Address }
 
-export type JsonRpcAccount = {
-  address: Address
+export type JsonRpcAccount<TAddress extends Address = Address> = {
+  address: TAddress
   type: 'json-rpc'
 }
 
-export type LocalAccount = {
-  address: Address
+export type LocalAccount<TAddress extends Address = Address> = {
+  address: TAddress
   signMessage: (message: string) => Promise<Hash>
   signTransaction: (
     transaction: Omit<TransactionRequest, 'from'> & {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -2,12 +2,13 @@ import type { Address, TypedData } from 'abitype'
 import type { Hash } from './misc'
 import type { TransactionRequest } from './transaction'
 import type { TypedDataDefinition } from './typedData'
+import type { IsUndefined } from './utils'
 
 export type Account = JsonRpcAccount | LocalAccount
 
 export type GetAccountParameter<
-  TAccount extends Account | undefined = undefined,
-> = TAccount extends undefined
+  TAccount extends Account | undefined = Account | undefined,
+> = IsUndefined<TAccount> extends true
   ? { account: Account | Address }
   : { account?: Account | Address }
 
@@ -33,8 +34,3 @@ export type LocalAccount = {
   ) => Promise<Hash>
   type: 'local'
 }
-
-export type ParseAccount<TAccount extends Account | Address | undefined> =
-  | (TAccount extends Account ? TAccount : never)
-  | (TAccount extends Address ? JsonRpcAccount : never)
-  | (TAccount extends undefined ? undefined : never)

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,6 +1,7 @@
 import type { Chain as Chain_ } from '@wagmi/chains'
 import type { Address } from 'abitype'
 import type { Formatters } from './formatter'
+import type { IsUndefined } from './utils'
 
 export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
   formatters?: TFormatters
@@ -14,6 +15,6 @@ export type ChainContract = {
 export type GetChain<
   TChain extends Chain | undefined,
   TChainOverride extends Chain | undefined = undefined,
-> = TChain extends Chain
-  ? { chain?: TChainOverride | null }
-  : { chain: TChainOverride | null }
+> = IsUndefined<TChain> extends true
+  ? { chain: TChainOverride | null }
+  : { chain?: TChainOverride | null }

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -13,7 +13,7 @@ export type ChainContract = {
 
 export type GetChain<
   TChain extends Chain | undefined,
-  TChainOverride extends Chain | undefined = TChain,
+  TChainOverride extends Chain | undefined = undefined,
 > = TChain extends Chain
   ? { chain?: TChainOverride | null }
   : { chain: TChainOverride | null }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,6 +94,8 @@ export type {
 } from './typedData'
 
 export type {
+  IsNever,
+  IsUndefined,
   PartialBy,
   Prettify,
   MergeIntersectionProperties,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ export type {
   GetAccountParameter,
   LocalAccount,
   JsonRpcAccount,
-  ParseAccount,
 } from './account'
 
 export type {

--- a/src/types/utils.test-d.ts
+++ b/src/types/utils.test-d.ts
@@ -1,0 +1,28 @@
+import { test, expectTypeOf } from 'vitest'
+import type { IsNever, IsUndefined } from './utils'
+
+test('IsNever', () => {
+  expectTypeOf<IsNever<never>>().toEqualTypeOf<true>()
+
+  expectTypeOf<IsNever<'never'>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<undefined>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<null>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<0>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<false>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<[]>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<{}>>().toEqualTypeOf<false>()
+  expectTypeOf<IsNever<never[]>>().toEqualTypeOf<false>()
+})
+
+test('IsUndefined', () => {
+  expectTypeOf<IsUndefined<undefined>>().toEqualTypeOf<true>()
+
+  expectTypeOf<IsUndefined<never>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<'never'>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<null>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<0>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<false>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<[]>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<{}>>().toEqualTypeOf<false>()
+  expectTypeOf<IsUndefined<undefined[]>>().toEqualTypeOf<false>()
+})

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,4 +1,22 @@
 /**
+ * @description Checks if {@link T} is `never`
+ * @param T - Type to check
+ * @example
+ * type Result = IsNever<never>
+ * //   ^? true
+ */
+export type IsNever<T> = [T] extends [never] ? true : false
+
+/**
+ * @description Checks if {@link T} is `undefined`
+ * @param T - Type to check
+ * @example
+ * type Result = IsUndefined<undefined>
+ * //   ^? true
+ */
+export type IsUndefined<T> = [undefined] extends [T] ? true : false
+
+/**
  * @description Excludes empty attributes from T if TMaybeExclude is true.
  *
  * @example

--- a/src/utils/abi/encodePacked.ts
+++ b/src/utils/abi/encodePacked.ts
@@ -29,12 +29,11 @@ type PackedAbiType =
   | SolidityString
   | SolidityArrayWithoutTuple
 
-type EncodePackedValues<TPackedAbiTypes extends PackedAbiType[] | unknown[],> =
-  {
-    [K in keyof TPackedAbiTypes]: TPackedAbiTypes[K] extends AbiType
-      ? AbiParameterToPrimitiveType<{ type: TPackedAbiTypes[K] }>
-      : unknown
-  }
+type EncodePackedValues<TPackedAbiTypes extends PackedAbiType[] | unknown[]> = {
+  [K in keyof TPackedAbiTypes]: TPackedAbiTypes[K] extends AbiType
+    ? AbiParameterToPrimitiveType<{ type: TPackedAbiTypes[K] }>
+    : unknown
+}
 
 export function encodePacked<
   TPackedAbiTypes extends PackedAbiType[] | unknown[],

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -6,7 +6,7 @@ import {
   getTransactionCount,
   SendTransactionParameters,
 } from '../../actions'
-import type { PublicClientArg, WalletClientArg, Transport } from '../../clients'
+import type { PublicClient, Transport, WalletClient } from '../../clients'
 import { AccountNotFoundError, BaseError } from '../../errors'
 import type { Account, Address, Chain, GetAccountParameter } from '../../types'
 import { parseAccount } from '../account'
@@ -38,13 +38,13 @@ export type PrepareRequestReturnType<
 export const defaultTip = parseGwei('1.5')
 
 export async function prepareRequest<
+  TChain extends Chain | undefined,
   TAccount extends Account | undefined,
   TParameters extends PrepareRequestParameters<TAccount>,
-  TChain extends Chain | undefined,
 >(
   client:
-    | WalletClientArg<Transport, TChain, TAccount>
-    | PublicClientArg<Transport, TChain>,
+    | WalletClient<Transport, TChain, TAccount>
+    | PublicClient<Transport, TChain>,
   args: TParameters,
 ): Promise<PrepareRequestReturnType<TAccount, TParameters>> {
   const {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "target": "ESNext",
     "types": ["node"]
   },
-  "exclude": ["node_modules", "playgrounds", "dist"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "target": "ESNext",
     "types": ["node"]
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "playgrounds", "dist"]
 }


### PR DESCRIPTION
Changes types for `chain` and `account` to get narrowed types. Could make it so `chain` isn't a valid property (e.g. `client.chain` errors), but maybe too annoying for us to internally check if `chain` exists all the time.

**Client created with chain**

| Before | After |
|--------|--------|
| <img width="311" alt="image" src="https://user-images.githubusercontent.com/6759464/227065190-75fa62e1-cb6b-4d17-b9ed-84e8215266c7.png"> | <img width="295" alt="image" src="https://user-images.githubusercontent.com/6759464/227065655-508cdbb8-29a7-45a1-a268-501e14c817a9.png"> |

**Client created without chain**

| Before | After |
|--------|--------|
| <img width="383" alt="image" src="https://user-images.githubusercontent.com/6759464/227065271-71644527-f33b-42e9-9d6b-f0cc647115aa.png"> | <img width="293" alt="image" src="https://user-images.githubusercontent.com/6759464/227558807-bab209e0-3e4d-449d-bff1-3b551f0948d5.png"> |

**Wallet Client created with account**

| Header | Header |
|--------|--------|
| <img width="362" alt="image" src="https://user-images.githubusercontent.com/6759464/227558066-0a4e83a8-e05a-4513-b1da-78766e6e2beb.png"> | <img width="334" alt="image" src="https://user-images.githubusercontent.com/6759464/227557658-2bb927ea-ed40-4600-b0f0-27f3d514d19a.png"> | 

**Wallet Client created without account**

| Header | Header |
|--------|--------|
| <img width="313" alt="image" src="https://user-images.githubusercontent.com/6759464/227558418-87ca48d3-c1b0-4d9f-ae6f-a0cee87179dc.png"> | <img width="335" alt="image" src="https://user-images.githubusercontent.com/6759464/227557808-9972f096-63e3-42c4-91bb-1021b596c6f2.png"> | 