### PR TITLE
feat: use ws subscriptions (`eth_subscribe`) for `watchBlocks`, `watchBlockNumber` & `watchPendingTransactions`

### DIFF
--- a/.changeset/gentle-peas-act.md
+++ b/.changeset/gentle-peas-act.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added WebSocket `eth_subscribe` support `watchBlocks`, `watchBlockNumber`, and `watchPendingTransactions`.

--- a/site/docs/actions/public/watchBlockNumber.md
+++ b/site/docs/actions/public/watchBlockNumber.md
@@ -98,7 +98,7 @@ const unwatch = publicClient.watchBlockNumber(
 ### poll (optional)
 
 - **Type:** `boolean`
-- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+- **Default:** `false` for WebSocket Transports, `true` for non-WebSocket Transports
 
 Whether or not to use a polling mechanism to check for new block numbers instead of a WebSocket subscription.
 

--- a/site/docs/actions/public/watchBlockNumber.md
+++ b/site/docs/actions/public/watchBlockNumber.md
@@ -95,6 +95,32 @@ const unwatch = publicClient.watchBlockNumber(
 )
 ```
 
+### poll (optional)
+
+- **Type:** `boolean`
+- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+
+Whether or not to use a polling mechanism to check for new block numbers instead of a WebSocket subscription.
+
+This option is only configurable for Clients with a [WebSocket Transport](/docs/clients/transports/websocket).
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket()
+})
+
+const unwatch = publicClient.watchBlockNumber(
+  { 
+    onBlockNumber: blockNumber => console.log(blockNumber),
+    poll: true, // [!code focus]
+  }
+)
+```
+
 ### pollingInterval (optional)
 
 - **Type:** `number`
@@ -118,6 +144,5 @@ Check out the usage of `watchBlockNumber` in the live [Watch Block Numbers Examp
 
 ## JSON-RPC Methods
 
-Calls [`eth_blockNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber) on a polling interval. 
-
-Real-time subscriptions ([`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon)) coming shortly.
+- When `poll: true`, calls [`eth_blockNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber) on a polling interval.
+- When `poll: false` & WebSocket Transport, uses a WebSocket subscription via [`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon) and the `"newHeads"` event. 

--- a/site/docs/actions/public/watchBlocks.md
+++ b/site/docs/actions/public/watchBlocks.md
@@ -142,6 +142,32 @@ const unwatch = publicClient.watchBlocks(
 )
 ```
 
+### poll (optional)
+
+- **Type:** `boolean`
+- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+
+Whether or not to use a polling mechanism to check for new blocks instead of a WebSocket subscription.
+
+This option is only configurable for Clients with a [WebSocket Transport](/docs/clients/transports/websocket).
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket()
+})
+
+const unwatch = publicClient.watchBlocks(
+  { 
+    onBlock: block => console.log(block),
+    poll: true, // [!code focus]
+  }
+)
+```
+
 ### pollingInterval (optional)
 
 - **Type:** `number`
@@ -165,6 +191,5 @@ Check out the usage of `watchBlocks` in the live [Watch Blocks Example](https://
 
 ## JSON-RPC Methods
 
-Calls [`eth_getBlockByNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getBlockByNumber) on a polling interval. 
-
-Real-time subscriptions ([`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon)) coming shortly.
+- When `poll: true`, calls [`eth_getBlockByNumber`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getBlockByNumber) on a polling interval.
+- When `poll: false` & WebSocket Transport, uses a WebSocket subscription via [`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon) and the `"newHeads"` event. 

--- a/site/docs/actions/public/watchPendingTransactions.md
+++ b/site/docs/actions/public/watchPendingTransactions.md
@@ -99,6 +99,32 @@ const unwatch = publicClient.watchPendingTransactions(
 )
 ```
 
+### poll (optional)
+
+- **Type:** `boolean`
+- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+
+Whether or not to use a polling mechanism to check for new pending transactions instead of a WebSocket subscription.
+
+This option is only configurable for Clients with a [WebSocket Transport](/docs/clients/transports/websocket).
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket()
+})
+
+const unwatch = publicClient.watchPendingTransactions(
+  { 
+    onTransactions: transactions => console.log(transactions),
+    poll: true, // [!code focus]
+  }
+)
+```
+
 ### pollingInterval (optional)
 
 - **Type:** `number`
@@ -116,5 +142,7 @@ const unwatch = publicClient..watchPendingTransactions(
 
 ## JSON-RPC Methods
 
-- Calls [`eth_newPendingTransactionFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newpendingtransactionfilter) to initialize the filter.
-- Calls [`eth_getFilterChanges`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getFilterChanges) on a polling interval.
+- When `poll: true`
+  - Calls [`eth_newPendingTransactionFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newpendingtransactionfilter) to initialize the filter.
+  - Calls [`eth_getFilterChanges`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getFilterChanges) on a polling interval.
+- When `poll: false` & WebSocket Transport, uses a WebSocket subscription via [`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon) and the `"newPendingTransactions"` topic. 

--- a/site/docs/actions/public/watchPendingTransactions.md
+++ b/site/docs/actions/public/watchPendingTransactions.md
@@ -145,4 +145,4 @@ const unwatch = publicClient..watchPendingTransactions(
 - When `poll: true`
   - Calls [`eth_newPendingTransactionFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newpendingtransactionfilter) to initialize the filter.
   - Calls [`eth_getFilterChanges`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getFilterChanges) on a polling interval.
-- When `poll: false` & WebSocket Transport, uses a WebSocket subscription via [`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon) and the `"newPendingTransactions"` topic. 
+- When `poll: false` & WebSocket Transport, uses a WebSocket subscription via [`eth_subscribe`](https://docs.alchemy.com/reference/eth-subscribe-polygon) and the `"newPendingTransactions"` event. 

--- a/src/_test/index.ts
+++ b/src/_test/index.ts
@@ -26,4 +26,5 @@ export {
   signTransaction,
   walletClientWithAccount,
   walletClientWithoutChain,
+  webSocketClient,
 } from './utils'

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -91,18 +91,23 @@ const provider = {
   },
 }
 
-export const publicClient =
+export const httpClient = createPublicClient({
+  chain: anvilChain,
+  pollingInterval: 1_000,
+  transport: http(),
+})
+
+export const webSocketClient = createPublicClient({
+  chain: anvilChain,
+  pollingInterval: 1_000,
+  transport: webSocket(localWsUrl),
+})
+
+export const publicClient = (
   process.env.VITE_NETWORK_TRANSPORT_MODE === 'webSocket'
-    ? createPublicClient({
-        chain: anvilChain,
-        pollingInterval: 1_000,
-        transport: webSocket(localWsUrl),
-      })
-    : createPublicClient({
-        chain: anvilChain,
-        pollingInterval: 1_000,
-        transport: http(),
-      })
+    ? webSocketClient
+    : httpClient
+) as typeof httpClient
 
 export const walletClient = createWalletClient({
   chain: anvilChain,

--- a/src/actions/public/createPendingTransactionFilter.ts
+++ b/src/actions/public/createPendingTransactionFilter.ts
@@ -4,9 +4,10 @@ import type { Chain, Filter } from '../../types'
 export type CreatePendingTransactionFilterReturnType = Filter<'transaction'>
 
 export async function createPendingTransactionFilter<
+  TTransport extends Transport,
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TTransport, TChain>,
 ): Promise<CreatePendingTransactionFilterReturnType> {
   const id = await client.request({
     method: 'eth_newPendingTransactionFilter',

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -31,13 +31,14 @@ export type GetFilterChangesReturnType<
   : Hash[]
 
 export async function getFilterChanges<
+  TTransport extends Transport,
   TChain extends Chain | undefined,
   TFilterType extends FilterType,
   TAbiEvent extends AbiEvent | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TTransport, TChain>,
   {
     filter,
   }: GetFilterChangesParameters<TFilterType, TAbiEvent, TAbi, TEventName>,

--- a/src/actions/public/uninstallFilter.ts
+++ b/src/actions/public/uninstallFilter.ts
@@ -6,8 +6,11 @@ export type UninstallFilterParameters = {
 }
 export type UninstallFilterReturnType = boolean
 
-export async function uninstallFilter<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+export async function uninstallFilter<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+>(
+  client: PublicClient<TTransport, TChain>,
   { filter }: UninstallFilterParameters,
 ): Promise<UninstallFilterReturnType> {
   return client.request({

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -77,6 +77,7 @@ export async function waitForTransactionReceipt<
         const unwatch = watchBlockNumber(client, {
           emitMissed: true,
           emitOnBegin: true,
+          poll: true,
           pollingInterval,
           async onBlockNumber(blockNumber) {
             const done = async (fn: () => void) => {

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -2,14 +2,13 @@ import { describe, expect, test, vi } from 'vitest'
 
 import type { OnBlockNumberParameter } from './watchBlockNumber'
 import { watchBlockNumber } from './watchBlockNumber'
-import { publicClient, testClient } from '../../_test'
+import { publicClient, testClient, webSocketClient } from '../../_test'
 import { wait } from '../../utils/wait'
 import { localhost } from '../../chains'
 import { createPublicClient, http, PublicClient } from '../../clients'
 import { mine } from '../test/mine'
 import * as getBlockNumber from './getBlockNumber'
 import { setIntervalMining } from '../test'
-import { webSocketClient } from '../../_test/utils'
 
 describe('poll', () => {
   test('watches for new block numbers', async () => {

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -5,283 +5,427 @@ import { watchBlockNumber } from './watchBlockNumber'
 import { publicClient, testClient } from '../../_test'
 import { wait } from '../../utils/wait'
 import { localhost } from '../../chains'
-import { createPublicClient, http } from '../../clients'
+import { createPublicClient, http, PublicClient } from '../../clients'
 import { mine } from '../test/mine'
 import * as getBlockNumber from './getBlockNumber'
 import { setIntervalMining } from '../test'
+import { webSocketClient } from '../../_test/utils'
 
-test('watches for new block numbers', async () => {
-  const blockNumbers: OnBlockNumberParameter[] = []
-  const unwatch = watchBlockNumber(publicClient, {
-    onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-  })
-  await wait(5000)
-  unwatch()
-  expect(blockNumbers.length).toBe(4)
-})
-
-describe('emitMissed', () => {
-  test('emits on missed blocks', async () => {
-    await setIntervalMining(testClient, { interval: 0 })
-    const blockNumbers: OnBlockNumberParameter[] = []
-    const unwatch = watchBlockNumber(publicClient, {
-      emitMissed: true,
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-      pollingInterval: 500,
-    })
-    await mine(testClient, { blocks: 1 })
-    await wait(1000)
-    await mine(testClient, { blocks: 5 })
-    await wait(1000)
-    unwatch()
-    await setIntervalMining(testClient, { interval: 1 })
-    expect(blockNumbers.length).toBe(6)
-  })
-})
-
-describe('emitOnBegin', () => {
+describe('poll', () => {
   test('watches for new block numbers', async () => {
     const blockNumbers: OnBlockNumberParameter[] = []
     const unwatch = watchBlockNumber(publicClient, {
-      emitOnBegin: true,
+      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      poll: true,
+    })
+    await wait(5000)
+    unwatch()
+    expect(blockNumbers.length).toBe(4)
+  })
+
+  describe('emitMissed', () => {
+    test('emits on missed blocks', async () => {
+      await setIntervalMining(testClient, { interval: 0 })
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        emitMissed: true,
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+        pollingInterval: 500,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(1000)
+      await mine(testClient, { blocks: 5 })
+      await wait(1000)
+      unwatch()
+      await setIntervalMining(testClient, { interval: 1 })
+      expect(blockNumbers.length).toBe(6)
+    })
+  })
+
+  describe('emitOnBegin', () => {
+    test('watches for new block numbers', async () => {
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        emitOnBegin: true,
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(5000)
+      unwatch()
+      expect(blockNumbers.length).toBe(5)
+    })
+  })
+
+  describe('pollingInterval on client', () => {
+    test('watches for new block numbers', async () => {
+      const client = createPublicClient({
+        chain: localhost,
+        transport: http(),
+        pollingInterval: 500,
+      })
+
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(client, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(2000)
+      unwatch()
+      expect(blockNumbers.length).toBe(2)
+    })
+  })
+
+  describe('behavior', () => {
+    test('does not emit when no new incoming blocks', async () => {
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+        pollingInterval: 100,
+      })
+      await wait(1200)
+      unwatch()
+      expect(blockNumbers.length).toBe(2)
+    })
+
+    test('watch > unwatch > watch', async () => {
+      let blockNumbers: OnBlockNumberParameter[] = []
+      let unwatch = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch()
+      expect(blockNumbers.length).toBe(2)
+
+      blockNumbers = []
+      unwatch = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch()
+      expect(blockNumbers.length).toBe(2)
+    })
+
+    test('multiple watchers', async () => {
+      let blockNumbers: OnBlockNumberParameter[] = []
+
+      let unwatch1 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      let unwatch2 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      let unwatch3 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blockNumbers.length).toBe(6)
+
+      blockNumbers = []
+
+      unwatch1 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      unwatch2 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      unwatch3 = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blockNumbers.length).toBe(6)
+    })
+
+    test('immediately unwatch', async () => {
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+        poll: true,
+      })
+      unwatch()
+      await wait(3000)
+      expect(blockNumbers.length).toBe(0)
+    })
+
+    test('out of order blocks', async () => {
+      vi.spyOn(getBlockNumber, 'getBlockNumber')
+        .mockResolvedValueOnce(420n)
+        .mockResolvedValueOnce(421n)
+        .mockResolvedValueOnce(419n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(426n)
+        .mockResolvedValueOnce(423n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(429n)
+        .mockResolvedValueOnce(430n)
+
+      const blockNumbers: [
+        OnBlockNumberParameter,
+        OnBlockNumberParameter | undefined,
+      ][] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        poll: true,
+        pollingInterval: 100,
+        onBlockNumber: (blockNumber, prevBlockNumber) =>
+          blockNumbers.push([blockNumber, prevBlockNumber]),
+      })
+      await wait(1000)
+      unwatch()
+      expect(blockNumbers).toMatchInlineSnapshot(`
+        [
+          [
+            420n,
+            undefined,
+          ],
+          [
+            421n,
+            420n,
+          ],
+          [
+            424n,
+            421n,
+          ],
+          [
+            426n,
+            424n,
+          ],
+          [
+            429n,
+            426n,
+          ],
+        ]
+      `)
+    })
+
+    test('out of order blocks (emitMissed)', async () => {
+      vi.spyOn(getBlockNumber, 'getBlockNumber')
+        .mockResolvedValueOnce(420n)
+        .mockResolvedValueOnce(421n)
+        .mockResolvedValueOnce(419n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(426n)
+        .mockResolvedValueOnce(423n)
+        .mockResolvedValueOnce(424n)
+        .mockResolvedValueOnce(429n)
+        .mockResolvedValueOnce(430n)
+
+      const blockNumbers: [
+        OnBlockNumberParameter,
+        OnBlockNumberParameter | undefined,
+      ][] = []
+      const unwatch = watchBlockNumber(publicClient, {
+        emitMissed: true,
+        poll: true,
+        pollingInterval: 100,
+        onBlockNumber: (blockNumber, prevBlockNumber) =>
+          blockNumbers.push([blockNumber, prevBlockNumber]),
+      })
+      await wait(1000)
+      unwatch()
+      expect(blockNumbers).toMatchInlineSnapshot(`
+        [
+          [
+            420n,
+            undefined,
+          ],
+          [
+            421n,
+            420n,
+          ],
+          [
+            422n,
+            421n,
+          ],
+          [
+            423n,
+            422n,
+          ],
+          [
+            424n,
+            423n,
+          ],
+          [
+            425n,
+            424n,
+          ],
+          [
+            426n,
+            425n,
+          ],
+          [
+            427n,
+            426n,
+          ],
+          [
+            428n,
+            427n,
+          ],
+          [
+            429n,
+            428n,
+          ],
+        ]
+      `)
+    })
+  })
+
+  describe('errors', () => {
+    test('handles error thrown', async () => {
+      vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValue(
+        new Error('foo'),
+      )
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlockNumber(publicClient, {
+          onBlockNumber: () => null,
+          onError: resolve,
+          poll: true,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: foo]')
+      unwatch()
+    })
+  })
+})
+
+describe('subscribe', () => {
+  test('watches for new block numbers', async () => {
+    const blockNumbers: OnBlockNumberParameter[] = []
+    const unwatch = watchBlockNumber(webSocketClient, {
       onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
     })
     await wait(5000)
     unwatch()
     expect(blockNumbers.length).toBe(5)
   })
-})
 
-describe('pollingInterval on client', () => {
-  test('watches for new block numbers', async () => {
-    const client = createPublicClient({
-      chain: localhost,
-      transport: http(),
-      pollingInterval: 500,
-    })
-
-    const blockNumbers: OnBlockNumberParameter[] = []
-    const unwatch = watchBlockNumber(client, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    await wait(2000)
-    unwatch()
-    expect(blockNumbers.length).toBe(2)
-  })
-})
-
-describe('behavior', () => {
-  test('does not emit when no new incoming blocks', async () => {
-    const blockNumbers: OnBlockNumberParameter[] = []
-    const unwatch = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-      pollingInterval: 100,
-    })
-    await wait(1200)
-    unwatch()
-    expect(blockNumbers.length).toBe(2)
-  })
-
-  test('watch > unwatch > watch', async () => {
-    let blockNumbers: OnBlockNumberParameter[] = []
-    let unwatch = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    await wait(3000)
-    unwatch()
-    expect(blockNumbers.length).toBe(2)
-
-    blockNumbers = []
-    unwatch = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    await wait(3000)
-    unwatch()
-    expect(blockNumbers.length).toBe(2)
-  })
-
-  test('multiple watchers', async () => {
-    let blockNumbers: OnBlockNumberParameter[] = []
-
-    let unwatch1 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    let unwatch2 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    let unwatch3 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    await wait(3000)
-    unwatch1()
-    unwatch2()
-    unwatch3()
-    expect(blockNumbers.length).toBe(6)
-
-    blockNumbers = []
-
-    unwatch1 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    unwatch2 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    unwatch3 = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    await wait(3000)
-    unwatch1()
-    unwatch2()
-    unwatch3()
-    expect(blockNumbers.length).toBe(6)
-  })
-
-  test('immediately unwatch', async () => {
-    const blockNumbers: OnBlockNumberParameter[] = []
-    const unwatch = watchBlockNumber(publicClient, {
-      onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
-    })
-    unwatch()
-    await wait(3000)
-    expect(blockNumbers.length).toBe(0)
-  })
-
-  test('out of order blocks', async () => {
-    vi.spyOn(getBlockNumber, 'getBlockNumber')
-      .mockResolvedValueOnce(420n)
-      .mockResolvedValueOnce(421n)
-      .mockResolvedValueOnce(419n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(426n)
-      .mockResolvedValueOnce(423n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(429n)
-      .mockResolvedValueOnce(430n)
-
-    const blockNumbers: [
-      OnBlockNumberParameter,
-      OnBlockNumberParameter | undefined,
-    ][] = []
-    const unwatch = watchBlockNumber(publicClient, {
-      pollingInterval: 100,
-      onBlockNumber: (blockNumber, prevBlockNumber) =>
-        blockNumbers.push([blockNumber, prevBlockNumber]),
-    })
-    await wait(1000)
-    unwatch()
-    expect(blockNumbers).toMatchInlineSnapshot(`
-      [
-        [
-          420n,
-          undefined,
-        ],
-        [
-          421n,
-          420n,
-        ],
-        [
-          424n,
-          421n,
-        ],
-        [
-          426n,
-          424n,
-        ],
-        [
-          429n,
-          426n,
-        ],
-      ]
-    `)
-  })
-
-  test('out of order blocks (emitMissed)', async () => {
-    vi.spyOn(getBlockNumber, 'getBlockNumber')
-      .mockResolvedValueOnce(420n)
-      .mockResolvedValueOnce(421n)
-      .mockResolvedValueOnce(419n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(426n)
-      .mockResolvedValueOnce(423n)
-      .mockResolvedValueOnce(424n)
-      .mockResolvedValueOnce(429n)
-      .mockResolvedValueOnce(430n)
-
-    const blockNumbers: [
-      OnBlockNumberParameter,
-      OnBlockNumberParameter | undefined,
-    ][] = []
-    const unwatch = watchBlockNumber(publicClient, {
-      emitMissed: true,
-      pollingInterval: 100,
-      onBlockNumber: (blockNumber, prevBlockNumber) =>
-        blockNumbers.push([blockNumber, prevBlockNumber]),
-    })
-    await wait(1000)
-    unwatch()
-    expect(blockNumbers).toMatchInlineSnapshot(`
-      [
-        [
-          420n,
-          undefined,
-        ],
-        [
-          421n,
-          420n,
-        ],
-        [
-          422n,
-          421n,
-        ],
-        [
-          423n,
-          422n,
-        ],
-        [
-          424n,
-          423n,
-        ],
-        [
-          425n,
-          424n,
-        ],
-        [
-          426n,
-          425n,
-        ],
-        [
-          427n,
-          426n,
-        ],
-        [
-          428n,
-          427n,
-        ],
-        [
-          429n,
-          428n,
-        ],
-      ]
-    `)
-  })
-})
-
-describe('errors', () => {
-  test('handles error thrown', async () => {
-    vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValue(
-      new Error('foo'),
-    )
-
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchBlockNumber(publicClient, {
-        onBlockNumber: () => null,
-        onError: resolve,
+  describe('behavior', () => {
+    test('watch > unwatch > watch', async () => {
+      let blockNumbers: OnBlockNumberParameter[] = []
+      let unwatch = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
       })
+      await wait(3000)
+      unwatch()
+      expect(blockNumbers.length).toBe(3)
+
+      blockNumbers = []
+      unwatch = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      await wait(3000)
+      unwatch()
+      expect(blockNumbers.length).toBe(3)
     })
-    expect(error).toMatchInlineSnapshot('[Error: foo]')
-    unwatch()
+
+    test('multiple watchers', async () => {
+      let blockNumbers: OnBlockNumberParameter[] = []
+
+      let unwatch1 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      let unwatch2 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      let unwatch3 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blockNumbers.length).toBe(9)
+
+      blockNumbers = []
+
+      unwatch1 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      unwatch2 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      unwatch3 = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blockNumbers.length).toBe(9)
+    })
+
+    test('immediately unwatch', async () => {
+      const blockNumbers: OnBlockNumberParameter[] = []
+      const unwatch = watchBlockNumber(webSocketClient, {
+        onBlockNumber: (blockNumber) => blockNumbers.push(blockNumber),
+      })
+      unwatch()
+      await wait(3000)
+      expect(blockNumbers.length).toBe(0)
+    })
+  })
+
+  describe('errors', () => {
+    test('handles error thrown on init', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe() {
+            throw new Error('error')
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlockNumber(client, {
+          onBlockNumber: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
+
+    test('handles error thrown on event', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe({ onError }: any) {
+            onError(new Error('error'))
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlockNumber(client as PublicClient, {
+          onBlockNumber: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
   })
 })

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -1,5 +1,6 @@
 import type { PublicClient, Transport } from '../../clients'
-import type { Chain } from '../../types'
+import type { Chain, GetTransportConfig } from '../../types'
+import { hexToBigInt } from '../../utils'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
 import type { GetBlockNumberReturnType } from './getBlockNumber'
@@ -11,77 +12,129 @@ export type OnBlockNumberFn = (
   prevBlockNumber: OnBlockNumberParameter | undefined,
 ) => void
 
-export type WatchBlockNumberParameters = {
+export type PollOptions = {
   /** Whether or not to emit the missed block numbers to the callback. */
   emitMissed?: boolean
   /** Whether or not to emit the latest block number to the callback when the subscription opens. */
   emitOnBegin?: boolean
-  /** The callback to call when a new block number is received. */
-  onBlockNumber: OnBlockNumberFn
-  /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
   pollingInterval?: number
 }
 
+export type WatchBlockNumberParameters<
+  TTransport extends Transport = Transport,
+> = {
+  /** The callback to call when a new block number is received. */
+  onBlockNumber: OnBlockNumberFn
+  /** The callback to call when an error occurred when trying to get for a new block. */
+  onError?: (error: Error) => void
+} & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
+  ?
+      | {
+          emitMissed?: never
+          emitOnBegin?: never
+          /** Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`. */
+          poll?: false
+          pollingInterval?: never
+        }
+      | (PollOptions & { poll: true })
+  : PollOptions & { poll?: true })
+
 export type WatchBlockNumberReturnType = () => void
 
 /** @description Watches and returns incoming block numbers. */
-export function watchBlockNumber<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+export function watchBlockNumber<
+  TChain extends Chain | undefined,
+  TTransport extends Transport,
+>(
+  client: PublicClient<TTransport, TChain>,
   {
     emitOnBegin = false,
     emitMissed = false,
     onBlockNumber,
     onError,
+    poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: WatchBlockNumberParameters,
+  }: WatchBlockNumberParameters<TTransport>,
 ): WatchBlockNumberReturnType {
-  const observerId = JSON.stringify([
-    'watchBlockNumber',
-    client.uid,
-    emitOnBegin,
-    emitMissed,
-    pollingInterval,
-  ])
+  const enablePolling =
+    typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
 
   let prevBlockNumber: GetBlockNumberReturnType | undefined
 
-  return observe(observerId, { onBlockNumber, onError }, (emit) =>
-    poll(
-      async () => {
-        try {
-          const blockNumber = await getBlockNumber(client, { maxAge: 0 })
+  const pollBlockNumber = () => {
+    const observerId = JSON.stringify([
+      'watchBlockNumber',
+      client.uid,
+      emitOnBegin,
+      emitMissed,
+      pollingInterval,
+    ])
 
-          if (prevBlockNumber) {
-            // If the current block number is the same as the previous,
-            // we can skip.
-            if (blockNumber === prevBlockNumber) return
+    return observe(observerId, { onBlockNumber, onError }, (emit) =>
+      poll(
+        async () => {
+          try {
+            const blockNumber = await getBlockNumber(client, { maxAge: 0 })
 
-            // If we have missed out on some previous blocks, and the
-            // `emitMissed` flag is truthy, let's emit those blocks.
-            if (blockNumber - prevBlockNumber > 1 && emitMissed) {
-              for (let i = prevBlockNumber + 1n; i < blockNumber; i++) {
-                emit.onBlockNumber(i, prevBlockNumber)
-                prevBlockNumber = i
+            if (prevBlockNumber) {
+              // If the current block number is the same as the previous,
+              // we can skip.
+              if (blockNumber === prevBlockNumber) return
+
+              // If we have missed out on some previous blocks, and the
+              // `emitMissed` flag is truthy, let's emit those blocks.
+              if (blockNumber - prevBlockNumber > 1 && emitMissed) {
+                for (let i = prevBlockNumber + 1n; i < blockNumber; i++) {
+                  emit.onBlockNumber(i, prevBlockNumber)
+                  prevBlockNumber = i
+                }
               }
             }
-          }
 
-          // If the next block number is greater than the previous,
-          // it is not in the past, and we can emit the new block number.
-          if (!prevBlockNumber || blockNumber > prevBlockNumber) {
-            emit.onBlockNumber(blockNumber, prevBlockNumber)
-            prevBlockNumber = blockNumber
+            // If the next block number is greater than the previous,
+            // it is not in the past, and we can emit the new block number.
+            if (!prevBlockNumber || blockNumber > prevBlockNumber) {
+              emit.onBlockNumber(blockNumber, prevBlockNumber)
+              prevBlockNumber = blockNumber
+            }
+          } catch (err) {
+            emit.onError?.(err as Error)
           }
-        } catch (err) {
-          emit.onError?.(err as Error)
-        }
-      },
-      {
-        emitOnBegin,
-        interval: pollingInterval,
-      },
-    ),
-  )
+        },
+        {
+          emitOnBegin,
+          interval: pollingInterval,
+        },
+      ),
+    )
+  }
+
+  const subscribeBlockNumber = () => {
+    let active = true
+    let unsubscribe = () => (active = false)
+    ;(async () => {
+      try {
+        const { unsubscribe: unsubscribe_ } = await client.transport.subscribe({
+          params: ['newHeads'],
+          onData(data: any) {
+            if (!active) return
+            const blockNumber = hexToBigInt(data.result?.number)
+            onBlockNumber(blockNumber, prevBlockNumber)
+            prevBlockNumber = blockNumber
+          },
+          onError(error: Error) {
+            onError?.(error)
+          },
+        })
+        unsubscribe = unsubscribe_
+        if (!active) unsubscribe()
+      } catch (err) {
+        onError?.(err as Error)
+      }
+    })()
+    return unsubscribe
+  }
+
+  return enablePolling ? pollBlockNumber() : subscribeBlockNumber()
 }

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test, vi } from 'vitest'
 
-import { celo, Chain, localhost } from '../../chains'
-import { createPublicClient, http } from '../../clients'
+import { celo, localhost } from '../../chains'
+import { createPublicClient, http, PublicClient } from '../../clients'
 import type { Block } from '../../types'
 import { parseEther } from '../../utils'
 import { wait } from '../../utils/wait'
 import { accounts, publicClient, testClient, walletClient } from '../../_test'
+import { webSocketClient } from '../../_test/utils'
 import { setIntervalMining } from '../test'
 import { mine } from '../test/mine'
 import { sendTransaction } from '../wallet'
@@ -13,476 +14,637 @@ import * as getBlock from './getBlock'
 import type { OnBlockParameter } from './watchBlocks'
 import { watchBlocks } from './watchBlocks'
 
-test('watches for new blocks', async () => {
-  const blocks: OnBlockParameter[] = []
-  const prevBlocks: OnBlockParameter[] = []
-  const unwatch = watchBlocks(publicClient, {
-    onBlock: (block, prevBlock) => {
-      blocks.push(block)
-      prevBlock && block !== prevBlock && prevBlocks.push(prevBlock)
-    },
-  })
-  await wait(5000)
-  unwatch()
-  expect(blocks.length).toBe(4)
-  expect(prevBlocks.length).toBe(3)
-})
-
-test(
-  'args: includeTransactions',
-  async () => {
-    await mine(testClient, { blocks: 1 })
-
-    const blocks: OnBlockParameter<Chain, true>[] = []
-    const unwatch = watchBlocks(publicClient, {
-      includeTransactions: true,
-      onBlock: (block) => {
-        blocks.push(block)
-      },
-    })
-
-    await sendTransaction(walletClient, {
-      account: accounts[0].address,
-      to: accounts[1].address,
-      value: parseEther('1'),
-    })
-    await wait(2000)
-
-    unwatch()
-    expect(blocks.length).toBe(1)
-    expect(blocks[0].transactions.length).toBe(1)
-  },
-  { retry: 3 },
-)
-
-describe('emitMissed', () => {
-  test('emits on missed blocks', async () => {
-    await setIntervalMining(testClient, { interval: 0 })
-    const blocks: OnBlockParameter[] = []
-    const unwatch = watchBlocks(publicClient, {
-      emitMissed: true,
-      onBlock: (block) => blocks.push(block),
-      pollingInterval: 500,
-    })
-    await mine(testClient, { blocks: 1 })
-    await wait(1000)
-    await mine(testClient, { blocks: 5 })
-    await wait(1000)
-    unwatch()
-    expect(blocks.length).toBe(6)
-    await setIntervalMining(testClient, { interval: 1 })
-  })
-})
-
-describe('emitOnBegin', () => {
+describe('poll', () => {
   test('watches for new blocks', async () => {
     const blocks: OnBlockParameter[] = []
+    const prevBlocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {
+      onBlock: (block, prevBlock) => {
+        blocks.push(block)
+        prevBlock && block !== prevBlock && prevBlocks.push(prevBlock)
+      },
+      poll: true,
+    })
+    await wait(5000)
+    unwatch()
+    expect(blocks.length).toBe(4)
+    expect(prevBlocks.length).toBe(3)
+  })
+
+  test(
+    'args: includeTransactions',
+    async () => {
+      await mine(testClient, { blocks: 1 })
+
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(publicClient, {
+        includeTransactions: true,
+        onBlock: (block) => {
+          blocks.push(block)
+        },
+        poll: true,
+      })
+
+      await sendTransaction(walletClient, {
+        account: accounts[0].address,
+        to: accounts[1].address,
+        value: parseEther('1'),
+      })
+      await wait(2000)
+
+      unwatch()
+      expect(blocks.length).toBe(1)
+      expect(blocks[0].transactions.length).toBe(1)
+    },
+    { retry: 3 },
+  )
+
+  describe('emitMissed', () => {
+    test('emits on missed blocks', async () => {
+      await setIntervalMining(testClient, { interval: 0 })
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(publicClient, {
+        emitMissed: true,
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+        pollingInterval: 500,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(1000)
+      await mine(testClient, { blocks: 5 })
+      await wait(1000)
+      unwatch()
+      expect(blocks.length).toBe(6)
+      await setIntervalMining(testClient, { interval: 1 })
+    })
+  })
+
+  describe('emitOnBegin', () => {
+    test('watches for new blocks', async () => {
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(publicClient, {
+        emitOnBegin: true,
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(5000)
+      unwatch()
+      expect(blocks.length).toBe(5)
+    })
+  })
+
+  describe('pollingInterval on client', () => {
+    test('watches for new blocks', async () => {
+      const client = createPublicClient({
+        chain: localhost,
+        transport: http(),
+        pollingInterval: 500,
+      })
+
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(client, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(2000)
+      unwatch()
+      expect(blocks.length).toBe(2)
+    })
+  })
+
+  test('custom chain type', async () => {
+    const client = createPublicClient({
+      chain: celo,
+      transport: http(),
+    })
+
+    const blocks: OnBlockParameter<typeof celo>[] = []
+    const unwatch = watchBlocks(client, {
       emitOnBegin: true,
       onBlock: (block) => blocks.push(block),
+      poll: true,
+    })
+    await wait(2000)
+    unwatch()
+    expect(blocks[0].randomness).toBeDefined()
+  })
+
+  describe('behavior', () => {
+    test('does not emit when no new incoming blocks', async () => {
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+        pollingInterval: 100,
+      })
+      await wait(1200)
+      unwatch()
+      expect(blocks.length).toBe(2)
+    })
+
+    test('watch > unwatch > watch', async () => {
+      let blocks: OnBlockParameter[] = []
+      let unwatch = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch()
+      expect(blocks.length).toBe(2)
+
+      blocks = []
+      unwatch = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch()
+      expect(blocks.length).toBe(2)
+    })
+
+    test('multiple watchers', async () => {
+      let blocks: OnBlockParameter[] = []
+
+      let unwatch1 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      let unwatch2 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      let unwatch3 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blocks.length).toBe(6)
+
+      blocks = []
+
+      unwatch1 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      unwatch2 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      unwatch3 = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blocks.length).toBe(6)
+    })
+
+    test('immediately unwatch', async () => {
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(publicClient, {
+        onBlock: (block) => blocks.push(block),
+        poll: true,
+      })
+      unwatch()
+      await wait(3000)
+      expect(blocks.length).toBe(0)
+    })
+
+    test('out of order blocks', async () => {
+      vi.spyOn(getBlock, 'getBlock')
+        .mockResolvedValueOnce({ number: 420n } as Block)
+        .mockResolvedValueOnce({ number: 421n } as Block)
+        .mockResolvedValueOnce({ number: 419n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 426n } as Block)
+        .mockResolvedValueOnce({ number: 423n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 429n } as Block)
+        .mockResolvedValueOnce({ number: 430n } as Block)
+
+      const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
+      const unwatch = watchBlocks(publicClient, {
+        pollingInterval: 100,
+        poll: true,
+        onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
+      })
+      await wait(1000)
+      unwatch()
+      expect(blocks).toMatchInlineSnapshot(`
+        [
+          [
+            {
+              "number": 420n,
+            },
+            undefined,
+          ],
+          [
+            {
+              "number": 421n,
+            },
+            {
+              "number": 420n,
+            },
+          ],
+          [
+            {
+              "number": 424n,
+            },
+            {
+              "number": 421n,
+            },
+          ],
+          [
+            {
+              "number": 426n,
+            },
+            {
+              "number": 424n,
+            },
+          ],
+          [
+            {
+              "number": 429n,
+            },
+            {
+              "number": 426n,
+            },
+          ],
+        ]
+      `)
+    })
+
+    test('out of order blocks (emitMissed)', async () => {
+      vi.spyOn(getBlock, 'getBlock')
+        .mockResolvedValueOnce({ number: 420n } as Block)
+        .mockResolvedValueOnce({ number: 421n } as Block)
+        .mockResolvedValueOnce({ number: 419n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 422n } as Block)
+        .mockResolvedValueOnce({ number: 423n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 426n } as Block)
+        .mockResolvedValueOnce({ number: 425n } as Block)
+        .mockResolvedValueOnce({ number: 423n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 429n } as Block)
+        .mockResolvedValueOnce({ number: 427n } as Block)
+        .mockResolvedValueOnce({ number: 428n } as Block)
+        .mockResolvedValueOnce({ number: 429n } as Block)
+
+      const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
+      const unwatch = watchBlocks(publicClient, {
+        emitMissed: true,
+        pollingInterval: 100,
+        poll: true,
+        onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
+      })
+      await wait(1000)
+      unwatch()
+      expect(blocks).toMatchInlineSnapshot(`
+        [
+          [
+            {
+              "number": 420n,
+            },
+            undefined,
+          ],
+          [
+            {
+              "number": 421n,
+            },
+            {
+              "number": 420n,
+            },
+          ],
+          [
+            {
+              "number": 422n,
+            },
+            {
+              "number": 421n,
+            },
+          ],
+          [
+            {
+              "number": 423n,
+            },
+            {
+              "number": 422n,
+            },
+          ],
+          [
+            {
+              "number": 424n,
+            },
+            {
+              "number": 423n,
+            },
+          ],
+          [
+            {
+              "number": 425n,
+            },
+            {
+              "number": 424n,
+            },
+          ],
+          [
+            {
+              "number": 426n,
+            },
+            {
+              "number": 425n,
+            },
+          ],
+          [
+            {
+              "number": 427n,
+            },
+            {
+              "number": 426n,
+            },
+          ],
+          [
+            {
+              "number": 428n,
+            },
+            {
+              "number": 427n,
+            },
+          ],
+          [
+            {
+              "number": 429n,
+            },
+            {
+              "number": 428n,
+            },
+          ],
+        ]
+      `)
+    })
+
+    test('pending blocks (no number)', async () => {
+      vi.spyOn(getBlock, 'getBlock')
+        .mockResolvedValueOnce({ number: 420n } as Block)
+        .mockResolvedValueOnce({ number: 424n } as Block)
+        .mockResolvedValueOnce({ number: 428n } as Block)
+        .mockResolvedValueOnce({ number: 431n } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: 433n } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+        .mockResolvedValueOnce({ number: null } as Block)
+
+      const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
+      const unwatch = watchBlocks(publicClient, {
+        pollingInterval: 100,
+        poll: true,
+        blockTag: 'pending',
+        onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
+      })
+      await wait(1000)
+      unwatch()
+      expect(blocks).toMatchInlineSnapshot(`
+        [
+          [
+            {
+              "number": 420n,
+            },
+            undefined,
+          ],
+          [
+            {
+              "number": 424n,
+            },
+            {
+              "number": 420n,
+            },
+          ],
+          [
+            {
+              "number": 428n,
+            },
+            {
+              "number": 424n,
+            },
+          ],
+          [
+            {
+              "number": 431n,
+            },
+            {
+              "number": 428n,
+            },
+          ],
+          [
+            {
+              "number": null,
+            },
+            {
+              "number": 431n,
+            },
+          ],
+          [
+            {
+              "number": 433n,
+            },
+            {
+              "number": null,
+            },
+          ],
+          [
+            {
+              "number": null,
+            },
+            {
+              "number": 433n,
+            },
+          ],
+          [
+            {
+              "number": null,
+            },
+            {
+              "number": null,
+            },
+          ],
+          [
+            {
+              "number": null,
+            },
+            {
+              "number": null,
+            },
+          ],
+        ]
+      `)
+    })
+  })
+
+  describe('errors', () => {
+    test('handles error thrown', async () => {
+      vi.spyOn(getBlock, 'getBlock').mockRejectedValue(new Error('foo'))
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlocks(publicClient, {
+          onBlock: () => null,
+          onError: resolve,
+          poll: true,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: foo]')
+      unwatch()
+    })
+  })
+})
+
+describe('subscribe', () => {
+  test('watches for new blocks', async () => {
+    const blocks: OnBlockParameter[] = []
+    const prevBlocks: OnBlockParameter[] = []
+    const unwatch = watchBlocks(webSocketClient, {
+      onBlock: (block, prevBlock) => {
+        blocks.push(block)
+        prevBlock && block !== prevBlock && prevBlocks.push(prevBlock)
+      },
     })
     await wait(5000)
     unwatch()
     expect(blocks.length).toBe(5)
-  })
-})
-
-describe('pollingInterval on client', () => {
-  test('watches for new blocks', async () => {
-    const client = createPublicClient({
-      chain: localhost,
-      transport: http(),
-      pollingInterval: 500,
-    })
-
-    const blocks: OnBlockParameter[] = []
-    const unwatch = watchBlocks(client, {
-      onBlock: (block) => blocks.push(block),
-    })
-    await wait(2000)
-    unwatch()
-    expect(blocks.length).toBe(2)
-  })
-})
-
-test('custom chain type', async () => {
-  const client = createPublicClient({
-    chain: celo,
-    transport: http(),
+    expect(prevBlocks.length).toBe(4)
   })
 
-  const blocks: OnBlockParameter<typeof celo>[] = []
-  const unwatch = watchBlocks(client, {
-    emitOnBegin: true,
-    onBlock: (block) => blocks.push(block),
-  })
-  await wait(2000)
-  unwatch()
-  expect(blocks[0].randomness).toBeDefined()
-})
-
-describe('behavior', () => {
-  test('does not emit when no new incoming blocks', async () => {
-    const blocks: OnBlockParameter[] = []
-    const unwatch = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-      pollingInterval: 100,
-    })
-    await wait(1200)
-    unwatch()
-    expect(blocks.length).toBe(2)
-  })
-
-  test('watch > unwatch > watch', async () => {
-    let blocks: OnBlockParameter[] = []
-    let unwatch = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    await wait(3000)
-    unwatch()
-    expect(blocks.length).toBe(2)
-
-    blocks = []
-    unwatch = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    await wait(3000)
-    unwatch()
-    expect(blocks.length).toBe(2)
-  })
-
-  test('multiple watchers', async () => {
-    let blocks: OnBlockParameter[] = []
-
-    let unwatch1 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    let unwatch2 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    let unwatch3 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    await wait(3000)
-    unwatch1()
-    unwatch2()
-    unwatch3()
-    expect(blocks.length).toBe(6)
-
-    blocks = []
-
-    unwatch1 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    unwatch2 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    unwatch3 = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    await wait(3000)
-    unwatch1()
-    unwatch2()
-    unwatch3()
-    expect(blocks.length).toBe(6)
-  })
-
-  test('immediately unwatch', async () => {
-    const blocks: OnBlockParameter[] = []
-    const unwatch = watchBlocks(publicClient, {
-      onBlock: (block) => blocks.push(block),
-    })
-    unwatch()
-    await wait(3000)
-    expect(blocks.length).toBe(0)
-  })
-
-  test('out of order blocks', async () => {
-    vi.spyOn(getBlock, 'getBlock')
-      .mockResolvedValueOnce({ number: 420n } as Block)
-      .mockResolvedValueOnce({ number: 421n } as Block)
-      .mockResolvedValueOnce({ number: 419n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 426n } as Block)
-      .mockResolvedValueOnce({ number: 423n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 429n } as Block)
-      .mockResolvedValueOnce({ number: 430n } as Block)
-
-    const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
-    const unwatch = watchBlocks(publicClient, {
-      pollingInterval: 100,
-      onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
-    })
-    await wait(1000)
-    unwatch()
-    expect(blocks).toMatchInlineSnapshot(`
-      [
-        [
-          {
-            "number": 420n,
-          },
-          undefined,
-        ],
-        [
-          {
-            "number": 421n,
-          },
-          {
-            "number": 420n,
-          },
-        ],
-        [
-          {
-            "number": 424n,
-          },
-          {
-            "number": 421n,
-          },
-        ],
-        [
-          {
-            "number": 426n,
-          },
-          {
-            "number": 424n,
-          },
-        ],
-        [
-          {
-            "number": 429n,
-          },
-          {
-            "number": 426n,
-          },
-        ],
-      ]
-    `)
-  })
-
-  test('out of order blocks (emitMissed)', async () => {
-    vi.spyOn(getBlock, 'getBlock')
-      .mockResolvedValueOnce({ number: 420n } as Block)
-      .mockResolvedValueOnce({ number: 421n } as Block)
-      .mockResolvedValueOnce({ number: 419n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 422n } as Block)
-      .mockResolvedValueOnce({ number: 423n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 426n } as Block)
-      .mockResolvedValueOnce({ number: 425n } as Block)
-      .mockResolvedValueOnce({ number: 423n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 429n } as Block)
-      .mockResolvedValueOnce({ number: 427n } as Block)
-      .mockResolvedValueOnce({ number: 428n } as Block)
-      .mockResolvedValueOnce({ number: 429n } as Block)
-
-    const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
-    const unwatch = watchBlocks(publicClient, {
-      emitMissed: true,
-      pollingInterval: 100,
-      onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
-    })
-    await wait(1000)
-    unwatch()
-    expect(blocks).toMatchInlineSnapshot(`
-      [
-        [
-          {
-            "number": 420n,
-          },
-          undefined,
-        ],
-        [
-          {
-            "number": 421n,
-          },
-          {
-            "number": 420n,
-          },
-        ],
-        [
-          {
-            "number": 422n,
-          },
-          {
-            "number": 421n,
-          },
-        ],
-        [
-          {
-            "number": 423n,
-          },
-          {
-            "number": 422n,
-          },
-        ],
-        [
-          {
-            "number": 424n,
-          },
-          {
-            "number": 423n,
-          },
-        ],
-        [
-          {
-            "number": 425n,
-          },
-          {
-            "number": 424n,
-          },
-        ],
-        [
-          {
-            "number": 426n,
-          },
-          {
-            "number": 425n,
-          },
-        ],
-        [
-          {
-            "number": 427n,
-          },
-          {
-            "number": 426n,
-          },
-        ],
-        [
-          {
-            "number": 428n,
-          },
-          {
-            "number": 427n,
-          },
-        ],
-        [
-          {
-            "number": 429n,
-          },
-          {
-            "number": 428n,
-          },
-        ],
-      ]
-    `)
-  })
-
-  test('pending blocks (no number)', async () => {
-    vi.spyOn(getBlock, 'getBlock')
-      .mockResolvedValueOnce({ number: 420n } as Block)
-      .mockResolvedValueOnce({ number: 424n } as Block)
-      .mockResolvedValueOnce({ number: 428n } as Block)
-      .mockResolvedValueOnce({ number: 431n } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: 433n } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-      .mockResolvedValueOnce({ number: null } as Block)
-
-    const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
-    const unwatch = watchBlocks(publicClient, {
-      pollingInterval: 100,
-      blockTag: 'pending',
-      onBlock: (block, prevBlock) => blocks.push([block, prevBlock]),
-    })
-    await wait(1000)
-    unwatch()
-    expect(blocks).toMatchInlineSnapshot(`
-      [
-        [
-          {
-            "number": 420n,
-          },
-          undefined,
-        ],
-        [
-          {
-            "number": 424n,
-          },
-          {
-            "number": 420n,
-          },
-        ],
-        [
-          {
-            "number": 428n,
-          },
-          {
-            "number": 424n,
-          },
-        ],
-        [
-          {
-            "number": 431n,
-          },
-          {
-            "number": 428n,
-          },
-        ],
-        [
-          {
-            "number": null,
-          },
-          {
-            "number": 431n,
-          },
-        ],
-        [
-          {
-            "number": 433n,
-          },
-          {
-            "number": null,
-          },
-        ],
-        [
-          {
-            "number": null,
-          },
-          {
-            "number": 433n,
-          },
-        ],
-        [
-          {
-            "number": null,
-          },
-          {
-            "number": null,
-          },
-        ],
-        [
-          {
-            "number": null,
-          },
-          {
-            "number": null,
-          },
-        ],
-      ]
-    `)
-  })
-})
-
-describe('errors', () => {
-  test('handles error thrown', async () => {
-    vi.spyOn(getBlock, 'getBlock').mockRejectedValue(new Error('foo'))
-
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchBlocks(publicClient, {
-        onBlock: () => null,
-        onError: resolve,
+  describe('behavior', () => {
+    test('does not emit when no new incoming blocks', async () => {
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
       })
+      await wait(1200)
+      unwatch()
+      expect(blocks.length).toBe(1)
     })
-    expect(error).toMatchInlineSnapshot('[Error: foo]')
-    unwatch()
+
+    test('watch > unwatch > watch', async () => {
+      let blocks: OnBlockParameter[] = []
+      let unwatch = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      await wait(3000)
+      unwatch()
+      expect(blocks.length).toBe(3)
+
+      blocks = []
+      unwatch = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      await wait(3000)
+      unwatch()
+      expect(blocks.length).toBe(3)
+    })
+
+    test('multiple watchers', async () => {
+      let blocks: OnBlockParameter[] = []
+
+      let unwatch1 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      let unwatch2 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      let unwatch3 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blocks.length).toBe(9)
+
+      blocks = []
+
+      unwatch1 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      unwatch2 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      unwatch3 = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      await wait(3000)
+      unwatch1()
+      unwatch2()
+      unwatch3()
+      expect(blocks.length).toBe(9)
+    })
+
+    test('immediately unwatch', async () => {
+      const blocks: OnBlockParameter[] = []
+      const unwatch = watchBlocks(webSocketClient, {
+        onBlock: (block) => blocks.push(block),
+      })
+      unwatch()
+      await wait(3000)
+      expect(blocks.length).toBe(0)
+    })
+  })
+
+  describe('errors', () => {
+    test('handles error thrown on init', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe() {
+            throw new Error('error')
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlocks(client, {
+          onBlock: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
+
+    test('handles error thrown on event', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe({ onError }: any) {
+            onError(new Error('error'))
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchBlocks(client as PublicClient, {
+          onBlock: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
   })
 })

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -1,52 +1,52 @@
 import type { PublicClient, Transport } from '../../clients'
-import type { BlockTag, Chain } from '../../types'
+import type { BlockTag, Chain, GetTransportConfig } from '../../types'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
 import type { GetBlockReturnType } from './getBlock'
 import { getBlock } from './getBlock'
 
-export type OnBlockParameter<
-  TChain extends Chain | undefined = Chain | undefined,
-  TIncludeTransactions = false,
-> = Omit<
-  GetBlockReturnType<TChain>,
-  TIncludeTransactions extends false ? 'transactions' : ''
->
-export type OnBlock<
-  TChain extends Chain | undefined = Chain | undefined,
-  TIncludeTransactions = false,
-> = (
-  block: OnBlockParameter<TChain, TIncludeTransactions>,
-  prevBlock: OnBlockParameter<TChain, TIncludeTransactions> | undefined,
+export type OnBlockParameter<TChain extends Chain | undefined = Chain> =
+  GetBlockReturnType<TChain>
+
+export type OnBlock<TChain extends Chain | undefined = Chain,> = (
+  block: OnBlockParameter<TChain>,
+  prevBlock: OnBlockParameter<TChain> | undefined,
 ) => void
 
-export type WatchBlocksParameters<
-  TChain extends Chain | undefined = Chain | undefined,
-> = {
+type PollOptions = {
   /** The block tag. Defaults to "latest". */
   blockTag?: BlockTag
   /** Whether or not to emit the missed blocks to the callback. */
   emitMissed?: boolean
   /** Whether or not to emit the block to the callback when the subscription opens. */
   emitOnBegin?: boolean
-  /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  /** Whether or not to include transaction data in the response. */
+  includeTransactions?: boolean
   /** Polling frequency (in ms). Defaults to the client's pollingInterval config. */
   pollingInterval?: number
-} & (
-  | {
-      /** Whether or not to include transaction data in the response. */
-      includeTransactions: true
-      /** The callback to call when a new block is received. */
-      onBlock: OnBlock<TChain, true>
-    }
-  | {
-      /** Whether or not to include transaction data in the response. */
-      includeTransactions?: false
-      /** The callback to call when a new block is received. */
-      onBlock: OnBlock<TChain>
-    }
-)
+}
+
+export type WatchBlocksParameters<
+  TChain extends Chain | undefined = Chain,
+  TTransport extends Transport = Transport,
+> = {
+  /** The callback to call when a new block is received. */
+  onBlock: OnBlock<TChain>
+  /** The callback to call when an error occurred when trying to get for a new block. */
+  onError?: (error: Error) => void
+} & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
+  ?
+      | {
+          blockTag?: never
+          emitMissed?: never
+          emitOnBegin?: never
+          includeTransactions?: never
+          /** Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`. */
+          poll?: false
+          pollingInterval?: never
+        }
+      | (PollOptions & { poll: true })
+  : PollOptions & { poll?: true })
 
 export type WatchBlocksReturnType = () => void
 
@@ -55,9 +55,9 @@ export type WatchBlocksReturnType = () => void
  */
 export function watchBlocks<
   TChain extends Chain | undefined,
-  TWatchBlocksParameters extends WatchBlocksParameters<TChain>,
+  TTransport extends Transport,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TTransport, TChain>,
   {
     blockTag = 'latest',
     emitMissed = false,
@@ -65,67 +65,101 @@ export function watchBlocks<
     onBlock,
     onError,
     includeTransactions = false,
+    poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: TWatchBlocksParameters,
+  }: WatchBlocksParameters<TChain, TTransport>,
 ): WatchBlocksReturnType {
-  const observerId = JSON.stringify([
-    'watchBlocks',
-    client.uid,
-    emitMissed,
-    emitOnBegin,
-    includeTransactions,
-    pollingInterval,
-  ])
+  const enablePolling =
+    typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
 
   let prevBlock: GetBlockReturnType<TChain> | undefined
 
-  return observe(observerId, { onBlock, onError }, (emit) =>
-    poll(
-      async () => {
-        try {
-          const block = await getBlock(client, {
-            blockTag,
-            includeTransactions,
-          })
-          if (block.number && prevBlock?.number) {
-            // If the current block number is the same as the previous,
-            // we can skip.
-            if (block.number === prevBlock.number) return
+  const pollBlocks = () => {
+    const observerId = JSON.stringify([
+      'watchBlocks',
+      client.uid,
+      emitMissed,
+      emitOnBegin,
+      includeTransactions,
+      pollingInterval,
+    ])
 
-            // If we have missed out on some previous blocks, and the
-            // `emitMissed` flag is truthy, let's emit those blocks.
-            if (block.number - prevBlock.number > 1 && emitMissed) {
-              for (let i = prevBlock?.number + 1n; i < block.number; i++) {
-                const block = await getBlock(client, {
-                  blockNumber: i,
-                  includeTransactions,
-                })
-                emit.onBlock(block, prevBlock)
-                prevBlock = block
+    return observe(observerId, { onBlock, onError }, (emit) =>
+      poll(
+        async () => {
+          try {
+            const block = await getBlock(client, {
+              blockTag,
+              includeTransactions,
+            })
+            if (block.number && prevBlock?.number) {
+              // If the current block number is the same as the previous,
+              // we can skip.
+              if (block.number === prevBlock.number) return
+
+              // If we have missed out on some previous blocks, and the
+              // `emitMissed` flag is truthy, let's emit those blocks.
+              if (block.number - prevBlock.number > 1 && emitMissed) {
+                for (let i = prevBlock?.number + 1n; i < block.number; i++) {
+                  const block = await getBlock(client, {
+                    blockNumber: i,
+                    includeTransactions,
+                  })
+                  emit.onBlock(block, prevBlock)
+                  prevBlock = block
+                }
               }
             }
-          }
 
-          if (
-            // If no previous block exists, emit.
-            !prevBlock?.number ||
-            // If the block tag is "pending" with no block number, emit.
-            (blockTag === 'pending' && !block?.number) ||
-            // If the next block number is greater than the previous block number, emit.
-            // We don't want to emit blocks in the past.
-            (block.number && block.number > prevBlock.number)
-          ) {
-            emit.onBlock(block, prevBlock)
-            prevBlock = block
+            if (
+              // If no previous block exists, emit.
+              !prevBlock?.number ||
+              // If the block tag is "pending" with no block number, emit.
+              (blockTag === 'pending' && !block?.number) ||
+              // If the next block number is greater than the previous block number, emit.
+              // We don't want to emit blocks in the past.
+              (block.number && block.number > prevBlock.number)
+            ) {
+              emit.onBlock(block, prevBlock)
+              prevBlock = block
+            }
+          } catch (err) {
+            emit.onError?.(err as Error)
           }
-        } catch (err) {
-          emit.onError?.(err as Error)
-        }
-      },
-      {
-        emitOnBegin,
-        interval: pollingInterval,
-      },
-    ),
-  )
+        },
+        {
+          emitOnBegin,
+          interval: pollingInterval,
+        },
+      ),
+    )
+  }
+
+  const subscribeBlocks = () => {
+    let active = true
+    let unsubscribe = () => (active = false)
+    ;(async () => {
+      try {
+        const { unsubscribe: unsubscribe_ } = await client.transport.subscribe({
+          params: ['newHeads'],
+          onData(data: any) {
+            if (!active) return
+            const block = data.result
+            onBlock(block, prevBlock)
+            prevBlock = block
+          },
+          onError(error: Error) {
+            onError?.(error)
+          },
+        })
+        unsubscribe = unsubscribe_
+        if (!active) unsubscribe()
+      } catch (err) {
+        onError?.(err as Error)
+      }
+    })()
+    return unsubscribe
+  }
+
+  return enablePolling ? pollBlocks() : subscribeBlocks()
 }

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -8,7 +8,7 @@ import { getBlock } from './getBlock'
 export type OnBlockParameter<TChain extends Chain | undefined = Chain> =
   GetBlockReturnType<TChain>
 
-export type OnBlock<TChain extends Chain | undefined = Chain,> = (
+export type OnBlock<TChain extends Chain | undefined = Chain> = (
   block: OnBlockParameter<TChain>,
   prevBlock: OnBlockParameter<TChain> | undefined,
 ) => void
@@ -27,8 +27,8 @@ type PollOptions = {
 }
 
 export type WatchBlocksParameters<
-  TChain extends Chain | undefined = Chain,
   TTransport extends Transport = Transport,
+  TChain extends Chain | undefined = Chain,
 > = {
   /** The callback to call when a new block is received. */
   onBlock: OnBlock<TChain>
@@ -54,8 +54,8 @@ export type WatchBlocksReturnType = () => void
  * @description Watches and returns information for incoming blocks.
  */
 export function watchBlocks<
-  TChain extends Chain | undefined,
   TTransport extends Transport,
+  TChain extends Chain | undefined,
 >(
   client: PublicClient<TTransport, TChain>,
   {
@@ -67,7 +67,7 @@ export function watchBlocks<
     includeTransactions = false,
     poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: WatchBlocksParameters<TChain, TTransport>,
+  }: WatchBlocksParameters<TTransport, TChain>,
 ): WatchBlocksReturnType {
   const enablePolling =
     typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'

--- a/src/actions/public/watchPendingTransactions.test.ts
+++ b/src/actions/public/watchPendingTransactions.test.ts
@@ -9,18 +9,56 @@ import { wait } from '../../utils/wait'
 import { sendTransaction } from '../wallet'
 import { parseEther } from '../../utils'
 import { mine, setIntervalMining } from '../test'
+import { webSocketClient } from '../../_test/utils'
+import type { PublicClient } from '../../clients'
 
-test(
-  'watches for pending transactions',
-  async () => {
+describe('poll', () => {
+  test(
+    'watches for pending transactions',
+    async () => {
+      await setIntervalMining(testClient, { interval: 0 })
+      await wait(1000)
+
+      let transactions: OnTransactionsParameter = []
+      const unwatch = watchPendingTransactions(publicClient, {
+        onTransactions: (transactions_) => {
+          transactions = [...transactions, ...transactions_]
+        },
+        poll: true,
+      })
+      await wait(1000)
+      await sendTransaction(walletClient, {
+        account: accounts[0].address,
+        to: accounts[1].address,
+        value: parseEther('1'),
+      })
+      await wait(1000)
+      await sendTransaction(walletClient, {
+        account: accounts[2].address,
+        to: accounts[3].address,
+        value: parseEther('1'),
+      })
+      await wait(1500)
+      unwatch()
+      expect(transactions.length).toBe(2)
+
+      await setIntervalMining(testClient, { interval: 1 })
+      await mine(testClient, { blocks: 1 })
+    },
+    { timeout: 10_000, retry: 3 },
+  )
+
+  test('watches for pending transactions (unbatched)', async () => {
     await setIntervalMining(testClient, { interval: 0 })
     await wait(1000)
 
     let transactions: OnTransactionsParameter = []
     const unwatch = watchPendingTransactions(publicClient, {
+      batch: false,
       onTransactions: (transactions_) => {
         transactions = [...transactions, ...transactions_]
       },
+      poll: true,
     })
     await wait(1000)
     await sendTransaction(walletClient, {
@@ -30,87 +68,137 @@ test(
     })
     await wait(1000)
     await sendTransaction(walletClient, {
-      account: accounts[2].address,
-      to: accounts[3].address,
+      account: accounts[0].address,
+      to: accounts[1].address,
       value: parseEther('1'),
     })
-    await wait(1500)
+    await sendTransaction(walletClient, {
+      account: accounts[0].address,
+      to: accounts[1].address,
+      value: parseEther('1'),
+    })
+    await wait(2000)
     unwatch()
-    expect(transactions.length).toBe(2)
+    expect(transactions.length).toBe(3)
 
     await setIntervalMining(testClient, { interval: 1 })
     await mine(testClient, { blocks: 1 })
-  },
-  { timeout: 10_000, retry: 3 },
-)
+  })
 
-test('watches for pending transactions (unbatched)', async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-  await wait(1000)
+  describe('errors', () => {
+    test('handles error thrown from creating filter', async () => {
+      vi.spyOn(
+        createPendingTransactionFilter,
+        'createPendingTransactionFilter',
+      ).mockRejectedValueOnce(new Error('foo'))
 
-  let transactions: OnTransactionsParameter = []
-  const unwatch = watchPendingTransactions(publicClient, {
-    batch: false,
-    onTransactions: (transactions_) => {
-      transactions = [...transactions, ...transactions_]
-    },
-  })
-  await wait(1000)
-  await sendTransaction(walletClient, {
-    account: accounts[0].address,
-    to: accounts[1].address,
-    value: parseEther('1'),
-  })
-  await wait(1000)
-  await sendTransaction(walletClient, {
-    account: accounts[0].address,
-    to: accounts[1].address,
-    value: parseEther('1'),
-  })
-  await sendTransaction(walletClient, {
-    account: accounts[0].address,
-    to: accounts[1].address,
-    value: parseEther('1'),
-  })
-  await wait(2000)
-  unwatch()
-  expect(transactions.length).toBe(3)
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchPendingTransactions(publicClient, {
+          onTransactions: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: foo]')
+      unwatch()
+    })
 
-  await setIntervalMining(testClient, { interval: 1 })
-  await mine(testClient, { blocks: 1 })
+    test('handles error thrown from filter changes', async () => {
+      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+        new Error('bar'),
+      )
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchPendingTransactions(publicClient, {
+          onTransactions: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: bar]')
+      unwatch()
+    })
+  })
 })
 
-describe('errors', () => {
-  test('handles error thrown from creating filter', async () => {
-    vi.spyOn(
-      createPendingTransactionFilter,
-      'createPendingTransactionFilter',
-    ).mockRejectedValueOnce(new Error('foo'))
+describe('subscribe', () => {
+  test(
+    'watches for pending transactions',
+    async () => {
+      await setIntervalMining(testClient, { interval: 0 })
+      await wait(1000)
 
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchPendingTransactions(publicClient, {
-        onTransactions: () => null,
-        onError: resolve,
+      let transactions: OnTransactionsParameter = []
+      const unwatch = watchPendingTransactions(webSocketClient, {
+        onTransactions: (transactions_) => {
+          transactions = [...transactions, ...transactions_]
+        },
       })
-    })
-    expect(error).toMatchInlineSnapshot('[Error: foo]')
-    unwatch()
-  })
-
-  test('handles error thrown from filter changes', async () => {
-    vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-      new Error('bar'),
-    )
-
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchPendingTransactions(publicClient, {
-        onTransactions: () => null,
-        onError: resolve,
+      await wait(1000)
+      await sendTransaction(walletClient, {
+        account: accounts[0].address,
+        to: accounts[1].address,
+        value: parseEther('1'),
       })
+      await wait(1000)
+      await sendTransaction(walletClient, {
+        account: accounts[2].address,
+        to: accounts[3].address,
+        value: parseEther('1'),
+      })
+      await wait(1500)
+      unwatch()
+      expect(transactions.length).toBe(2)
+
+      await setIntervalMining(testClient, { interval: 1 })
+      await mine(testClient, { blocks: 1 })
+    },
+    { timeout: 10_000, retry: 3 },
+  )
+
+  describe('errors', () => {
+    test('handles error thrown on init', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe() {
+            throw new Error('error')
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchPendingTransactions(client, {
+          onTransactions: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
     })
-    expect(error).toMatchInlineSnapshot('[Error: bar]')
-    unwatch()
+
+    test('handles error thrown on event', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe({ onError }: any) {
+            onError(new Error('error'))
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchPendingTransactions(client as PublicClient, {
+          onTransactions: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
   })
 })

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -1,5 +1,5 @@
 import type { PublicClient, Transport } from '../../clients'
-import type { Chain, Filter, Hash } from '../../types'
+import type { Chain, Filter, GetTransportConfig, Hash } from '../../types'
 import { observe } from '../../utils/observe'
 import { poll } from '../../utils/poll'
 import { createPendingTransactionFilter } from './createPendingTransactionFilter'
@@ -9,68 +9,121 @@ import { uninstallFilter } from './uninstallFilter'
 export type OnTransactionsParameter = Hash[]
 export type OnTransactionsFn = (transactions: OnTransactionsParameter) => void
 
-export type WatchPendingTransactionsParameters = {
+type PollOptions = {
   /** Whether or not the transaction hashes should be batched on each invocation. */
   batch?: boolean
-  /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
-  /** The callback to call when new transactions are received. */
-  onTransactions: OnTransactionsFn
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
   pollingInterval?: number
 }
 
+export type WatchPendingTransactionsParameters<
+  TTransport extends Transport = Transport,
+> = {
+  /** The callback to call when an error occurred when trying to get for a new block. */
+  onError?: (error: Error) => void
+  /** The callback to call when new transactions are received. */
+  onTransactions: OnTransactionsFn
+} & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
+  ?
+      | {
+          batch?: never
+          /** Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`. */
+          poll?: false
+          pollingInterval?: never
+        }
+      | (PollOptions & { poll: true })
+  : PollOptions & {
+      poll?: true
+    })
+
 export type WatchPendingTransactionsReturnType = () => void
 
-export function watchPendingTransactions<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+export function watchPendingTransactions<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+>(
+  client: PublicClient<TTransport, TChain>,
   {
     batch = true,
     onError,
     onTransactions,
+    poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: WatchPendingTransactionsParameters,
-): WatchPendingTransactionsReturnType {
-  const observerId = JSON.stringify([
-    'watchPendingTransactions',
-    client.uid,
-    batch,
-    pollingInterval,
-  ])
+  }: WatchPendingTransactionsParameters<TTransport>,
+) {
+  const enablePolling =
+    typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
 
-  return observe(observerId, { onTransactions, onError }, (emit) => {
-    let filter: Filter<'transaction'>
+  const pollPendingTransactions = () => {
+    const observerId = JSON.stringify([
+      'watchPendingTransactions',
+      client.uid,
+      batch,
+      pollingInterval,
+    ])
+    return observe(observerId, { onTransactions, onError }, (emit) => {
+      let filter: Filter<'transaction'>
 
-    const unwatch = poll(
-      async () => {
-        try {
-          if (!filter) {
-            try {
-              filter = await createPendingTransactionFilter(client)
-              return
-            } catch (err) {
-              unwatch()
-              throw err
+      const unwatch = poll(
+        async () => {
+          try {
+            if (!filter) {
+              try {
+                filter = await createPendingTransactionFilter(client)
+                return
+              } catch (err) {
+                unwatch()
+                throw err
+              }
             }
+
+            const hashes = await getFilterChanges(client, { filter })
+            if (hashes.length === 0) return
+            if (batch) emit.onTransactions(hashes)
+            else hashes.forEach((hash) => emit.onTransactions([hash]))
+          } catch (err) {
+            emit.onError?.(err as Error)
           }
+        },
+        {
+          emitOnBegin: true,
+          interval: pollingInterval,
+        },
+      )
 
-          const hashes = await getFilterChanges(client, { filter })
-          if (hashes.length === 0) return
-          if (batch) emit.onTransactions(hashes)
-          else hashes.forEach((hash) => emit.onTransactions([hash]))
-        } catch (err) {
-          emit.onError?.(err as Error)
-        }
-      },
-      {
-        emitOnBegin: true,
-        interval: pollingInterval,
-      },
-    )
+      return async () => {
+        if (filter) await uninstallFilter(client, { filter })
+        unwatch()
+      }
+    })
+  }
 
-    return async () => {
-      if (filter) await uninstallFilter(client, { filter })
-      unwatch()
-    }
-  })
+  const subscribePendingTransactions = () => {
+    let active = true
+    let unsubscribe = () => (active = false)
+    ;(async () => {
+      try {
+        const { unsubscribe: unsubscribe_ } = await client.transport.subscribe({
+          params: ['newPendingTransactions'],
+          onData(data: any) {
+            if (!active) return
+            const transaction = data.result
+            onTransactions([transaction])
+          },
+          onError(error: Error) {
+            onError?.(error)
+          },
+        })
+        unsubscribe = unsubscribe_
+        if (!active) unsubscribe()
+      } catch (err) {
+        onError?.(err as Error)
+      }
+    })()
+    return unsubscribe
+  }
+
+  return enablePolling
+    ? pollPendingTransactions()
+    : subscribePendingTransactions()
 }

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -19,7 +19,7 @@ export type PublicClient<
   TIncludeActions extends boolean = true,
 > = Prettify<
   Client<TTransport, PublicRequests, TChain> &
-    (TIncludeActions extends true ? PublicActions<TChain> : unknown)
+    (TIncludeActions extends true ? PublicActions<TTransport, TChain> : unknown)
 >
 
 /**

--- a/src/clients/decorators/public.test.ts
+++ b/src/clients/decorators/public.test.ts
@@ -13,7 +13,7 @@ import {
 import { publicActions } from './public'
 
 test('default', async () => {
-  expect(publicActions(publicClient as any)).toMatchInlineSnapshot(`
+  expect(publicActions(publicClient)).toMatchInlineSnapshot(`
     {
       "call": [Function],
       "createBlockFilter": [Function],

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -235,7 +235,7 @@ export type PublicActions<
     args: WatchBlockNumberParameters,
   ) => WatchBlockNumberReturnType
   watchBlocks: (
-    args: WatchBlocksParameters<TChain, TTransport>,
+    args: WatchBlocksParameters<TTransport, TChain>,
   ) => WatchBlocksReturnType
   watchContractEvent: <
     TAbi extends Abi | readonly unknown[],

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -115,6 +115,7 @@ import type { PublicClient } from '../createPublicClient'
 import type { Transport } from '../transports'
 
 export type PublicActions<
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
 > = {
   call: (args: CallParameters<TChain>) => Promise<CallReturnType>
@@ -233,7 +234,9 @@ export type PublicActions<
   watchBlockNumber: (
     args: WatchBlockNumberParameters,
   ) => WatchBlockNumberReturnType
-  watchBlocks: (args: WatchBlocksParameters<TChain>) => WatchBlocksReturnType
+  watchBlocks: (
+    args: WatchBlocksParameters<TChain, TTransport>,
+  ) => WatchBlocksReturnType
   watchContractEvent: <
     TAbi extends Abi | readonly unknown[],
     TEventName extends string,
@@ -244,16 +247,16 @@ export type PublicActions<
     args: WatchEventParameters<TAbiEvent>,
   ) => WatchEventReturnType
   watchPendingTransactions: (
-    args: WatchPendingTransactionsParameters,
+    args: WatchPendingTransactionsParameters<TTransport>,
   ) => WatchPendingTransactionsReturnType
 }
 
 export const publicActions = <
-  TTransport extends Transport,
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
 >(
   client: PublicClient<TTransport, TChain>,
-): PublicActions<TChain> => ({
+): PublicActions<TTransport, TChain> => ({
   call: (args) => call(client, args),
   createBlockFilter: () => createBlockFilter(client),
   createContractEventFilter: (args) => createContractEventFilter(client, args),

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -102,7 +102,8 @@ export function webSocket(
                     resolve(data)
                     return
                   }
-                  onData(data)
+                  if (data.method !== 'eth_subscription') return
+                  onData(data.params)
                 },
                 onError: (error) => {
                   reject(error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export type {
   ExtractFunctionNameFromAbi,
   ExtractNameFromAbi,
   ExtractResultFromAbi,
+  GetTransportConfig,
   HDAccount,
   HDKey,
   HDOptions,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -101,6 +101,8 @@ export type {
   TransactionSerializedLegacy,
 } from './transaction'
 
+export type { GetTransportConfig } from './transport'
+
 export type {
   GetTypedDataDomain,
   GetTypedDataMessage,

--- a/src/types/transport.ts
+++ b/src/types/transport.ts
@@ -1,0 +1,4 @@
+import type { Transport } from '../clients'
+
+export type GetTransportConfig<TTransport extends Transport> =
+  ReturnType<TTransport>['config']


### PR DESCRIPTION
Added WebSocket `eth_subscribe` support `watchBlocks`, `watchBlockNumber`, and `watchPendingTransactions`.