### PR TITLE
Fix getAbiItem item name in example

### DIFF
--- a/site/docs/abi/getAbiItem.md
+++ b/site/docs/abi/getAbiItem.md
@@ -51,7 +51,7 @@ const encodedData = getAbiItem({
       stateMutability: 'view'
     }
   ],
-  name: 'x',
+  name: 'y',
 })
 /**
  * { 


### PR DESCRIPTION
Seems to be wrong based on the commented return block.