### PR TITLE
fix: allow passing full contract abi to decodeFunctionData

### DIFF
--- a/.changeset/rich-numbers-crash.md
+++ b/.changeset/rich-numbers-crash.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Fixed issue where ABIs with constructors would throw for `decodeFunctionData`.

--- a/src/utils/abi/decodeFunctionData.ts
+++ b/src/utils/abi/decodeFunctionData.ts
@@ -18,7 +18,9 @@ export function decodeFunctionData({
 }: DecodeFunctionDataParameters) {
   const signature = slice(data, 0, 4)
   const description = (abi as Abi).find(
-    (x) => signature === getFunctionSelector(formatAbiItem(x)),
+    (x) =>
+      x.type === 'function' &&
+      signature === getFunctionSelector(formatAbiItem(x)),
   )
   if (!description)
     throw new AbiFunctionSignatureNotFoundError(signature, {


### PR DESCRIPTION
Fixes #262 

Not sure if you want to fix it like this as mentioned in the issue or whether you'd want to support constructors there.