### PR TITLE
docs: Update migration from ethers guide

### DIFF
--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -260,7 +260,7 @@ const provider = new providers.Web3Provider(window.ethereum)
 
 #### viem
 
-```ts {3-7}
+```ts {4-7}
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
@@ -311,7 +311,7 @@ signer.sendTransaction({ ... })
 
 #### viem
 
-```ts {9-11}
+```ts {9-10}
 import { createWalletClient, custom, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
 
@@ -404,7 +404,7 @@ client.getTransaction(...)
 
 #### Ethers
 
-```ts {7-10}
+```ts {8-10}
 import { providers } from 'ethers'
 
 const provider = new providers.Web3Provider(window.ethereum)
@@ -419,7 +419,7 @@ signer.signMessage(...)
 
 #### viem
 
-```ts {9-12}
+```ts {12-14}
 import { createWalletClient, custom, getAccount } from 'viem'
 import { mainnet } from 'viem/chains'
 
@@ -459,7 +459,7 @@ const supply = await contract.totalSupply()
 
 #### viem
 
-```ts {9-13}
+```ts {10-13}
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { wagmiContractConfig } from './abi'
@@ -539,7 +539,7 @@ await contract.deploy()
 
 #### viem
 
-```ts {12-16}
+```ts {13-17}
 import { createWalletClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { abi, bytecode } from './abi'
@@ -583,7 +583,7 @@ contract.off('Transfer', listener)
 
 #### viem
 
-```ts {9-20}
+```ts {10-20}
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { wagmiContractConfig } from './abi'
@@ -625,7 +625,7 @@ const gas = contract.estimateGas.mint()
 
 #### viem
 
-```ts {9-13}
+```ts {10-13}
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { wagmiContractConfig } from './abi'
@@ -658,7 +658,7 @@ await contract.callStatic.mint()
 
 #### viem
 
-```ts {9-13}
+```ts {10-13}
 import { createPublicClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { wagmiContractConfig } from './abi'

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -495,7 +495,7 @@ const hash = await contract.mint()
 
 #### viem
 
-```ts {15-21}
+```ts {17-22}
 import { createPublicClient, createWalletClient, http } from 'viem'
 import { mainnet } from 'viem/chains'
 import { wagmiContractConfig } from './abi'
@@ -517,7 +517,7 @@ const request = await publicClient.simulateContract({
   functionName: 'mint',
   account,
 })
-const supply = await walletClient.writeContract(request)
+const hash = await walletClient.writeContract(request)
 ```
 
 ### Deploying Contracts

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -512,7 +512,7 @@ const walletClient = createWalletClient({
 const [address] = await walletClient.getAddresses()
 const account = getAccount(address)
 
-const request = await publicClient.simulateContract({
+const { request } = await publicClient.simulateContract({
   ...wagmiContractConfig,
   functionName: 'mint',
   account,


### PR DESCRIPTION
- Extract `request` from the `simulateContract` returns to use as the `writeContract` arg in the "Writing to Contracts" section
- Fix typos
- Update highlighted lines