### PR TITLE
feat: return discriminated union type from decodeFunctionData

### DIFF
--- a/.changeset/quiet-toes-wave.md
+++ b/.changeset/quiet-toes-wave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Return discrimated union type from `decodeFunctionData`

--- a/src/utils/abi/decodeFunctionData.test.ts
+++ b/src/utils/abi/decodeFunctionData.test.ts
@@ -106,7 +106,7 @@ test('getVoter((uint256,bool,address,uint256))', () => {
     functionName: 'getVoter',
   })
 
-  expectTypeOf(result).toMatchTypeOf<{
+  expectTypeOf(result).toEqualTypeOf<{
     functionName: 'getVoter'
     args: readonly [
       {
@@ -117,6 +117,85 @@ test('getVoter((uint256,bool,address,uint256))', () => {
       },
     ]
   }>()
+})
+
+test('returns discrimated union type for abi with multiple abi items', () => {
+  const result = decodeFunctionData({
+    abi: [
+      {
+        inputs: [
+          {
+            components: [
+              {
+                name: 'weight',
+                type: 'uint256',
+              },
+              {
+                name: 'voted',
+                type: 'bool',
+              },
+              {
+                name: 'delegate',
+                type: 'address',
+              },
+              {
+                name: 'vote',
+                type: 'uint256',
+              },
+            ],
+            name: 'voter',
+            type: 'tuple',
+          },
+        ],
+        name: 'getVoter',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [
+          {
+            name: 'a',
+            type: 'uint256',
+          },
+        ],
+        name: 'bar',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+      {
+        inputs: [],
+        name: 'foo',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ] as const,
+    data: '0x0423a1320000000000000000000000000000000000000000000000000000000000000001',
+  })
+
+  expectTypeOf(result).toEqualTypeOf<
+    | {
+        functionName: 'getVoter'
+        args: readonly [
+          {
+            delegate: `0x${string}`
+            vote: bigint
+            voted: boolean
+            weight: bigint
+          },
+        ]
+      }
+    | {
+        functionName: 'bar'
+        args: readonly [bigint]
+      }
+    | {
+        functionName: 'foo'
+        args: undefined
+      }
+  >()
 })
 
 test("errors: function doesn't exist", () => {

--- a/src/utils/abi/decodeFunctionData.test.ts
+++ b/src/utils/abi/decodeFunctionData.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, expectTypeOf, test } from 'vitest'
 
 import { decodeFunctionData } from './decodeFunctionData'
 
@@ -58,43 +58,43 @@ test('bar(uint256)', () => {
 })
 
 test('getVoter((uint256,bool,address,uint256))', () => {
-  expect(
-    decodeFunctionData({
-      abi: [
-        {
-          inputs: [
-            {
-              components: [
-                {
-                  name: 'weight',
-                  type: 'uint256',
-                },
-                {
-                  name: 'voted',
-                  type: 'bool',
-                },
-                {
-                  name: 'delegate',
-                  type: 'address',
-                },
-                {
-                  name: 'vote',
-                  type: 'uint256',
-                },
-              ],
-              name: 'voter',
-              type: 'tuple',
-            },
-          ],
-          name: 'getVoter',
-          outputs: [],
-          stateMutability: 'nonpayable',
-          type: 'function',
-        },
-      ] as const,
-      data: '0xf37414670000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac0000000000000000000000000000000000000000000000000000000000000029',
-    }),
-  ).toEqual({
+  const result = decodeFunctionData({
+    abi: [
+      {
+        inputs: [
+          {
+            components: [
+              {
+                name: 'weight',
+                type: 'uint256',
+              },
+              {
+                name: 'voted',
+                type: 'bool',
+              },
+              {
+                name: 'delegate',
+                type: 'address',
+              },
+              {
+                name: 'vote',
+                type: 'uint256',
+              },
+            ],
+            name: 'voter',
+            type: 'tuple',
+          },
+        ],
+        name: 'getVoter',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      },
+    ] as const,
+    data: '0xf37414670000000000000000000000000000000000000000000000000000000000010f2c0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac0000000000000000000000000000000000000000000000000000000000000029',
+  })
+
+  expect(result).toEqual({
     args: [
       {
         delegate: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
@@ -105,6 +105,18 @@ test('getVoter((uint256,bool,address,uint256))', () => {
     ],
     functionName: 'getVoter',
   })
+
+  expectTypeOf(result).toMatchTypeOf<{
+    functionName: 'getVoter'
+    args: readonly [
+      {
+        delegate: `0x${string}`
+        vote: bigint
+        voted: boolean
+        weight: bigint
+      },
+    ]
+  }>()
 })
 
 test("errors: function doesn't exist", () => {

--- a/src/utils/abi/decodeFunctionData.ts
+++ b/src/utils/abi/decodeFunctionData.ts
@@ -8,14 +8,14 @@ import { decodeAbiParameters } from './decodeAbiParameters'
 import { formatAbiItem } from './formatAbiItem'
 
 export type DecodeFunctionDataParameters<
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] = Abi,
 > = {
   abi: TAbi
   data: Hex
 }
 
 export type DecodeFunctionDataReturnType<
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] = Abi,
   _FunctionNames extends string = TAbi extends Abi
     ? Abi extends TAbi
       ? string

--- a/src/utils/abi/decodeFunctionData.ts
+++ b/src/utils/abi/decodeFunctionData.ts
@@ -1,21 +1,37 @@
-import type { Abi } from 'abitype'
+import type { Abi, ExtractAbiFunctionNames } from 'abitype'
 
 import { AbiFunctionSignatureNotFoundError } from '../../errors'
-import type { Hex } from '../../types'
+import type { GetFunctionArgs, Hex } from '../../types'
 import { slice } from '../data'
 import { getFunctionSelector } from '../hash'
 import { decodeAbiParameters } from './decodeAbiParameters'
 import { formatAbiItem } from './formatAbiItem'
 
-export type DecodeFunctionDataParameters = {
-  abi: Abi | readonly unknown[]
+export type DecodeFunctionDataParameters<
+  TAbi extends Abi | readonly unknown[],
+> = {
+  abi: TAbi
   data: Hex
 }
 
-export function decodeFunctionData({
+export type DecodeFunctionDataReturnType<
+  TAbi extends Abi | readonly unknown[],
+  _FunctionNames extends string = TAbi extends Abi
+    ? Abi extends TAbi
+      ? string
+      : ExtractAbiFunctionNames<TAbi>
+    : string,
+> = {
+  [TName in _FunctionNames]: {
+    args: GetFunctionArgs<TAbi, TName>['args']
+    functionName: TName
+  }
+}[_FunctionNames]
+
+export function decodeFunctionData<TAbi extends Abi | readonly unknown[]>({
   abi,
   data,
-}: DecodeFunctionDataParameters) {
+}: DecodeFunctionDataParameters<TAbi>) {
   const signature = slice(data, 0, 4)
   const description = (abi as Abi).find(
     (x) =>
@@ -33,5 +49,5 @@ export function decodeFunctionData({
     description.inputs.length > 0
       ? decodeAbiParameters(description.inputs, slice(data, 4))
       : undefined) as readonly unknown[] | undefined,
-  }
+  } as DecodeFunctionDataReturnType<TAbi>
 }


### PR DESCRIPTION
I'm probably missing sth. here as I've not spent that much time with `abitype` yet. 

Btw., I cannot emphasize enough how much you guys are knocking it out of the park here). Test suite, type harness, etc. everything is such a pleasant experience to work with. Refactoring, writing tests, adding features, it's hands down the easiest / lowest barrier of entry experience I've ever had to contributing to a library.

ref: https://github.com/wagmi-dev/viem/discussions/264