### PR TITLE
fix: check whether tx properties are defined to derive tx type

### DIFF
--- a/.changeset/shy-vans-tan.md
+++ b/.changeset/shy-vans-tan.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fix getTransactionType to account for undefined values

--- a/.changeset/shy-vans-tan.md
+++ b/.changeset/shy-vans-tan.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fix getTransactionType to account for undefined values
+Fixed `getTransactionType` to honor `undefined` EIP-1559, EIP-2930 or Legacy attributes.

--- a/src/utils/transaction/getTransactionType.test.ts
+++ b/src/utils/transaction/getTransactionType.test.ts
@@ -23,7 +23,20 @@ describe('type', () => {
 
 describe('attributes', () => {
   test('eip1559', () => {
-    const type = getTransactionType({ chainId: 1, maxFeePerGas: 1n })
+    const type = getTransactionType({
+      chainId: 1,
+      maxFeePerGas: 1n,
+    })
+    assertType<'eip1559'>(type)
+    expect(type).toEqual('eip1559')
+  })
+
+  test('eip1559 with gasPrice undefined', () => {
+    const type = getTransactionType({
+      chainId: 1,
+      maxFeePerGas: 1n,
+      gasPrice: undefined,
+    })
     assertType<'eip1559'>(type)
     expect(type).toEqual('eip1559')
   })
@@ -38,8 +51,30 @@ describe('attributes', () => {
     expect(type).toEqual('eip2930')
   })
 
+  test('eip2930 with eip1559 properties undefined', () => {
+    const type = getTransactionType({
+      chainId: 1,
+      gasPrice: 1n,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+      accessList: [],
+    })
+    assertType<'eip2930'>(type)
+    expect(type).toEqual('eip2930')
+  })
+
   test('legacy', () => {
     const type = getTransactionType({ gasPrice: 1n })
+    assertType<'legacy'>(type)
+    expect(type).toEqual('legacy')
+  })
+
+  test('legacy with eip1559 properties undefined', () => {
+    const type = getTransactionType({
+      gasPrice: 1n,
+      maxFeePerGas: undefined,
+      maxPriorityFeePerGas: undefined,
+    })
     assertType<'legacy'>(type)
     expect(type).toEqual('legacy')
   })

--- a/src/utils/transaction/getTransactionType.ts
+++ b/src/utils/transaction/getTransactionType.ts
@@ -27,11 +27,14 @@ export function getTransactionType<
   if (transaction.type)
     return transaction.type as GetTransactionType<TTransactionSerializable>
 
-  if ('maxFeePerGas' in transaction || 'maxPriorityFeePerGas' in transaction)
+  if (
+    typeof transaction.maxFeePerGas !== 'undefined' ||
+    typeof transaction.maxPriorityFeePerGas !== 'undefined'
+  )
     return 'eip1559' as GetTransactionType<TTransactionSerializable>
 
-  if ('gasPrice' in transaction) {
-    if ('accessList' in transaction)
+  if (typeof transaction.gasPrice !== 'undefined') {
+    if (typeof transaction.accessList !== 'undefined')
       return 'eip2930' as GetTransactionType<TTransactionSerializable>
     return 'legacy' as GetTransactionType<TTransactionSerializable>
   }


### PR DESCRIPTION
Fixes #301 

The transaction object arrives at `getTransactionType` with `maxFeePerGas` and `maxPriorityFeePerGas` set as `undefined`. So we need to check that instead of checking whether the property exists or not.

