### PR TITLE
fix: derive eip1559 support by mere existence of the `maxFeePerGas` property

### DIFF
--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -68,7 +68,7 @@ export async function prepareRequest<
       blockTag: 'pending',
     })
 
-  if (block.baseFeePerGas) {
+  if (typeof block.baseFeePerGas === 'undefined') {
     if (typeof gasPrice !== 'undefined')
       throw new BaseError('Chain does not support legacy `gasPrice`.')
 


### PR DESCRIPTION
Fixes #301 

Turns out that zkEVM testnet returns `null` for baseFeePerGas. So let's maybe derive support for EIP-1559 by checking if the property exists at all?