### PR TITLE
fix: make `GetValue` return `{ value?: never }` for contract functions that are not payable

### DIFF
--- a/.changeset/tender-tools-nail.md
+++ b/.changeset/tender-tools-nail.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Made `GetValue` return `{ value?: never }` instead of `unknown` for contract functions that are not payable.

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -419,7 +419,7 @@ export function getContract<
                 functionName,
                 args,
                 ...options,
-              } as WriteContractParameters<
+              } as unknown as WriteContractParameters<
                 TAbi,
                 typeof functionName,
                 TChain,

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -170,10 +170,12 @@ test('GetValue', () => {
   expectTypeOf<Result>().toEqualTypeOf<{ value?: bigint | undefined }>()
 
   // other
-  expectTypeOf<
-    GetValue<typeof seaportAbi, 'getOrderStatus'>
-  >().toEqualTypeOf<unknown>()
-  expectTypeOf<GetValue<typeof seaportAbi, 'cancel'>>().toEqualTypeOf<unknown>()
+  expectTypeOf<GetValue<typeof seaportAbi, 'getOrderStatus'>>().toEqualTypeOf<{
+    value?: never
+  }>()
+  expectTypeOf<GetValue<typeof seaportAbi, 'cancel'>>().toEqualTypeOf<{
+    value?: never
+  }>()
 })
 
 test('InferErrorName', () => {

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -67,7 +67,7 @@ export type GetValue<
   ? { value?: TValueType }
   : TAbiFunction['payable'] extends true
   ? { value?: TValueType }
-  : unknown
+  : { value?: never }
 
 export type MaybeAbiEventName<TAbiEvent extends AbiEvent | undefined> =
   TAbiEvent extends AbiEvent ? TAbiEvent['name'] : undefined


### PR DESCRIPTION
I think this will help the story around type abstraction for consumers (ie. wagmi), as we will still be able to safely extract a `value` without other TS pain.