### PR TITLE
feat: tree-shakeable client types

### DIFF
--- a/src/actions/actions.test-d.ts
+++ b/src/actions/actions.test-d.ts
@@ -1,0 +1,87 @@
+import { seaportAbi } from 'abitype/test'
+import { test } from 'vitest'
+import { mainnet } from '../chains'
+
+import {
+  createClient,
+  createPublicClient,
+  createTestClient,
+  createWalletClient,
+  http,
+} from '../clients'
+import { readContract } from './public'
+import { impersonateAccount } from './test'
+import { writeContract } from './wallet'
+
+const client = createClient({
+  chain: mainnet,
+  transport: http(),
+})
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+})
+const walletClient = createWalletClient({
+  chain: mainnet,
+  transport: http(),
+  account: '0x',
+})
+const testClient = createTestClient({
+  mode: 'anvil',
+  chain: mainnet,
+  transport: http(),
+})
+
+test('tree shakeable with plain client', () => {
+  readContract(client, {
+    abi: seaportAbi,
+    address: '0x',
+    functionName: 'name',
+  })
+  writeContract(client, {
+    abi: seaportAbi,
+    address: '0x',
+    account: '0x',
+    functionName: 'incrementCounter',
+  })
+  // TODO: test actions work with `client`
+  // impersonateAccount(client, {
+  //   address: '0x',
+  //   mode: 'anvil',
+  // })
+})
+
+test('public client decorator', () => {
+  publicClient.readContract({
+    abi: seaportAbi,
+    address: '0x',
+    functionName: 'name',
+  })
+  readContract(publicClient, {
+    abi: seaportAbi,
+    address: '0x',
+    functionName: 'name',
+  })
+})
+
+test('wallet client decorator', () => {
+  walletClient.writeContract({
+    abi: seaportAbi,
+    address: '0x',
+    functionName: 'incrementCounter',
+  })
+  writeContract(walletClient, {
+    abi: seaportAbi,
+    address: '0x',
+    functionName: 'incrementCounter',
+  })
+})
+
+test('test client decorator', () => {
+  testClient.impersonateAccount({
+    address: '0x',
+  })
+  impersonateAccount(testClient, {
+    address: '0x',
+  })
+})

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -1,7 +1,7 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import {
   singleAddressResolverAbi,
-  universalResolverAbi
+  universalResolverAbi,
 } from '../../constants/abis'
 import type { Address, Chain, Prettify } from '../../types'
 import {
@@ -9,7 +9,7 @@ import {
   encodeFunctionData,
   getChainContractAddress,
   toHex,
-  trim
+  trim,
 } from '../../utils'
 import { namehash, packetToBytes } from '../../utils/ens'
 import { readContract, ReadContractParameters } from '../public'
@@ -32,7 +32,7 @@ export type GetEnsAddressReturnType = Address | null
  * - Since ENS names prohibit certain forbidden characters (e.g. underscore) and have other validation rules, you likely want to [normalize ENS names](https://docs.ens.domains/contract-api-reference/name-processing#normalising-names) with [UTS-46 normalization](https://unicode.org/reports/tr46) before passing them to `getEnsAddress`. You can use the built-in [`normalize`](https://viem.sh/docs/ens/utilities/normalize.html) function for this.
  */
 export async function getEnsAddress<TChain extends Chain | undefined,>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockNumber,
     blockTag,

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { AssetGatewayUrls, Chain, Prettify } from '../../types'
 import { parseAvatarRecord } from '../../utils/ens'
 import { getEnsText, GetEnsTextParameters } from './getEnsText'
@@ -16,7 +16,7 @@ export type GetEnsAvatarReturnType = string | null
  * @description Gets avatar URI for ENS name.
  */
 export async function getEnsAvatar<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockNumber,
     blockTag,

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import { panicReasons } from '../../constants'
 import {
   ContractFunctionExecutionError,
@@ -32,7 +32,7 @@ export type GetEnsNameReturnType = string | null
  * // 'wagmi-dev.eth'
  */
 export async function getEnsName<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     address,
     blockNumber,

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Address, Chain, Prettify } from '../../types'
 import { getChainContractAddress, toHex } from '../../utils'
 import { packetToBytes } from '../../utils/ens'
@@ -19,7 +19,7 @@ export type GetEnsResolverReturnType = Address
  * @description Gets resolver for ENS name.
  */
 export async function getEnsResolver<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockNumber,
     blockTag,

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import { textResolverAbi, universalResolverAbi } from '../../constants/abis'
 import type { Address, Chain, Prettify } from '../../types'
 import {
@@ -39,7 +39,7 @@ export type GetEnsTextReturnType = string | null
  * // 'wagmi_sh'
  */
 export async function getEnsText<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockNumber,
     blockTag,

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -45,13 +45,13 @@ import {
 } from './wallet'
 
 export type GetContractParameters<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
+  TTransport extends Transport = Transport,
   TAbi extends Abi | readonly unknown[] = Abi,
-  TPublicClient extends PublicClient<TTransport, TChain> | unknown = unknown,
+  TPublicClient extends PublicClient<TChain, TTransport> | unknown = unknown,
   TWalletClient extends
-    | WalletClient<TTransport, TChain, TAccount>
+    | WalletClient<TChain, TAccount, TTransport>
     | unknown = unknown,
 > = {
   /** Contract ABI */
@@ -201,15 +201,15 @@ export type GetContractReturnType<
  * Gets type-safe contract instance.
  */
 export function getContract<
-  TTransport extends Transport,
   TAbi extends Abi | readonly unknown[],
+  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
-  TPublicClient extends PublicClient<TTransport, TChain> | undefined =
-    | PublicClient<TTransport, TChain>
+  TPublicClient extends PublicClient<TChain, TTransport> | undefined =
+    | PublicClient<TChain, TTransport>
     | undefined,
-  TWalletClient extends WalletClient<TTransport, TChain, TAccount> | undefined =
-    | WalletClient<TTransport, TChain, TAccount>
+  TWalletClient extends WalletClient<TChain, TAccount, TTransport> | undefined =
+    | WalletClient<TChain, TAccount, TTransport>
     | undefined,
 >({
   abi,
@@ -217,9 +217,9 @@ export function getContract<
   publicClient,
   walletClient,
 }: GetContractParameters<
-  TTransport,
   TChain,
   TAccount,
+  TTransport,
   TAbi,
   TPublicClient,
   TWalletClient

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
   Account,
@@ -49,7 +49,7 @@ export type CallParameters<
 export type CallReturnType = { data: Hex | undefined }
 
 export async function call<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   args: CallParameters<TChain>,
 ): Promise<CallReturnType> {
   const {

--- a/src/actions/public/createBlockFilter.ts
+++ b/src/actions/public/createBlockFilter.ts
@@ -1,10 +1,10 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Chain, Filter } from '../../types'
 
 export type CreateBlockFilterReturnType = Filter<'block'>
 
 export async function createBlockFilter<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
 ): Promise<CreateBlockFilterReturnType> {
   const id = await client.request({
     method: 'eth_newBlockFilter',

--- a/src/actions/public/createContractEventFilter.ts
+++ b/src/actions/public/createContractEventFilter.ts
@@ -1,5 +1,5 @@
 import type { Abi, Narrow } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 
 import type {
   Address,
@@ -57,7 +57,7 @@ export async function createContractEventFilter<
   TEventName extends string | undefined,
   TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     address,
     abi,

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -1,5 +1,5 @@
 import type { Abi, AbiEvent, Narrow } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 
 import type {
   Address,
@@ -71,7 +71,7 @@ export async function createEventFilter<
     | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
     | undefined = undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     address,
     args,

--- a/src/actions/public/createPendingTransactionFilter.ts
+++ b/src/actions/public/createPendingTransactionFilter.ts
@@ -4,10 +4,10 @@ import type { Chain, Filter } from '../../types'
 export type CreatePendingTransactionFilterReturnType = Filter<'transaction'>
 
 export async function createPendingTransactionFilter<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
+  TTransport extends Transport,
 >(
-  client: PublicClient<TTransport, TChain>,
+  client: PublicClient<TChain, TTransport>,
 ): Promise<CreatePendingTransactionFilterReturnType> {
   const id = await client.request({
     method: 'eth_newPendingTransactionFilter',

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BaseError } from '../../errors'
 import type { Chain, ContractFunctionConfig, GetValue } from '../../types'
 import {
@@ -26,7 +26,7 @@ export async function estimateContractGas<
   TFunctionName extends string,
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     abi,
     address,

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, WalletClient, Transport } from '../../clients'
+import type { PublicClient, WalletClient, Client } from '../../clients'
 import type { BaseError } from '../../errors'
 import { AccountNotFoundError } from '../../errors'
 import type {
@@ -58,8 +58,9 @@ export async function estimateGas<
   TAccount extends Account | undefined = undefined,
 >(
   client:
-    | PublicClient<Transport, TChain>
-    | WalletClient<Transport, TChain, TAccount>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
   args: EstimateGasParameters<TChain, TAccount>,
 ): Promise<EstimateGasReturnType> {
   if (!args.account)

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Address, BlockTag, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -24,7 +24,7 @@ export type GetBalanceReturnType = bigint
  * @description Returns the balance of an address in wei.
  */
 export async function getBalance<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { address, blockNumber, blockTag = 'latest' }: GetBalanceParameters,
 ): Promise<GetBalanceReturnType> {
   const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, WalletClient, Transport } from '../../clients'
+import type { Client, PublicClient, WalletClient } from '../../clients'
 import { BlockNotFoundError } from '../../errors'
 import type { Account, BlockTag, Chain, Hash, RpcBlock } from '../../types'
 import type { BlockFormatter, FormattedBlock } from '../../utils'
@@ -37,8 +37,9 @@ export async function getBlock<
   TAccount extends Account | undefined,
 >(
   client:
-    | PublicClient<Transport, TChain>
-    | WalletClient<Transport, TChain, TAccount>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Chain } from '../../types'
 import { getCache, withCache } from '../../utils/promise'
 
@@ -19,7 +19,7 @@ export function getBlockNumberCache(id: string) {
  * @description Returns the number of the most recent block seen.
  */
 export async function getBlockNumber<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { maxAge = client.pollingInterval }: GetBlockNumberParameters = {},
 ): Promise<GetBlockNumberReturnType> {
   const blockNumberHex = await withCache(

--- a/src/actions/public/getBlockTransactionCount.ts
+++ b/src/actions/public/getBlockTransactionCount.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BlockTag, Chain, Hash, Quantity } from '../../types'
 import { hexToNumber, numberToHex } from '../../utils'
 
@@ -27,7 +27,7 @@ export type GetBlockTransactionCountReturnType = number
 export async function getBlockTransactionCount<
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getBytecode.ts
+++ b/src/actions/public/getBytecode.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Address, BlockTag, Chain, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -18,7 +18,7 @@ export type GetBytecodeParameters = {
 export type GetBytecodeReturnType = Hex | undefined
 
 export async function getBytecode<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { address, blockNumber, blockTag = 'latest' }: GetBytecodeParameters,
 ): Promise<GetBytecodeReturnType> {
   const blockNumberHex =

--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Client, PublicClient, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import { hexToNumber } from '../../utils'
 
@@ -9,8 +9,9 @@ export async function getChainId<
   TAccount extends Account | undefined,
 >(
   client:
-    | PublicClient<Transport, TChain>
-    | WalletClient<Transport, TChain, TAccount>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
 ): Promise<GetChainIdReturnType> {
   const chainIdHex = await client.request({ method: 'eth_chainId' })
   return hexToNumber(chainIdHex)

--- a/src/actions/public/getFeeHistory.ts
+++ b/src/actions/public/getFeeHistory.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BlockTag, Chain, FeeHistory } from '../../types'
 
 import { numberToHex } from '../../utils'
@@ -23,7 +23,7 @@ export type GetFeeHistoryReturnType = FeeHistory
  * @description Returns a collection of historical gas information.
  */
 export async function getFeeHistory<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockCount,
     blockNumber,

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -1,5 +1,5 @@
 import type { Abi, AbiEvent } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type {
   Chain,
   Filter,
@@ -31,14 +31,13 @@ export type GetFilterChangesReturnType<
   : Hash[]
 
 export async function getFilterChanges<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
   TFilterType extends FilterType,
   TAbiEvent extends AbiEvent | undefined,
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClient<TTransport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     filter,
   }: GetFilterChangesParameters<TFilterType, TAbiEvent, TAbi, TEventName>,

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -1,5 +1,5 @@
 import type { Abi, AbiEvent } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Chain, Filter, Log, MaybeAbiEventName } from '../../types'
 import { decodeEventLog } from '../../utils'
 
@@ -24,7 +24,7 @@ export async function getFilterLogs<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { filter }: GetFilterLogsParameters<TAbiEvent, TAbi, TEventName>,
 ): Promise<GetFilterLogsReturnType<TAbiEvent, TAbi, TEventName>> {
   const logs = await client.request({

--- a/src/actions/public/getGasPrice.ts
+++ b/src/actions/public/getGasPrice.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Client, PublicClient, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 
 export type GetGasPriceReturnType = bigint
@@ -11,8 +11,9 @@ export async function getGasPrice<
   TAccount extends Account | undefined,
 >(
   client:
-    | PublicClient<Transport, TChain>
-    | WalletClient<Transport, TChain, TAccount>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
 ): Promise<GetGasPriceReturnType> {
   const gasPrice = await client.request({
     method: 'eth_gasPrice',

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -1,5 +1,5 @@
 import type { AbiEvent } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type {
   Address,
   BlockNumber,
@@ -60,7 +60,7 @@ export async function getLogs<
   TChain extends Chain | undefined,
   TAbiEvent extends AbiEvent | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     address,
     blockHash,

--- a/src/actions/public/getStorageAt.ts
+++ b/src/actions/public/getStorageAt.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Address, BlockTag, Chain, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -19,7 +19,7 @@ export type GetStorageAtParameters = {
 export type GetStorageAtReturnType = Hex | undefined
 
 export async function getStorageAt<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { address, blockNumber, blockTag = 'latest', slot }: GetStorageAtParameters,
 ): Promise<GetStorageAtReturnType> {
   const blockNumberHex =

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import { TransactionNotFoundError } from '../../errors/transaction'
 import type { BlockTag, Chain, Hash, RpcTransaction } from '../../types'
 import { format, numberToHex } from '../../utils'
@@ -50,7 +50,7 @@ export type GetTransactionReturnType<TChain extends Chain | undefined = Chain> =
 
 /** @description Returns information about a transaction given a hash or block identifier. */
 export async function getTransaction<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     blockHash,
     blockNumber,

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Chain, Hash } from '../../types'
 import type {
   FormattedTransactionReceipt,
@@ -28,7 +28,7 @@ export type GetTransactionConfirmationsReturnType = bigint
 export async function getTransactionConfirmations<
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { hash, transactionReceipt }: GetTransactionConfirmationsParameters<TChain>,
 ): Promise<GetTransactionConfirmationsReturnType> {
   const [blockNumber, transaction] = await Promise.all([

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { Client, PublicClient, WalletClient } from '../../clients'
 import type { Account, Address, BlockTag, Chain } from '../../types'
 import { hexToNumber, numberToHex } from '../../utils'
 
@@ -27,8 +27,9 @@ export async function getTransactionCount<
   TAccount extends Account | undefined,
 >(
   client:
-    | PublicClient<Transport, TChain>
-    | WalletClient<Transport, TChain, TAccount>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
   { address, blockTag = 'latest', blockNumber }: GetTransactionCountParameters,
 ): Promise<GetTransactionCountReturnType> {
   const count = await client.request({

--- a/src/actions/public/getTransactionReceipt.ts
+++ b/src/actions/public/getTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import { TransactionReceiptNotFoundError } from '../../errors'
 import type { Chain, Hash } from '../../types'
 import { format } from '../../utils'
@@ -18,7 +18,7 @@ export type GetTransactionReceiptReturnType<
 > = FormattedTransactionReceipt<TransactionReceiptFormatter<TChain>>
 
 export async function getTransactionReceipt<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { hash }: GetTransactionReceiptParameters,
 ) {
   const receipt = await client.request({

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -1,5 +1,5 @@
 import type { Narrow } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import { multicall3Abi } from '../../constants'
 import {
   AbiDecodingZeroDataError,
@@ -43,7 +43,7 @@ export async function multicall<
   TContracts extends ContractFunctionConfig[],
   TAllowFailure extends boolean = true,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   args: MulticallParameters<TContracts, TAllowFailure>,
 ): Promise<MulticallReturnType<TContracts, TAllowFailure>> {
   const {

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
   Chain,
@@ -32,7 +32,7 @@ export async function readContract<
   TAbi extends Abi | readonly unknown[],
   TFunctionName extends string,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     abi,
     address,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { BaseError } from '../../errors'
 import type {
   Chain,
@@ -60,7 +60,7 @@ export async function simulateContract<
   TFunctionName extends string,
   TChainOverride extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     abi,
     address,

--- a/src/actions/public/uninstallFilter.ts
+++ b/src/actions/public/uninstallFilter.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type { Chain, Filter } from '../../types'
 
 export type UninstallFilterParameters = {
@@ -6,11 +6,8 @@ export type UninstallFilterParameters = {
 }
 export type UninstallFilterReturnType = boolean
 
-export async function uninstallFilter<
-  TTransport extends Transport,
-  TChain extends Chain | undefined,
->(
-  client: PublicClient<TTransport, TChain>,
+export async function uninstallFilter<TChain extends Chain | undefined,>(
+  client: PublicClient<TChain> | Client<TChain>,
   { filter }: UninstallFilterParameters,
 ): Promise<UninstallFilterReturnType> {
   return client.request({

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import {
   TransactionNotFoundError,
   TransactionReceiptNotFoundError,
@@ -44,7 +44,7 @@ export type WaitForTransactionReceiptParameters<
 export async function waitForTransactionReceipt<
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     confirmations = 1,
     hash,

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient, Transport } from '../../clients'
 import type { Chain, GetTransportConfig } from '../../types'
 import { hexToBigInt } from '../../utils'
 import { observe } from '../../utils/observe'
@@ -47,7 +47,7 @@ export function watchBlockNumber<
   TChain extends Chain | undefined,
   TTransport extends Transport,
 >(
-  client: PublicClient<TTransport, TChain>,
+  client: PublicClient<TChain, TTransport> | Client<TChain>,
   {
     emitOnBegin = false,
     emitMissed = false,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -54,10 +54,10 @@ export type WatchBlocksReturnType = () => void
  * @description Watches and returns information for incoming blocks.
  */
 export function watchBlocks<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
+  TTransport extends Transport,
 >(
-  client: PublicClient<TTransport, TChain>,
+  client: PublicClient<TChain, TTransport>,
   {
     blockTag = 'latest',
     emitMissed = false,

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -1,5 +1,5 @@
 import type { Abi, ExtractAbiEvent, Narrow } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type {
   Address,
   Chain,
@@ -60,7 +60,7 @@ export function watchContractEvent<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     abi,
     address,

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -1,5 +1,5 @@
 import type { AbiEvent } from 'abitype'
-import type { PublicClient, Transport } from '../../clients'
+import type { Client, PublicClient } from '../../clients'
 import type {
   Address,
   Chain,
@@ -60,7 +60,7 @@ export function watchEvent<
   TAbiEvent extends AbiEvent | undefined,
   TEventName extends string | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     address,
     args,

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -39,10 +39,10 @@ export type WatchPendingTransactionsParameters<
 export type WatchPendingTransactionsReturnType = () => void
 
 export function watchPendingTransactions<
-  TTransport extends Transport,
   TChain extends Chain | undefined,
+  TTransport extends Transport,
 >(
-  client: PublicClient<TTransport, TChain>,
+  client: PublicClient<TChain, TTransport>,
   {
     batch = true,
     onError,

--- a/src/actions/test/dropTransaction.ts
+++ b/src/actions/test/dropTransaction.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain, Hash } from '../../types'
 
 export type DropTransactionParameters = {
@@ -7,7 +7,7 @@ export type DropTransactionParameters = {
 }
 
 export async function dropTransaction<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { hash }: DropTransactionParameters,
 ) {
   return await client.request({

--- a/src/actions/test/getAutomine.ts
+++ b/src/actions/test/getAutomine.ts
@@ -1,10 +1,10 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export type GetAutomineReturnType = boolean
 
 export async function getAutomine<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
 ): Promise<GetAutomineReturnType> {
   return await client.request({
     method: `${client.mode}_getAutomine`,

--- a/src/actions/test/getTxpoolContent.ts
+++ b/src/actions/test/getTxpoolContent.ts
@@ -1,5 +1,5 @@
 import type { Address } from 'abitype'
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain, RpcTransaction } from '../../types'
 
 export type GetTxpoolContentReturnType = {
@@ -8,7 +8,7 @@ export type GetTxpoolContentReturnType = {
 }
 
 export async function getTxpoolContent<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
 ): Promise<GetTxpoolContentReturnType> {
   return await client.request({
     method: 'txpool_content',

--- a/src/actions/test/getTxpoolStatus.ts
+++ b/src/actions/test/getTxpoolStatus.ts
@@ -1,5 +1,5 @@
-import type { Chain } from '@wagmi/chains'
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
+import type { Chain } from '../../types'
 import { hexToNumber } from '../../utils'
 
 export type GetTxpoolStatusReturnType = {
@@ -8,7 +8,7 @@ export type GetTxpoolStatusReturnType = {
 }
 
 export async function getTxpoolStatus<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
 ): Promise<GetTxpoolStatusReturnType> {
   const { pending, queued } = await client.request({
     method: 'txpool_status',

--- a/src/actions/test/impersonateAccount.ts
+++ b/src/actions/test/impersonateAccount.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 
 export type ImpersonateAccountParameters = {
@@ -6,8 +6,8 @@ export type ImpersonateAccountParameters = {
   address: Address
 }
 
-export async function impersonateAccount<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+export async function impersonateAccount<TChain extends Chain | undefined,>(
+  client: TestClient<TestClientMode, TChain>,
   { address }: ImpersonateAccountParameters,
 ) {
   return await client.request({

--- a/src/actions/test/increaseTime.ts
+++ b/src/actions/test/increaseTime.ts
@@ -1,5 +1,5 @@
-import type { Chain } from '@wagmi/chains'
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
+import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
 export type IncreaseTimeParameters = {
@@ -8,7 +8,7 @@ export type IncreaseTimeParameters = {
 }
 
 export async function increaseTime<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { seconds }: IncreaseTimeParameters,
 ) {
   return await client.request({

--- a/src/actions/test/inspectTxpool.ts
+++ b/src/actions/test/inspectTxpool.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 
 export type InspectTxpoolReturnType = {
@@ -7,7 +7,7 @@ export type InspectTxpoolReturnType = {
 }
 
 export async function inspectTxpool<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
 ): Promise<InspectTxpoolReturnType> {
   return await client.request({
     method: 'txpool_inspect',

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -10,7 +10,7 @@ export type MineParameters = {
 }
 
 export async function mine<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { blocks, interval }: MineParameters,
 ) {
   return await client.request({

--- a/src/actions/test/removeBlockTimestampInterval.ts
+++ b/src/actions/test/removeBlockTimestampInterval.ts
@@ -1,9 +1,9 @@
-import type { Chain } from '@wagmi/chains'
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
+import type { Chain } from '../../types'
 
 export async function removeBlockTimestampInterval<
   TChain extends Chain | undefined,
->(client: TestClient<TestClientMode, Transport, TChain>) {
+>(client: TestClient<TestClientMode, TChain>) {
   return await client.request({
     method: `${client.mode}_removeBlockTimestampInterval`,
   })

--- a/src/actions/test/reset.ts
+++ b/src/actions/test/reset.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export type ResetParameters = {
@@ -9,7 +9,7 @@ export type ResetParameters = {
 }
 
 export async function reset<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { blockNumber, jsonRpcUrl }: ResetParameters = {},
 ) {
   return await client.request({

--- a/src/actions/test/revert.ts
+++ b/src/actions/test/revert.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain, Quantity } from '../../types'
 
 export type RevertParameters = {
@@ -7,7 +7,7 @@ export type RevertParameters = {
 }
 
 export async function revert<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { id }: RevertParameters,
 ) {
   return await client.request({

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain, Hash, TransactionRequest } from '../../types'
 import { formatTransactionRequest } from '../../utils'
 
@@ -9,7 +9,7 @@ export type SendUnsignedTransactionReturnType = Hash
 export async function sendUnsignedTransaction<
   TChain extends Chain | undefined,
 >(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
   const request_ = formatTransactionRequest(request)

--- a/src/actions/test/setAutomine.ts
+++ b/src/actions/test/setAutomine.ts
@@ -1,8 +1,8 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export async function setAutomine<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   enabled: boolean,
 ) {
   return await client.request({

--- a/src/actions/test/setBalance.ts
+++ b/src/actions/test/setBalance.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -10,7 +10,7 @@ export type SetBalanceParameters = {
 }
 
 export async function setBalance<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address, value }: SetBalanceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setBlockGasLimit.ts
+++ b/src/actions/test/setBlockGasLimit.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -8,7 +8,7 @@ export type SetBlockGasLimitParameters = {
 }
 
 export async function setBlockGasLimit<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { gasLimit }: SetBlockGasLimitParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setBlockTimestampInterval.ts
+++ b/src/actions/test/setBlockTimestampInterval.ts
@@ -1,5 +1,5 @@
-import type { Chain } from '@wagmi/chains'
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
+import type { Chain } from '../../types'
 
 export type SetBlockTimestampIntervalParameters = {
   /** The interval (in seconds). */
@@ -9,7 +9,7 @@ export type SetBlockTimestampIntervalParameters = {
 export async function setBlockTimestampInterval<
   TChain extends Chain | undefined,
 >(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { interval }: SetBlockTimestampIntervalParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setCode.ts
+++ b/src/actions/test/setCode.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain, Hex } from '../../types'
 
 export type SetCodeParameters = {
@@ -9,7 +9,7 @@ export type SetCodeParameters = {
 }
 
 export async function setCode<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address, bytecode }: SetCodeParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setCoinbase.ts
+++ b/src/actions/test/setCoinbase.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 
 export type SetCoinbaseParameters = {
@@ -7,7 +7,7 @@ export type SetCoinbaseParameters = {
 }
 
 export async function setCoinbase<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address }: SetCoinbaseParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setIntervalMining.ts
+++ b/src/actions/test/setIntervalMining.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export type SetIntervalMiningParameters = {
@@ -7,7 +7,7 @@ export type SetIntervalMiningParameters = {
 }
 
 export async function setIntervalMining<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { interval }: SetIntervalMiningParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setLoggingEnabled.ts
+++ b/src/actions/test/setLoggingEnabled.ts
@@ -1,8 +1,8 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export async function setLoggingEnabled<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   enabled: boolean,
 ) {
   return await client.request({

--- a/src/actions/test/setMinGasPrice.ts
+++ b/src/actions/test/setMinGasPrice.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -8,7 +8,7 @@ export type SetMinGasPriceParameters = {
 }
 
 export async function setMinGasPrice<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { gasPrice }: SetMinGasPriceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNextBlockBaseFeePerGas.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -10,7 +10,7 @@ export type SetNextBlockBaseFeePerGasParameters = {
 export async function setNextBlockBaseFeePerGas<
   TChain extends Chain | undefined,
 >(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { baseFeePerGas }: SetNextBlockBaseFeePerGasParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNextBlockTimestamp.ts
+++ b/src/actions/test/setNextBlockTimestamp.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -8,7 +8,7 @@ export type SetNextBlockTimestampParameters = {
 }
 
 export async function setNextBlockTimestamp<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { timestamp }: SetNextBlockTimestampParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setNonce.ts
+++ b/src/actions/test/setNonce.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -10,7 +10,7 @@ export type SetNonceParameters = {
 }
 
 export async function setNonce<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address, nonce }: SetNonceParameters,
 ) {
   return await client.request({

--- a/src/actions/test/setRpcUrl.ts
+++ b/src/actions/test/setRpcUrl.ts
@@ -1,8 +1,8 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export async function setRpcUrl<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   jsonRpcUrl: string,
 ) {
   return await client.request({

--- a/src/actions/test/setStorageAt.ts
+++ b/src/actions/test/setStorageAt.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain, Hash, Hex } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -12,7 +12,7 @@ export type SetStorageAtParameters = {
 }
 
 export async function setStorageAt<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address, index, value }: SetStorageAtParameters,
 ) {
   return await client.request({

--- a/src/actions/test/snapshot.ts
+++ b/src/actions/test/snapshot.ts
@@ -1,8 +1,8 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Chain } from '../../types'
 
 export async function snapshot<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
 ) {
   return await client.request({
     method: 'evm_snapshot',

--- a/src/actions/test/stopImpersonatingAccount.ts
+++ b/src/actions/test/stopImpersonatingAccount.ts
@@ -1,4 +1,4 @@
-import type { TestClient, TestClientMode, Transport } from '../../clients'
+import type { TestClient, TestClientMode } from '../../clients'
 import type { Address, Chain } from '../../types'
 
 export type StopImpersonatingAccountParameters = {
@@ -9,7 +9,7 @@ export type StopImpersonatingAccountParameters = {
 export async function stopImpersonatingAccount<
   TChain extends Chain | undefined,
 >(
-  client: TestClient<TestClientMode, Transport, TChain>,
+  client: TestClient<TestClientMode, TChain>,
   { address }: StopImpersonatingAccountParameters,
 ) {
   return await client.request({

--- a/src/actions/wallet/addChain.ts
+++ b/src/actions/wallet/addChain.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -10,7 +10,7 @@ export async function addChain<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   { chain }: AddChainParameters,
 ) {
   const { id, name, nativeCurrency, rpcUrls, blockExplorers } = chain

--- a/src/actions/wallet/deployContract.test.ts
+++ b/src/actions/wallet/deployContract.test.ts
@@ -10,7 +10,6 @@ import { parseEther } from '../../utils'
 import { mine, setBalance } from '../test'
 
 import { deployContract } from './deployContract'
-import { arbitrum } from '../../chains'
 
 test('default', async () => {
   const hash = await deployContract(walletClient, {

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -1,6 +1,6 @@
 import type { Abi, Narrow } from 'abitype'
 
-import type { WalletClient, Transport } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type {
   Account,
   Chain,
@@ -37,7 +37,7 @@ export function deployContract<
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined,
 >(
-  walletClient: WalletClient<Transport, TChain, TAccount>,
+  walletClient: WalletClient<TChain, TAccount> | Client<TChain>,
   {
     abi,
     args,

--- a/src/actions/wallet/getAddresses.ts
+++ b/src/actions/wallet/getAddresses.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'abitype'
 
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import { checksumAddress } from '../../utils/address'
 
@@ -10,7 +10,7 @@ export async function getAddresses<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
 ): Promise<GetAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_accounts' })
   return addresses.map((address) => checksumAddress(address))

--- a/src/actions/wallet/getPermissions.ts
+++ b/src/actions/wallet/getPermissions.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import type { WalletPermission } from '../../types/eip1193'
 
@@ -7,7 +7,7 @@ export type GetPermissionsReturnType = WalletPermission[]
 export async function getPermissions<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
->(client: WalletClient<Transport, TChain, TAccount>) {
+>(client: WalletClient<TChain, TAccount> | Client<TChain>) {
   const permissions = await client.request({ method: 'wallet_getPermissions' })
   return permissions
 }

--- a/src/actions/wallet/requestAddresses.ts
+++ b/src/actions/wallet/requestAddresses.ts
@@ -1,6 +1,6 @@
 import type { Address } from 'abitype'
 
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import { getAddress } from '../../utils'
 
@@ -10,7 +10,7 @@ export async function requestAddresses<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
 ): Promise<RequestAddressesReturnType> {
   const addresses = await client.request({ method: 'eth_requestAccounts' })
   return addresses.map((address) => getAddress(address))

--- a/src/actions/wallet/requestPermissions.ts
+++ b/src/actions/wallet/requestPermissions.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import type { WalletPermission } from '../../types/eip1193'
 
@@ -13,7 +13,7 @@ export async function requestPermissions<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   permissions: RequestPermissionsParameters,
 ) {
   return client.request({

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import {
   AccountNotFoundError,
   BaseError,
@@ -51,11 +51,11 @@ export async function sendTransaction<
   TAccount extends Account | undefined,
   TChainOverride extends Chain | undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   args: SendTransactionParameters<TChain, TAccount, TChainOverride>,
 ): Promise<SendTransactionReturnType> {
   const {
-    account: account_ = client.account,
+    account: account_ = (client as WalletClient).account,
     chain = client.chain,
     accessList,
     data,

--- a/src/actions/wallet/signMessage.ts
+++ b/src/actions/wallet/signMessage.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import { AccountNotFoundError } from '../../errors'
 import type { Account, Chain, GetAccountParameter, Hex } from '../../types'
 import { parseAccount, toHex } from '../../utils'
@@ -15,9 +15,9 @@ export async function signMessage<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   {
-    account: account_ = client.account,
+    account: account_ = (client as WalletClient).account,
     message,
   }: SignMessageParameters<TAccount>,
 ): Promise<SignMessageReturnType> {

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -1,5 +1,5 @@
 import type { TypedData } from 'abitype'
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import { AccountNotFoundError } from '../../errors'
 import type {
   Account,
@@ -25,9 +25,9 @@ export async function signTypedData<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   {
-    account: account_ = client.account,
+    account: account_ = (client as WalletClient).account,
     domain,
     message,
     primaryType,

--- a/src/actions/wallet/switchChain.ts
+++ b/src/actions/wallet/switchChain.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import { numberToHex } from '../../utils'
 
@@ -8,7 +8,7 @@ export async function switchChain<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   { id }: SwitchChainParameters,
 ) {
   await client.request({

--- a/src/actions/wallet/watchAsset.ts
+++ b/src/actions/wallet/watchAsset.ts
@@ -1,4 +1,4 @@
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type { Account, Chain } from '../../types'
 import type { WatchAssetParams } from '../../types/eip1193'
 
@@ -9,7 +9,7 @@ export async function watchAsset<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   params: WatchAssetParameters,
 ): Promise<WatchAssetReturnType> {
   const added = await client.request({

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -1,6 +1,6 @@
 import type { Abi } from 'abitype'
 
-import type { Transport, WalletClient } from '../../clients'
+import type { Client, WalletClient } from '../../clients'
 import type {
   Account,
   Chain,
@@ -38,7 +38,7 @@ export async function writeContract<
   TFunctionName extends string,
   TChainOverride extends Chain | undefined = undefined,
 >(
-  client: WalletClient<Transport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount> | Client<TChain>,
   {
     abi,
     address,

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -4,8 +4,8 @@ import { uid } from '../utils/uid'
 import type { BaseRpcRequests, Transport } from './transports/createTransport'
 
 export type ClientConfig<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
 > = {
   /** Chain for the client. */
   chain?: TChain
@@ -25,9 +25,9 @@ export type ClientConfig<
 }
 
 export type Client<
-  TTransport extends Transport = Transport,
-  TRequests extends BaseRpcRequests = Requests,
   TChain extends Chain | undefined = Chain | undefined,
+  TRequests extends BaseRpcRequests = Requests,
+  TTransport extends Transport = Transport,
 > = {
   /** Chain for the client. */
   chain: TChain
@@ -51,8 +51,8 @@ export type Client<
  * @description Creates a base client with the given transport.
  */
 export function createClient<
-  TTransport extends Transport,
   TRequests extends BaseRpcRequests,
+  TTransport extends Transport,
   TChain extends Chain | undefined = undefined,
 >({
   chain,
@@ -61,7 +61,7 @@ export function createClient<
   pollingInterval = 4_000,
   transport,
   type = 'base',
-}: ClientConfig<TTransport, TChain>): Client<TTransport, TRequests, TChain> {
+}: ClientConfig<TChain, TTransport>): Client<TChain, TRequests, TTransport> {
   const { config, request, value } = transport({ chain, pollingInterval })
   return {
     chain: chain as TChain,

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -6,37 +6,37 @@ import { publicActions, PublicActions } from './decorators'
 import type { Chain, Prettify } from '../types'
 
 export type PublicClientConfig<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
 > = Pick<
-  ClientConfig<TTransport, TChain>,
+  ClientConfig<TChain, TTransport>,
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
 >
 
 export type PublicClient<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
   TIncludeActions extends boolean = true,
 > = Prettify<
-  Client<TTransport, PublicRequests, TChain> &
-    (TIncludeActions extends true ? PublicActions<TTransport, TChain> : unknown)
+  Client<TChain, PublicRequests, TTransport> &
+    (TIncludeActions extends true ? PublicActions<TChain, TTransport> : unknown)
 >
 
 /**
  * @description Creates a public client with a given transport.
  */
 export function createPublicClient<
-  TTransport extends Transport,
   TChain extends Chain | undefined = undefined,
+  TTransport extends Transport = Transport,
 >({
   chain,
   key = 'public',
   name = 'Public Client',
   transport,
   pollingInterval,
-}: PublicClientConfig<TTransport, TChain>): PublicClient<
-  TTransport,
+}: PublicClientConfig<TChain, TTransport>): PublicClient<
   TChain,
+  TTransport,
   true
 > {
   const client = createClient({
@@ -46,7 +46,7 @@ export function createPublicClient<
     pollingInterval,
     transport,
     type: 'publicClient',
-  }) as PublicClient<TTransport, TChain>
+  }) as PublicClient<TChain, TTransport>
   return {
     ...client,
     ...publicActions(client),

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -9,10 +9,10 @@ export type TestClientMode = 'anvil' | 'hardhat'
 
 export type TestClientConfig<
   TMode extends TestClientMode = TestClientMode,
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
 > = Pick<
-  ClientConfig<TTransport, TChain>,
+  ClientConfig<TChain, TTransport>,
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
 > & {
   /** Mode of the test client. Available: "anvil" | "hardhat" */
@@ -21,10 +21,10 @@ export type TestClientConfig<
 
 export type TestClient<
   TMode extends TestClientMode = TestClientMode,
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
-  TIncludeActions extends boolean = true,
-> = Client<TTransport, TestRequests<TMode>, TChain> &
+  TTransport extends Transport = Transport,
+  TIncludeActions extends boolean = true | false,
+> = Client<TChain, TestRequests<TMode>, TTransport> &
   (TIncludeActions extends true ? TestActions : unknown) & {
     mode: TMode
   }
@@ -34,8 +34,8 @@ export type TestClient<
  */
 export function createTestClient<
   TMode extends TestClientMode,
-  TTransport extends Transport,
   TChain extends Chain | undefined = undefined,
+  TTransport extends Transport = Transport,
 >({
   chain,
   key = 'test',
@@ -43,10 +43,10 @@ export function createTestClient<
   mode,
   pollingInterval,
   transport,
-}: TestClientConfig<TMode, TTransport, TChain>): TestClient<
+}: TestClientConfig<TMode, TChain, TTransport>): TestClient<
   TMode,
-  TTransport,
   TChain,
+  TTransport,
   true
 > {
   const client = {
@@ -59,7 +59,7 @@ export function createTestClient<
       type: 'testClient',
     }),
     mode,
-  } as TestClient<TMode, TTransport, TChain>
+  } as TestClient<TMode, TChain, TTransport>
   return {
     ...client,
     ...testActions(client),

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -13,14 +13,14 @@ import { parseAccount } from '../utils'
 import type { Requests } from '../types/eip1193'
 
 export type WalletClientConfig<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccountOrAddress extends Account | Address | undefined =
     | Account
     | Address
     | undefined,
+  TTransport extends Transport = Transport,
 > = Pick<
-  ClientConfig<TTransport, TChain>,
+  ClientConfig<TChain, TTransport>,
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
 > & {
   /** The Account to use for the Wallet Client. This will be used for Actions that require an account as an argument. */
@@ -28,12 +28,12 @@ export type WalletClientConfig<
 }
 
 export type WalletClient<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
+  TTransport extends Transport = Transport,
   TIncludeActions extends boolean = true,
 > = Prettify<
-  Client<TTransport, Requests, TChain> &
+  Client<TChain, Requests, TTransport> &
     (TIncludeActions extends true
       ? WalletActions<TChain, TAccount>
       : unknown) & {
@@ -46,9 +46,9 @@ export type WalletClient<
  * @description Creates a wallet client with a given transport.
  */
 export function createWalletClient<
-  TTransport extends Transport,
   TChain extends Chain | undefined = undefined,
   TAccountOrAddress extends Account | Address | undefined = undefined,
+  TTransport extends Transport = Transport,
 >({
   account,
   chain,
@@ -56,12 +56,12 @@ export function createWalletClient<
   key = 'wallet',
   name = 'Wallet Client',
   pollingInterval,
-}: WalletClientConfig<TTransport, TChain, TAccountOrAddress>): WalletClient<
-  TTransport,
+}: WalletClientConfig<TChain, TAccountOrAddress, TTransport>): WalletClient<
   TChain,
   TAccountOrAddress extends Address
     ? Prettify<JsonRpcAccount<TAccountOrAddress>>
     : TAccountOrAddress,
+  TTransport,
   true
 > {
   const client = {
@@ -75,11 +75,11 @@ export function createWalletClient<
     }),
     account: account ? parseAccount(account) : undefined,
   } as WalletClient<
-    TTransport,
     TChain,
     TAccountOrAddress extends Address
       ? JsonRpcAccount<TAccountOrAddress>
-      : TAccountOrAddress
+      : TAccountOrAddress,
+    TTransport
   >
   return {
     ...client,

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -127,8 +127,8 @@ import type { PublicClient } from '../createPublicClient'
 import type { Transport } from '../transports'
 
 export type PublicActions<
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
 > = {
   call: (args: CallParameters<TChain>) => Promise<CallReturnType>
   createBlockFilter: () => Promise<CreateBlockFilterReturnType>
@@ -271,11 +271,11 @@ export type PublicActions<
 }
 
 export const publicActions = <
-  TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
 >(
-  client: PublicClient<TTransport, TChain>,
-): PublicActions<TTransport, TChain> => ({
+  client: PublicClient<TChain, TTransport>,
+): PublicActions<TChain, TTransport> => ({
   call: (args) => call(client, args),
   createBlockFilter: () => createBlockFilter(client),
   createContractEventFilter: (args) => createContractEventFilter(client, args),

--- a/src/clients/decorators/test.ts
+++ b/src/clients/decorators/test.ts
@@ -99,9 +99,11 @@ export type TestActions = {
   ) => Promise<void>
 }
 
-export function testActions<TChain extends Chain | undefined>(
-  client: TestClient<TestClientMode, Transport, TChain>,
-): TestActions {
+export function testActions<
+  TMode extends TestClientMode = TestClientMode,
+  TChain extends Chain | undefined = Chain | undefined,
+  TTransport extends Transport = Transport,
+>(client: TestClient<TMode, TChain, TTransport>): TestActions {
   return {
     dropTransaction: (args) => dropTransaction(client, args),
     getAutomine: () => getAutomine(client),

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -88,11 +88,11 @@ export type WalletActions<
 }
 
 export const walletActions = <
-  TTransport extends Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
+  TTransport extends Transport = Transport,
 >(
-  client: WalletClient<TTransport, TChain, TAccount>,
+  client: WalletClient<TChain, TAccount, TTransport>,
 ): WalletActions<TChain, TAccount> => ({
   addChain: (args) => addChain(client, args),
   deployContract: (args) => deployContract(client, args),

--- a/src/utils/ens/avatar/parseAvatarRecord.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.ts
@@ -1,4 +1,4 @@
-import type { PublicClient, Transport } from '../../../clients'
+import type { Client, PublicClient } from '../../../clients'
 import type { AssetGatewayUrls, Chain } from '../../../types'
 import {
   getJsonImage,
@@ -10,7 +10,7 @@ import {
 } from './utils'
 
 export async function parseAvatarRecord<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     gatewayUrls,
     record,
@@ -25,7 +25,7 @@ export async function parseAvatarRecord<TChain extends Chain | undefined>(
 }
 
 async function parseNftAvatarUri<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   {
     gatewayUrls,
     record,

--- a/src/utils/ens/avatar/utils.ts
+++ b/src/utils/ens/avatar/utils.ts
@@ -1,5 +1,5 @@
 import { readContract } from '../../../actions'
-import type { PublicClient, Transport } from '../../../clients'
+import type { Client, PublicClient } from '../../../clients'
 import {
   EnsAvatarInvalidMetadataError,
   EnsAvatarInvalidNftUriError,
@@ -209,7 +209,7 @@ export function parseNftUri(uri: string): ParsedNft {
 }
 
 export async function getNftTokenUri<TChain extends Chain | undefined>(
-  client: PublicClient<Transport, TChain>,
+  client: PublicClient<TChain> | Client<TChain>,
   { nft }: { nft: ParsedNft },
 ) {
   if (nft.namespace === 'erc721') {

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -7,7 +7,7 @@ import {
   getTransactionCount,
   SendTransactionParameters,
 } from '../../actions'
-import type { PublicClient, Transport, WalletClient } from '../../clients'
+import type { PublicClient, WalletClient, Client } from '../../clients'
 import { AccountNotFoundError, BaseError } from '../../errors'
 import type { Account, Address, Chain, GetAccountParameter } from '../../types'
 import { parseGwei } from '../unit/parseGwei'
@@ -43,8 +43,9 @@ export async function prepareRequest<
   TParameters extends PrepareRequestParameters<TAccount>,
 >(
   client:
-    | WalletClient<Transport, TChain, TAccount>
-    | PublicClient<Transport, TChain>,
+    | PublicClient<TChain>
+    | WalletClient<TChain, TAccount>
+    | Client<TChain>,
   args: TParameters,
 ): Promise<PrepareRequestReturnType<TAccount, TParameters>> {
   const {


### PR DESCRIPTION
Allows `Client` type to be used with public and wallet actions for maximum tree shakeability.

```ts
const client = createClient({
  chain: mainnet,
  transport: http(),
})
const res = await readContract(client, {
  abi: seaportAbi,
  address: '0x',
  functionName: 'name',
})
```

Doesn't work with test actions right now since they have a more complex type set up (e.g. `mode`).

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0dff606</samp>

### Summary
🧪🔄🤝

<!--
1.  🧪 - This emoji represents the addition of tests for the actions module using the `vitest` framework. The test tube emoji conveys the idea of experimentation and verification of the code functionality.
2.  🔄 - This emoji represents the refactoring and reordering of the generic type parameters in some of the functions and types. The clockwise arrows emoji conveys the idea of changing the order or direction of something.
3.  🤝 - This emoji represents the broadening of the compatibility and flexibility of the functions and types to handle different types of clients. The handshake emoji conveys the idea of cooperation and agreement between different parties.
-->
This pull request enhances the compatibility and flexibility of the actions module by refactoring the functions to accept different types of clients from the `clients` module. It also adds tests for the actions module using the `vitest` framework. It affects the files in the `src/actions` directory and the new file `src/actions/actions.test-d.ts`.

> _`Client` type expands_
> _Actions work with many kinds_
> _Autumn of refactor_

### Walkthrough
*  Add tests for the actions module using the `vitest` framework in a new file `actions.test-d.ts` ([link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-9be828c79a3e9cb54e0a72ca39bc5933f5b52f961fcef1647d0b15aa2fe09333R1-R87))
*  Refactor the actions module to accept more generic `Client` types instead of only `PublicClient` or `WalletClient` types, to make the actions more flexible and compatible with different types of clients ([link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-558e56c3ceef347752e66c0124345f4d02234267e325955259ecffc1abfa7b2bL1-R4), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-558e56c3ceef347752e66c0124345f4d02234267e325955259ecffc1abfa7b2bL35-R35), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-17ff3b62185b07d342d7707332e62fec346aa1eb8dbb0c770b4621dba08081f2L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-17ff3b62185b07d342d7707332e62fec346aa1eb8dbb0c770b4621dba08081f2L19-R19), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-428143195eda69a05b80e12e8f52b2ff65180e206b076f4700d9e0c9eee00d70L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-428143195eda69a05b80e12e8f52b2ff65180e206b076f4700d9e0c9eee00d70L35-R35), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-6d2c0a21a207456eda46155682c095538a26ee6600634a2f21ee5d998223c72dL1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-6d2c0a21a207456eda46155682c095538a26ee6600634a2f21ee5d998223c72dL22-R22), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-75dbee1a05e5b8710a64fd8da1e94e9544bcf870299d83bea3554a7cf85ec992L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-75dbee1a05e5b8710a64fd8da1e94e9544bcf870299d83bea3554a7cf85ec992L42-R42), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-545e9b42d9b9f1f196aa9e12769154c35389844ad9f9d20a86dbcecce9c38e7aL1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-545e9b42d9b9f1f196aa9e12769154c35389844ad9f9d20a86dbcecce9c38e7aL52-R52), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-bce6a737c5425184b59b0ba5170f9a123e954dfd0b19bc6d950a1a48e63989c1L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-bce6a737c5425184b59b0ba5170f9a123e954dfd0b19bc6d950a1a48e63989c1L7-R7), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-47e3c49e8adfd745a0384baee8a6f5c3a1afc04ac0d2d553e343915f668e8a48L2-R2), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-47e3c49e8adfd745a0384baee8a6f5c3a1afc04ac0d2d553e343915f668e8a48L60-R60), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-ded6f6275e27ded192fd123043e47172886f1bc3d21a75cb54fc88e73675463cL2-R2), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-ded6f6275e27ded192fd123043e47172886f1bc3d21a75cb54fc88e73675463cL74-R74), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-938d780d4707c767e5396a5bb54909d972ec61e867964acd9d1b4834cd47cd84L3-R3), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-938d780d4707c767e5396a5bb54909d972ec61e867964acd9d1b4834cd47cd84L29-R29), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-36f01eca8a5ff7e486002007e5e9fadbef91a2baabd7a6553b346431ecd1f376L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-36f01eca8a5ff7e486002007e5e9fadbef91a2baabd7a6553b346431ecd1f376L27-R27), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-0299f67471966ca93786d9ff0abba9ea4b59fb59314ed2216e37e5a1c3d37561L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-0299f67471966ca93786d9ff0abba9ea4b59fb59314ed2216e37e5a1c3d37561L22-R22), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-324fb45a9dcceb5fc4e4c6f019a3fd6e727f55f581ca4112694eb5b9a065827cL1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-324fb45a9dcceb5fc4e4c6f019a3fd6e727f55f581ca4112694eb5b9a065827cL30-R30), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-0d90fc924984d5585cd474ec35c98b162c5477c596dc588b5ac5b116297e04c9L1-R1), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-0d90fc924984d5585cd474ec35c98b162c5477c596dc588b5ac5b116297e04c9L21-R21))
*  Update the order of the generic type parameters in the `getContract` function and the `GetContractParameters` type to match the order of the `Client` type, which is `TChain`, `TAccount`, `TTransport`, for consistency and ease of use ([link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-a1828dde770bf4dff63ad714b898138f40c37f278f6c91500612a9174ddb8c04L48-R54), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-a1828dde770bf4dff63ad714b898138f40c37f278f6c91500612a9174ddb8c04L204-R212), [link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-a1828dde770bf4dff63ad714b898138f40c37f278f6c91500612a9174ddb8c04L220-R222))
*  Update the order of the generic type parameters in the `createPendingTransactionFilter` function to match the order of the `Client` type, which is `TChain`, `TTransport`, for consistency and ease of use ([link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-64e44cdb806ccbbea7ae772237c22103d071f919dcf4b3349c9bd61e46818cb3L7-R10))
*  Add a comma after the `trim` import from the `utils` module in the `getEnsAddress` file to follow the code style and formatting rules ([link](https://github.com/wagmi-dev/viem/pull/314/files?diff=unified&w=0#diff-558e56c3ceef347752e66c0124345f4d02234267e325955259ecffc1abfa7b2bL12-R12))

