### PR TITLE
fix: skip invalid logs

### DIFF
--- a/.changeset/spotty-chefs-glow.md
+++ b/.changeset/spotty-chefs-glow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where filtered logs that do not conform to the provided ABI would cause `getLogs`, `getFilterLogs` or `getFilterChanges` to throw – these logs are now skipped. See [#323](https://github.com/wagmi-dev/viem/issues/323#issuecomment-1499654052) for more info.

--- a/contracts/src/ERC20InvalidTransferEvent.sol
+++ b/contracts/src/ERC20InvalidTransferEvent.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+contract ERC20InvalidTransferEvent {
+    // Non-conforming `to` parameter (not indexed).
+    event Transfer(address indexed from, address to, uint256 value);
+
+    function transfer(address recipient, uint256 amount) public {
+        emit Transfer(msg.sender, recipient, amount);
+        return;
+    }
+}

--- a/src/_test/index.ts
+++ b/src/_test/index.ts
@@ -22,6 +22,7 @@ export {
   deploy,
   deployBAYC,
   deployEnsAvatarTokenUri,
+  deployErc20InvalidTransferEvent,
   publicClient,
   testClient,
   walletClient,

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -1,6 +1,7 @@
 /* c8 ignore start */
 import type { Abi } from 'abitype'
 import ensAvatarTokenUri from '../../contracts/out/EnsAvatarTokenUri.sol/EnsAvatarTokenUri.json'
+import erc20InvalidTransferEvent from '../../contracts/out/ERC20InvalidTransferEvent.sol/ERC20InvalidTransferEvent.json'
 import errorsExample from '../../contracts/out/ErrorsExample.sol/ErrorsExample.json'
 import {
   deployContract,
@@ -26,7 +27,11 @@ import { RpcError } from '../types/eip1193'
 import { rpc } from '../utils'
 import { baycContractConfig, ensRegistryConfig } from './abis'
 import { accounts, address, localWsUrl } from './constants'
-import { ensAvatarTokenUriABI, errorsExampleABI } from './generated'
+import {
+  ensAvatarTokenUriABI,
+  erc20InvalidTransferEventABI,
+  errorsExampleABI,
+} from './generated'
 
 import type { RequestListener } from 'http'
 import { createServer } from 'http'
@@ -186,6 +191,14 @@ export async function deployEnsAvatarTokenUri() {
   return deploy({
     abi: ensAvatarTokenUriABI,
     bytecode: ensAvatarTokenUri.bytecode.object as Hex,
+    account: accounts[0].address,
+  })
+}
+
+export async function deployErc20InvalidTransferEvent() {
+  return deploy({
+    abi: erc20InvalidTransferEventABI,
+    bytecode: erc20InvalidTransferEvent.bytecode.object as Hex,
     account: accounts[0].address,
   })
 }

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -3,12 +3,14 @@ import { afterAll, assertType, beforeAll, describe, expect, test } from 'vitest'
 import {
   accounts,
   address,
+  deployErc20InvalidTransferEvent,
   initialBlockNumber,
   publicClient,
   testClient,
   walletClient,
   usdcContractConfig,
 } from '../../_test'
+import { erc20InvalidTransferEventABI } from '../../_test/generated'
 
 import {
   impersonateAccount,
@@ -35,6 +37,27 @@ const event = {
       },
       {
         indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  invalid: {
+    inputs: [
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: false,
         name: 'to',
         type: 'address',
       },
@@ -868,5 +891,75 @@ describe('events', () => {
       getAddress(accounts[0].address),
       1n,
     ])
+  })
+})
+
+describe('skip invalid logs', () => {
+  test('indexed params mismatch', async () => {
+    const { contractAddress } = await deployErc20InvalidTransferEvent()
+
+    const filter = await createEventFilter(publicClient, {
+      event: event.default,
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      abi: erc20InvalidTransferEventABI,
+      address: contractAddress!,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      abi: erc20InvalidTransferEventABI,
+      address: contractAddress!,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+
+    const logs = await getFilterChanges(publicClient, { filter })
+    assertType<Log[]>(logs)
+    expect(logs.length).toBe(1)
+  })
+
+  test('non-indexed params mismatch', async () => {
+    const { contractAddress } = await deployErc20InvalidTransferEvent()
+
+    const filter = await createEventFilter(publicClient, {
+      event: event.invalid,
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      abi: erc20InvalidTransferEventABI,
+      address: contractAddress!,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      abi: erc20InvalidTransferEventABI,
+      address: contractAddress!,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+
+    const logs = await getFilterChanges(publicClient, { filter })
+    assertType<Log[]>(logs)
+    expect(logs.length).toBe(2)
   })
 })

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -47,16 +47,28 @@ export async function getFilterChanges<
     method: 'eth_getFilterChanges',
     params: [filter.id],
   })
-  return logs.map((log) => {
-    if (typeof log === 'string') return log
-    const { eventName, args } =
-      'abi' in filter && filter.abi
-        ? decodeEventLog({
-            abi: filter.abi,
-            data: log.data,
-            topics: log.topics as any,
-          })
-        : { eventName: undefined, args: undefined }
-    return formatLog(log, { args, eventName })
-  }) as GetFilterChangesReturnType<TFilterType, TAbiEvent, TAbi, TEventName>
+  return logs
+    .map((log) => {
+      if (typeof log === 'string') return log
+      try {
+        const { eventName, args } =
+          'abi' in filter && filter.abi
+            ? decodeEventLog({
+                abi: filter.abi,
+                data: log.data,
+                topics: log.topics as any,
+              })
+            : { eventName: undefined, args: undefined }
+        return formatLog(log, { args, eventName })
+      } catch {
+        // Skip log if there is an error decoding (e.g. indexed/non-indexed params mismatch).
+        return
+      }
+    })
+    .filter(Boolean) as GetFilterChangesReturnType<
+    TFilterType,
+    TAbiEvent,
+    TAbi,
+    TEventName
+  >
 }

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -31,15 +31,26 @@ export async function getFilterLogs<
     method: 'eth_getFilterLogs',
     params: [filter.id],
   })
-  return logs.map((log) => {
-    const { eventName, args } =
-      'abi' in filter && filter.abi
-        ? decodeEventLog({
-            abi: filter.abi,
-            data: log.data,
-            topics: log.topics as any,
-          })
-        : { eventName: undefined, args: undefined }
-    return formatLog(log, { args, eventName })
-  }) as unknown as GetFilterLogsReturnType<TAbiEvent, TAbi, TEventName>
+  return logs
+    .map((log) => {
+      try {
+        const { eventName, args } =
+          'abi' in filter && filter.abi
+            ? decodeEventLog({
+                abi: filter.abi,
+                data: log.data,
+                topics: log.topics as any,
+              })
+            : { eventName: undefined, args: undefined }
+        return formatLog(log, { args, eventName })
+      } catch {
+        // Skip log if there is an error decoding (e.g. indexed/non-indexed params mismatch).
+        return
+      }
+    })
+    .filter(Boolean) as unknown as GetFilterLogsReturnType<
+    TAbiEvent,
+    TAbi,
+    TEventName
+  >
 }

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -98,14 +98,22 @@ export async function getLogs<
       ],
     })
   }
-  return logs.map((log) => {
-    const { eventName, args } = event
-      ? decodeEventLog({
-          abi: [event],
-          data: log.data,
-          topics: log.topics as any,
-        })
-      : { eventName: undefined, args: undefined }
-    return formatLog(log, { args, eventName })
-  }) as unknown as GetLogsReturnType<TAbiEvent>
+
+  return logs
+    .map((log) => {
+      try {
+        const { eventName, args } = event
+          ? decodeEventLog({
+              abi: [event],
+              data: log.data,
+              topics: log.topics as any,
+            })
+          : { eventName: undefined, args: undefined }
+        return formatLog(log, { args, eventName })
+      } catch {
+        // Skip log if there is an error decoding (e.g. indexed/non-indexed params mismatch).
+        return
+      }
+    })
+    .filter(Boolean) as unknown as GetLogsReturnType<TAbiEvent>
 }

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -46,7 +46,7 @@ test('default', async () => {
         "status": "success",
       },
       {
-        "result": 231481998553n,
+        "result": 231481998547n,
         "status": "success",
       },
       {
@@ -81,7 +81,7 @@ test('args: allowFailure', async () => {
   ).toMatchInlineSnapshot(`
     [
       41119586940119550n,
-      231481998553n,
+      231481998547n,
       10000n,
     ]
   `)
@@ -115,7 +115,7 @@ test('args: multicallAddress', async () => {
         "status": "success",
       },
       {
-        "result": 231481998553n,
+        "result": 231481998547n,
         "status": "success",
       },
       {
@@ -168,7 +168,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998553n,
+            "result": 231481998547n,
             "status": "success",
           },
           {
@@ -222,7 +222,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998553n,
+            "result": 231481998547n,
             "status": "success",
           },
           {
@@ -276,7 +276,7 @@ describe('errors', async () => {
             "status": "failure",
           },
           {
-            "result": 231481998553n,
+            "result": 231481998547n,
             "status": "success",
           },
           {
@@ -321,11 +321,11 @@ describe('errors', async () => {
       ).toMatchInlineSnapshot(`
         [
           {
-            "result": 231481998553n,
+            "result": 231481998547n,
             "status": "success",
           },
           {
-            "result": 231481998553n,
+            "result": 231481998547n,
             "status": "success",
           },
           {

--- a/src/errors/abi.test.ts
+++ b/src/errors/abi.test.ts
@@ -13,7 +13,9 @@ import {
 } from './abi'
 
 test('AbiDecodingDataSizeInvalidError', () => {
-  expect(new AbiDecodingDataSizeInvalidError({ data: '0x1234', size: 2 })).toMatchInlineSnapshot(`
+  expect(
+    new AbiDecodingDataSizeInvalidError({ data: '0x1234', size: 2 }),
+  ).toMatchInlineSnapshot(`
     [AbiDecodingDataSizeInvalidError: Data size of 2 bytes is invalid.
     Size must be in increments of 32 bytes (size % 32 === 0).
 
@@ -24,7 +26,16 @@ test('AbiDecodingDataSizeInvalidError', () => {
 })
 
 test('AbiDecodingDataSizeTooSmallError', () => {
-  expect(new AbiDecodingDataSizeTooSmallError({ data: '0x1234', params: [{ name: 'a', type: 'uint256' }, { name: 'b', type: 'uint256' }], size: 2 })).toMatchInlineSnapshot(`
+  expect(
+    new AbiDecodingDataSizeTooSmallError({
+      data: '0x1234',
+      params: [
+        { name: 'a', type: 'uint256' },
+        { name: 'b', type: 'uint256' },
+      ],
+      size: 2,
+    }),
+  ).toMatchInlineSnapshot(`
     [AbiDecodingDataSizeTooSmallError: Data size of 2 bytes is too small for given parameters.
 
     Params: (uint256 a, uint256 b)
@@ -89,7 +100,16 @@ test('AbiEventSignatureEmptyTopicsError', () => {
 })
 
 test('DecodeLogDataMismatch', () => {
-  expect(new DecodeLogDataMismatch({ data: '0x1234', params: [{ name: 'a', type: 'uint256' }, { name: 'b', type: 'uint256' }], size: 2 })).toMatchInlineSnapshot(`
+  expect(
+    new DecodeLogDataMismatch({
+      data: '0x1234',
+      params: [
+        { name: 'a', type: 'uint256' },
+        { name: 'b', type: 'uint256' },
+      ],
+      size: 2,
+    }),
+  ).toMatchInlineSnapshot(`
     [DecodeLogDataMismatch: Data size of 2 bytes is too small for non-indexed event parameters.
 
     This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.

--- a/src/errors/abi.test.ts
+++ b/src/errors/abi.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import {
   AbiDecodingDataSizeInvalidError,
+  AbiDecodingDataSizeTooSmallError,
   AbiEncodingArrayLengthMismatchError,
   AbiEncodingLengthMismatchError,
   AbiEventSignatureEmptyTopicsError,
+  DecodeLogDataMismatch,
   DecodeLogTopicsMismatch,
   InvalidAbiDecodingTypeError,
   InvalidAbiEncodingTypeError,
@@ -11,9 +13,22 @@ import {
 } from './abi'
 
 test('AbiDecodingDataSizeInvalidError', () => {
-  expect(new AbiDecodingDataSizeInvalidError(69)).toMatchInlineSnapshot(`
-    [AbiDecodingDataSizeInvalidError: Data size of 69 bytes is invalid.
+  expect(new AbiDecodingDataSizeInvalidError({ data: '0x1234', size: 2 })).toMatchInlineSnapshot(`
+    [AbiDecodingDataSizeInvalidError: Data size of 2 bytes is invalid.
     Size must be in increments of 32 bytes (size % 32 === 0).
+
+    Data: 0x1234 (2 bytes)
+
+    Version: viem@1.0.2]
+  `)
+})
+
+test('AbiDecodingDataSizeTooSmallError', () => {
+  expect(new AbiDecodingDataSizeTooSmallError({ data: '0x1234', params: [{ name: 'a', type: 'uint256' }, { name: 'b', type: 'uint256' }], size: 2 })).toMatchInlineSnapshot(`
+    [AbiDecodingDataSizeTooSmallError: Data size of 2 bytes is too small for given parameters.
+
+    Params: (uint256 a, uint256 b)
+    Data:   0x1234 (2 bytes)
 
     Version: viem@1.0.2]
   `)
@@ -69,6 +84,19 @@ test('AbiEventSignatureEmptyTopicsError', () => {
     [AbiEventSignatureEmptyTopicsError: Cannot extract event signature from empty topics.
 
     Docs: https://viem.sh/test.html
+    Version: viem@1.0.2]
+  `)
+})
+
+test('DecodeLogDataMismatch', () => {
+  expect(new DecodeLogDataMismatch({ data: '0x1234', params: [{ name: 'a', type: 'uint256' }, { name: 'b', type: 'uint256' }], size: 2 })).toMatchInlineSnapshot(`
+    [DecodeLogDataMismatch: Data size of 2 bytes is too small for non-indexed event parameters.
+
+    This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.
+
+    Params: (uint256 a, uint256 b)
+    Data:   0x1234 (2 bytes)
+
     Version: viem@1.0.2]
   `)
 })

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -1,6 +1,6 @@
 import type { AbiParameter } from 'abitype'
 import type { AbiItem, Hex } from '../types'
-import { formatAbiItem, size } from '../utils'
+import { formatAbiItem, formatAbiParams, size } from '../utils'
 import { BaseError } from './base'
 
 export class AbiConstructorNotFoundError extends BaseError {
@@ -35,13 +35,44 @@ export class AbiConstructorParamsNotFoundError extends BaseError {
 
 export class AbiDecodingDataSizeInvalidError extends BaseError {
   name = 'AbiDecodingDataSizeInvalidError'
-  constructor(size: number) {
+  constructor({ data, size }: { data: Hex; size: number }) {
     super(
       [
         `Data size of ${size} bytes is invalid.`,
         'Size must be in increments of 32 bytes (size % 32 === 0).',
       ].join('\n'),
+      { metaMessages: [`Data: ${data} (${size} bytes)`] },
     )
+  }
+}
+
+export class AbiDecodingDataSizeTooSmallError extends BaseError {
+  name = 'AbiDecodingDataSizeTooSmallError'
+
+  data: Hex
+  params: readonly AbiParameter[]
+  size: number
+
+  constructor({
+    data,
+    params,
+    size,
+  }: { data: Hex; params: readonly AbiParameter[]; size: number }) {
+    super(
+      [`Data size of ${size} bytes is too small for given parameters.`].join(
+        '\n',
+      ),
+      {
+        metaMessages: [
+          `Params: (${formatAbiParams(params, { includeName: true })})`,
+          `Data:   ${data} (${size} bytes)`,
+        ],
+      },
+    )
+
+    this.data = data
+    this.params = params
+    this.size = size
   }
 }
 
@@ -237,6 +268,38 @@ export class BytesSizeMismatchError extends BaseError {
     givenSize,
   }: { expectedSize: number; givenSize: number }) {
     super(`Expected bytes${expectedSize}, got bytes${givenSize}.`)
+  }
+}
+
+export class DecodeLogDataMismatch extends BaseError {
+  name = 'DecodeLogDataMismatch'
+
+  data: Hex
+  params: readonly AbiParameter[]
+  size: number
+
+  constructor({
+    data,
+    params,
+    size,
+  }: { data: Hex; params: readonly AbiParameter[]; size: number }) {
+    super(
+      [
+        `Data size of ${size} bytes is too small for non-indexed event parameters.`,
+      ].join('\n'),
+      {
+        metaMessages: [
+          'This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.',
+          '',
+          `Params: (${formatAbiParams(params, { includeName: true })})`,
+          `Data:   ${data} (${size} bytes)`,
+        ],
+      },
+    )
+
+    this.data = data
+    this.params = params
+    this.size = size
   }
 }
 

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -2,6 +2,7 @@ export {
   AbiConstructorNotFoundError,
   AbiConstructorParamsNotFoundError,
   AbiDecodingDataSizeInvalidError,
+  AbiDecodingDataSizeTooSmallError,
   AbiDecodingZeroDataError,
   AbiEncodingArrayLengthMismatchError,
   AbiEncodingBytesSizeMismatchError,

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -1964,6 +1964,24 @@ test('invalid size', () => {
     "Data size of 35 bytes is invalid.
     Size must be in increments of 32 bytes (size % 32 === 0).
 
+    Data: 0x0000000000000000000000000000000000000000000000000000000000010fabababab (35 bytes)
+
+    Version: viem@1.0.2"
+  `)
+})
+
+test('data size too small', () => {
+  expect(() =>
+    decodeAbiParameters(
+      [{ type: 'uint256' }, { type: 'uint256' }],
+      '0x0000000000000000000000000000000000000000000000000000000000010f2c',
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Data size of 32 bytes is too small for given parameters.
+
+    Params: (uint256, uint256)
+    Data:   0x0000000000000000000000000000000000000000000000000000000000010f2c (32 bytes)
+
     Version: viem@1.0.2"
   `)
 })

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -490,6 +490,57 @@ describe('GitHub repros', () => {
       )
     })
   })
+
+  describe('https://github.com/wagmi-dev/viem/issues/323', () => {
+    test('data + params mismatch', () => {
+      expect(() =>
+        decodeEventLog({
+          abi: [
+            {
+              anonymous: false,
+              inputs: [
+                {
+                  indexed: true,
+                  internalType: 'address',
+                  name: 'from',
+                  type: 'address',
+                },
+                {
+                  indexed: false,
+                  internalType: 'address',
+                  name: 'to',
+                  type: 'address',
+                },
+                {
+                  indexed: false,
+                  internalType: 'uint256',
+                  name: 'id',
+                  type: 'uint256',
+                },
+              ],
+              name: 'Transfer',
+              type: 'event',
+            },
+          ],
+          data: '0x0000000000000000000000000000000000000000000000000000000023c34600',
+          topics: [
+            '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+            '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+            '0x00000000000000000000000070e8a65d014918798ba424110d5df658cde1cc58',
+          ],
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(`
+        "Data size of 32 bytes is too small for non-indexed event parameters.
+
+        This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.
+
+        Params: (address to, uint256 id)
+        Data:   0x0000000000000000000000000000000000000000000000000000000023c34600 (32 bytes)
+
+        Version: viem@1.0.2"
+      `)
+    })
+  })
 })
 
 test("errors: event doesn't exist", () => {
@@ -545,6 +596,50 @@ test('errors: no topics', () => {
     "Cannot extract event signature from empty topics.
 
     Docs: https://viem.sh/docs/contract/decodeEventLog.html
+    Version: viem@1.0.2"
+  `)
+})
+
+test("errors: invalid data size", () => {
+  expect(() =>
+    decodeEventLog({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'tokenId',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      data: '0x1',
+      eventName: 'Transfer',
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      ],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Data size of 1 bytes is invalid.
+    Size must be in increments of 32 bytes (size % 32 === 0).
+
+    Data: 0x1 (1 bytes)
+
     Version: viem@1.0.2"
   `)
 })

--- a/src/utils/abi/formatAbiItem.test.ts
+++ b/src/utils/abi/formatAbiItem.test.ts
@@ -1,46 +1,32 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
-import { formatAbiItem } from './formatAbiItem'
+import { formatAbiItem, formatAbiParams } from './formatAbiItem'
 
-test('foo()', () => {
-  expect(
-    // @ts-expect-error
-    formatAbiItem({
-      name: 'foo',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'function',
-    }),
-  ).toEqual('foo()')
-  expect(
-    formatAbiItem({
-      inputs: [],
-      name: 'foo',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'function',
-    }),
-  ).toEqual('foo()')
-})
-
-test('foo(uint256)', () => {
-  expect(
-    formatAbiItem({
-      inputs: [
-        {
-          name: 'a',
-          type: 'uint256',
-        },
-      ],
-      name: 'foo',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'function',
-    }),
-  ).toEqual('foo(uint256)')
-  expect(
-    formatAbiItem(
-      {
+describe('formatAbiItem', () => {
+  test('foo()', () => {
+    expect(
+      // @ts-expect-error
+      formatAbiItem({
+        name: 'foo',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      }),
+    ).toEqual('foo()')
+    expect(
+      formatAbiItem({
+        inputs: [],
+        name: 'foo',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      }),
+    ).toEqual('foo()')
+  })
+  
+  test('foo(uint256)', () => {
+    expect(
+      formatAbiItem({
         inputs: [
           {
             name: 'a',
@@ -51,56 +37,30 @@ test('foo(uint256)', () => {
         outputs: [],
         stateMutability: 'nonpayable',
         type: 'function',
-      },
-      { includeName: true },
-    ),
-  ).toEqual('foo(uint256 a)')
-})
-
-test('getVoter((uint256,bool,address,uint256),string[],bytes)', () => {
-  expect(
-    formatAbiItem({
-      inputs: [
+      }),
+    ).toEqual('foo(uint256)')
+    expect(
+      formatAbiItem(
         {
-          components: [
+          inputs: [
             {
-              name: 'weight',
-              type: 'uint256',
-            },
-            {
-              name: 'voted',
-              type: 'bool',
-            },
-            {
-              name: 'delegate',
-              type: 'address',
-            },
-            {
-              name: 'vote',
+              name: 'a',
               type: 'uint256',
             },
           ],
-          name: 'voter',
-          type: 'tuple',
-        },
-        {
           name: 'foo',
-          type: 'string[]',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
         },
-        {
-          name: 'bar',
-          type: 'bytes',
-        },
-      ],
-      name: 'getVoter',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'function',
-    }),
-  ).toEqual('getVoter((uint256,bool,address,uint256),string[],bytes)')
-  expect(
-    formatAbiItem(
-      {
+        { includeName: true },
+      ),
+    ).toEqual('foo(uint256 a)')
+  })
+  
+  test('getVoter((uint256,bool,address,uint256),string[],bytes)', () => {
+    expect(
+      formatAbiItem({
         inputs: [
           {
             components: [
@@ -137,58 +97,58 @@ test('getVoter((uint256,bool,address,uint256),string[],bytes)', () => {
         outputs: [],
         stateMutability: 'nonpayable',
         type: 'function',
-      },
-      { includeName: true },
-    ),
-  ).toEqual(
-    'getVoter((uint256 weight, bool voted, address delegate, uint256 vote), string[] foo, bytes bar)',
-  )
-})
-
-test('VoterEvent((uint256,bool,address,uint256),string[],bytes)', () => {
-  expect(
-    formatAbiItem({
-      inputs: [
+      }),
+    ).toEqual('getVoter((uint256,bool,address,uint256),string[],bytes)')
+    expect(
+      formatAbiItem(
         {
-          components: [
+          inputs: [
             {
-              name: 'weight',
-              type: 'uint256',
+              components: [
+                {
+                  name: 'weight',
+                  type: 'uint256',
+                },
+                {
+                  name: 'voted',
+                  type: 'bool',
+                },
+                {
+                  name: 'delegate',
+                  type: 'address',
+                },
+                {
+                  name: 'vote',
+                  type: 'uint256',
+                },
+              ],
+              name: 'voter',
+              type: 'tuple',
             },
             {
-              name: 'voted',
-              type: 'bool',
+              name: 'foo',
+              type: 'string[]',
             },
             {
-              name: 'delegate',
-              type: 'address',
-            },
-            {
-              name: 'vote',
-              type: 'uint256',
+              name: 'bar',
+              type: 'bytes',
             },
           ],
-          name: 'voter',
-          type: 'tuple',
+          name: 'getVoter',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
         },
-        {
-          name: 'foo',
-          type: 'string[]',
-        },
-        {
-          name: 'bar',
-          type: 'bytes',
-        },
-      ],
-      name: 'VoterEvent',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'event',
-    }),
-  ).toEqual('VoterEvent((uint256,bool,address,uint256),string[],bytes)')
-  expect(
-    formatAbiItem(
-      {
+        { includeName: true },
+      ),
+    ).toEqual(
+      'getVoter((uint256 weight, bool voted, address delegate, uint256 vote), string[] foo, bytes bar)',
+    )
+  })
+  
+  test('VoterEvent((uint256,bool,address,uint256),string[],bytes)', () => {
+    expect(
+      formatAbiItem({
         inputs: [
           {
             components: [
@@ -225,73 +185,189 @@ test('VoterEvent((uint256,bool,address,uint256),string[],bytes)', () => {
         outputs: [],
         stateMutability: 'nonpayable',
         type: 'event',
-      },
-      { includeName: true },
-    ),
-  ).toEqual(
-    'VoterEvent((uint256 weight, bool voted, address delegate, uint256 vote), string[] foo, bytes bar)',
-  )
-})
-
-test('VoterError((uint256,bool,address,uint256),string[],bytes)', () => {
-  expect(
-    formatAbiItem({
-      inputs: [
+      }),
+    ).toEqual('VoterEvent((uint256,bool,address,uint256),string[],bytes)')
+    expect(
+      formatAbiItem(
         {
-          components: [
+          inputs: [
             {
-              name: 'weight',
-              type: 'uint256',
+              components: [
+                {
+                  name: 'weight',
+                  type: 'uint256',
+                },
+                {
+                  name: 'voted',
+                  type: 'bool',
+                },
+                {
+                  name: 'delegate',
+                  type: 'address',
+                },
+                {
+                  name: 'vote',
+                  type: 'uint256',
+                },
+              ],
+              name: 'voter',
+              type: 'tuple',
             },
             {
-              name: 'voted',
-              type: 'bool',
+              name: 'foo',
+              type: 'string[]',
             },
             {
-              name: 'delegate',
-              type: 'address',
-            },
-            {
-              name: 'vote',
-              type: 'uint256',
+              name: 'bar',
+              type: 'bytes',
             },
           ],
-          name: 'voter',
-          type: 'tuple',
+          name: 'VoterEvent',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'event',
         },
-        {
-          name: 'foo',
-          type: 'string[]',
-        },
-        {
-          name: 'bar',
-          type: 'bytes',
-        },
-      ],
-      name: 'VoterError',
-      outputs: [],
-      stateMutability: 'nonpayable',
-      type: 'error',
-    }),
-  ).toEqual('VoterError((uint256,bool,address,uint256),string[],bytes)')
+        { includeName: true },
+      ),
+    ).toEqual(
+      'VoterEvent((uint256 weight, bool voted, address delegate, uint256 vote), string[] foo, bytes bar)',
+    )
+  })
+  
+  test('VoterError((uint256,bool,address,uint256),string[],bytes)', () => {
+    expect(
+      formatAbiItem({
+        inputs: [
+          {
+            components: [
+              {
+                name: 'weight',
+                type: 'uint256',
+              },
+              {
+                name: 'voted',
+                type: 'bool',
+              },
+              {
+                name: 'delegate',
+                type: 'address',
+              },
+              {
+                name: 'vote',
+                type: 'uint256',
+              },
+            ],
+            name: 'voter',
+            type: 'tuple',
+          },
+          {
+            name: 'foo',
+            type: 'string[]',
+          },
+          {
+            name: 'bar',
+            type: 'bytes',
+          },
+        ],
+        name: 'VoterError',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'error',
+      }),
+    ).toEqual('VoterError((uint256,bool,address,uint256),string[],bytes)')
+  })
+  
+  test('error: invalid type', () => {
+    expect(() =>
+      formatAbiItem({
+        inputs: [
+          {
+            name: 'proposalNames',
+            type: 'bytes32[]',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "\\"constructor\\" is not a valid definition type.
+      Valid types: \\"function\\", \\"event\\", \\"error\\"
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('error: invalid type', () => {
-  expect(() =>
-    formatAbiItem({
-      inputs: [
-        {
-          name: 'proposalNames',
-          type: 'bytes32[]',
-        },
-      ],
-      stateMutability: 'nonpayable',
-      type: 'constructor',
-    }),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    "\\"constructor\\" is not a valid definition type.
-    Valid types: \\"function\\", \\"event\\", \\"error\\"
+describe('formatAbiParams', () => {
+  test('default', () => {
+    expect(formatAbiParams([{ name: 'a', type: 'uint256' }])).toMatchInlineSnapshot('"uint256"')
+    expect(formatAbiParams([
+      {
+        components: [
+          {
+            name: 'weight',
+            type: 'uint256',
+          },
+          {
+            name: 'voted',
+            type: 'bool',
+          },
+          {
+            name: 'delegate',
+            type: 'address',
+          },
+          {
+            name: 'vote',
+            type: 'uint256',
+          },
+        ],
+        name: 'voter',
+        type: 'tuple',
+      },
+      {
+        name: 'foo',
+        type: 'string[]',
+      },
+      {
+        name: 'bar',
+        type: 'bytes',
+      },
+    ])).toMatchInlineSnapshot('"(uint256,bool,address,uint256),string[],bytes"')
+  })
 
-    Version: viem@1.0.2"
-  `)
+  test('includeName', () => {
+    expect(formatAbiParams([{ name: 'a', type: 'uint256' }], { includeName: true })).toMatchInlineSnapshot('"uint256 a"')
+    expect(formatAbiParams([
+      {
+        components: [
+          {
+            name: 'weight',
+            type: 'uint256',
+          },
+          {
+            name: 'voted',
+            type: 'bool',
+          },
+          {
+            name: 'delegate',
+            type: 'address',
+          },
+          {
+            name: 'vote',
+            type: 'uint256',
+          },
+        ],
+        name: 'voter',
+        type: 'tuple',
+      },
+      {
+        name: 'foo',
+        type: 'string[]',
+      },
+      {
+        name: 'bar',
+        type: 'bytes',
+      },
+    ], { includeName: true })).toMatchInlineSnapshot('"(uint256 weight, bool voted, address delegate, uint256 vote), string[] foo, bytes bar"')
+  })
 })

--- a/src/utils/abi/formatAbiItem.ts
+++ b/src/utils/abi/formatAbiItem.ts
@@ -14,25 +14,25 @@ export function formatAbiItem(
   )
     throw new InvalidDefinitionTypeError(abiItem.type)
 
-  return `${abiItem.name}(${getParams(abiItem.inputs, { includeName })})`
+  return `${abiItem.name}(${formatAbiParams(abiItem.inputs, { includeName })})`
 }
 
-function getParams(
+export function formatAbiParams(
   params: readonly AbiParameter[] | undefined,
-  { includeName }: { includeName: boolean },
+  { includeName = false }: { includeName?: boolean } = {},
 ): string {
   if (!params) return ''
   return params
-    .map((param) => getParam(param, { includeName }))
+    .map((param) => formatAbiParam(param, { includeName }))
     .join(includeName ? ', ' : ',')
 }
 
-function getParam(
+function formatAbiParam(
   param: AbiParameter,
   { includeName }: { includeName: boolean },
 ): string {
   if (param.type.startsWith('tuple')) {
-    return `(${getParams(
+    return `(${formatAbiParams(
       (param as unknown as { components: AbiParameter[] }).components,
       { includeName },
     )})${param.type.slice('tuple'.length)}`

--- a/src/utils/abi/index.test.ts
+++ b/src/utils/abi/index.test.ts
@@ -19,6 +19,7 @@ test('exports utils', () => {
       "encodePacked": [Function],
       "formatAbiItem": [Function],
       "formatAbiItemWithArgs": [Function],
+      "formatAbiParams": [Function],
       "getAbiItem": [Function],
       "parseAbi": [Function],
       "parseAbiItem": [Function],

--- a/src/utils/abi/index.ts
+++ b/src/utils/abi/index.ts
@@ -57,7 +57,7 @@ export { encodePacked } from './encodePacked'
 
 export { formatAbiItemWithArgs } from './formatAbiItemWithArgs'
 
-export { formatAbiItem } from './formatAbiItem'
+export { formatAbiItem, formatAbiParams } from './formatAbiItem'
 
 export type { GetAbiItemParameters } from './getAbiItem'
 export { getAbiItem } from './getAbiItem'

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -49,6 +49,7 @@ test('exports utils', () => {
       "format": [Function],
       "formatAbiItem": [Function],
       "formatAbiItemWithArgs": [Function],
+      "formatAbiParams": [Function],
       "formatBlock": [Function],
       "formatEther": [Function],
       "formatGwei": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -34,6 +34,7 @@ export {
   encodePacked,
   formatAbiItemWithArgs,
   formatAbiItem,
+  formatAbiParams,
   getAbiItem,
   parseAbi,
   parseAbiItem,


### PR DESCRIPTION
Fixes #323.

- Skips event logs that do not conform to the given ABI filter
- Adds better error messaging for when ABI decoding `data` size is too short
- Adds better error messaging for when there is a mismatch between non-indexed arguments in the event ABI