### PR TITLE
feat: tweaked error inheritence for `UserRejectedRequestError` & `SwitchChainError`

### DIFF
--- a/.changeset/eleven-donkeys-lay.md
+++ b/.changeset/eleven-donkeys-lay.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Tweaked error inheritence for `UserRejectedRequestError` & `SwitchChainError` to be more friendly with custom errors.

--- a/src/errors/request.test.ts
+++ b/src/errors/request.test.ts
@@ -35,6 +35,9 @@ test('RequestError', () => {
   ).toMatchInlineSnapshot(`
     [RpcError: An internal error was received.
 
+    URL: http://localhost
+    Request body: {"foo":"bar"}
+
     Details: error details
     Version: viem@1.0.2]
   `)

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -13,7 +13,8 @@ export class RequestError extends BaseError {
     super(shortMessage, {
       cause: err,
       docsPath,
-      metaMessages: metaMessages || (err as { metaMessages?: string[] })?.metaMessages,
+      metaMessages:
+        metaMessages || (err as { metaMessages?: string[] })?.metaMessages,
     })
     this.name = err.name
   }

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -13,7 +13,7 @@ export class RequestError extends BaseError {
     super(shortMessage, {
       cause: err,
       docsPath,
-      metaMessages,
+      metaMessages: metaMessages || (err as { metaMessages?: string[] })?.metaMessages,
     })
     this.name = err.name
   }
@@ -26,7 +26,7 @@ export class RpcRequestError extends RequestError {
     err: RpcError,
     { docsPath, shortMessage }: { docsPath?: string; shortMessage: string },
   ) {
-    super(err, { docsPath, metaMessages: err.metaMessages, shortMessage })
+    super(err, { docsPath, shortMessage })
     this.code = err.code
     this.name = err.name
   }
@@ -157,22 +157,22 @@ export class JsonRpcVersionUnsupportedError extends RpcRequestError {
   }
 }
 
-export class UserRejectedRequestError extends RpcRequestError {
+export class UserRejectedRequestError extends RequestError {
   name = 'UserRejectedRequestError'
   code = 4001
 
-  constructor(err: RpcError) {
+  constructor(err: Error) {
     super(err, {
       shortMessage: 'User rejected the request.',
     })
   }
 }
 
-export class SwitchChainError extends RpcRequestError {
+export class SwitchChainError extends RequestError {
   name = 'SwitchChainError'
   code = 4902
 
-  constructor(err: RpcError) {
+  constructor(err: Error) {
     super(err, {
       shortMessage: 'An error occurred when attempting to switch chain.',
     })


### PR DESCRIPTION
As `UserRejectedRequestError` and `SwitchChainError` could come from another source (not just RPC – could be WalletConnect, Coinbase SDK, etc), making it so you can pass an arbitrary cause to these errors.