### PR TITLE
chore: use verbatim module syntax in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
   "references": [{ "path": "./tsconfig.node.json" }],
   "compilerOptions": {
     // Json import is used in `src/_test/utils.ts`.
-    "resolveJsonModule": true // TODO: Try to avoid this. Maybe generate .ts files for bytecode too with wagmi?
+    "resolveJsonModule": true, // TODO: Try to avoid this. Maybe generate .ts files for bytecode too with wagmi?
+    "verbatimModuleSyntax": true // Use explicit `type` imports & exports where applicable.
   }
 }


### PR DESCRIPTION
This causes `vscode` (and hopefully also other IDEs), to autocomplete type imports properly. We are not setting it in the `tsconfig.base.json` config because we don't want this for the `commonjs` build target.

So, setting it in `tsconfig.json` causes it to be considered by IDEs while still supporting the `commonjs` build target & setting it explicitly (using `--verabitmModuleSyntax`) for the ESM build target.