### PR TITLE
chore: remove isolated modules

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,7 +26,6 @@
     // Interop constraints
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "isolatedModules": true,
 
     // Language and environment
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
TIL: These two are not compatible (isolatedModules & verbatimModuleSyntax).