### PR TITLE
fix: conditional types for poll options

### DIFF
--- a/.changeset/funny-cars-provide.md
+++ b/.changeset/funny-cars-provide.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed conditional types for poll options on `watchBlocks` & `watchPendingTransactions`.

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -45,7 +45,7 @@ export type WatchBlocksParameters<
           poll?: false
           pollingInterval?: never
         }
-      | (PollOptions & { poll: true })
+      | (PollOptions & { poll?: true })
   : PollOptions & { poll?: true })
 
 export type WatchBlocksReturnType = () => void

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -36,7 +36,7 @@ export type WatchPendingTransactionsParameters<
           poll?: false
           pollingInterval?: never
         }
-      | (PollOptions & { poll: true })
+      | (PollOptions & { poll?: true })
   : PollOptions & {
       poll?: true
     })


### PR DESCRIPTION
Fixes #342 
Fixes #341 

This fixes the aforementioned issues. However (and without having looked into it & thought about it further yet), I think it would be better to remove knowledge of these transport specific options from the client completely. To me that looks like reversed coupling.