### PR TITLE
wip - fix: scope filters to their respective transport

### DIFF
--- a/.changeset/ten-roses-whisper.md
+++ b/.changeset/ten-roses-whisper.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Scoped filters to their respective transport.

--- a/src/actions/public/createBlockFilter.test.ts
+++ b/src/actions/public/createBlockFilter.test.ts
@@ -1,9 +1,48 @@
 import { expect, test } from 'vitest'
 
-import { publicClient } from '../../_test/index.js'
+import { createHttpServer, publicClient } from '../../_test/index.js'
 
 import { createBlockFilter } from './createBlockFilter.js'
+import { createPublicClient, fallback, http } from '../../clients/index.js'
 
 test('default', async () => {
   expect(await createBlockFilter(publicClient)).toBeDefined()
+})
+
+test('fallback client: scopes request', async () => {
+  let count1 = 0
+  const server1 = await createHttpServer((_req, res) => {
+    count1++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(
+      JSON.stringify({
+        error: { code: -32004, message: 'method not supported' },
+      }),
+    )
+  })
+
+  let count2 = 0
+  const server2 = await createHttpServer((_req, res) => {
+    count2++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(JSON.stringify({ result: '0x1' }))
+  })
+
+  const fallbackClient = createPublicClient({
+    transport: fallback([http(server1.url), http(server2.url)], {
+      rank: false,
+    }),
+  })
+  const filter = await createBlockFilter(fallbackClient)
+  expect(filter).toBeDefined()
+  expect(count1).toBe(1)
+  expect(count2).toBe(1)
+
+  await filter.request({ method: 'eth_getFilterChanges', params: [filter.id] })
+  expect(count1).toBe(1)
+  expect(count2).toBe(2)
 })

--- a/src/actions/public/createBlockFilter.ts
+++ b/src/actions/public/createBlockFilter.ts
@@ -1,4 +1,6 @@
 import type { PublicClient, Transport } from '../../clients/index.js'
+import type { OnResponseFn } from '../../clients/transports/fallback.js'
+import type { Requests } from '../../types/eip1193.js'
 import type { Chain, Filter } from '../../types/index.js'
 
 export type CreateBlockFilterReturnType = Filter<'block'>
@@ -6,8 +8,23 @@ export type CreateBlockFilterReturnType = Filter<'block'>
 export async function createBlockFilter<TChain extends Chain | undefined>(
   client: PublicClient<Transport, TChain>,
 ): Promise<CreateBlockFilterReturnType> {
+  let request = client.request
+
+  // If the transport is a fallback, we want to scope the request function
+  // to the successful child transport. This is because we want to keep the
+  // request function scoped & don't want to apply the fallback behavior to
+  // methods such as `eth_getFilterChanges`, `eth_getFilterLogs`, etc.
+  if (client.transport.type === 'fallback')
+    client.transport.onResponse(
+      ({ method, status, transport }: Parameters<OnResponseFn>[0]) => {
+        if (status === 'success' && method === 'eth_newBlockFilter') {
+          request = transport.request
+        }
+      },
+    )
+
   const id = await client.request({
     method: 'eth_newBlockFilter',
   })
-  return { id, type: 'block' }
+  return { id, request: request as Requests['request'], type: 'block' }
 }

--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -2,10 +2,13 @@ import { assertType, describe, expect, test } from 'vitest'
 
 import {
   accounts,
+  createHttpServer,
   initialBlockNumber,
   publicClient,
 } from '../../_test/index.js'
 import { createEventFilter } from './createEventFilter.js'
+import type { Requests } from '../../types/eip1193.js'
+import { createPublicClient, fallback, http } from '../../clients/index.js'
 
 const event = {
   default: {
@@ -49,11 +52,14 @@ const event = {
   },
 } as const
 
+const request = (() => {}) as unknown as Requests['request']
+
 describe('default', () => {
   test('no args', async () => {
     const filter = await createEventFilter(publicClient)
     assertType<typeof filter>({
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter.id).toBeDefined()
@@ -77,6 +83,7 @@ describe('default', () => {
       abi: [event.default],
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter.args).toBeUndefined()
@@ -100,6 +107,7 @@ describe('default', () => {
       },
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter.args).toEqual({
@@ -122,6 +130,7 @@ describe('default', () => {
       },
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter2.args).toEqual({
@@ -143,6 +152,7 @@ describe('default', () => {
       },
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter3.args).toEqual({
@@ -162,6 +172,7 @@ describe('default', () => {
       args: [accounts[0].address, accounts[1].address],
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter1.args).toEqual([accounts[0].address, accounts[1].address])
@@ -177,6 +188,7 @@ describe('default', () => {
       args: [[accounts[0].address, accounts[1].address]],
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter2.args).toEqual([[accounts[0].address, accounts[1].address]])
@@ -192,6 +204,7 @@ describe('default', () => {
       args: [null, accounts[0].address],
       eventName: 'Transfer',
       id: '0x',
+      request,
       type: 'event',
     })
     expect(filter3.args).toEqual([null, accounts[0].address])
@@ -220,4 +233,42 @@ describe('default', () => {
       toBlock: 'latest',
     })
   })
+})
+
+test('fallback client: scopes request', async () => {
+  let count1 = 0
+  const server1 = await createHttpServer((_req, res) => {
+    count1++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(
+      JSON.stringify({
+        error: { code: -32004, message: 'method not supported' },
+      }),
+    )
+  })
+
+  let count2 = 0
+  const server2 = await createHttpServer((_req, res) => {
+    count2++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(JSON.stringify({ result: '0x1' }))
+  })
+
+  const fallbackClient = createPublicClient({
+    transport: fallback([http(server1.url), http(server2.url)], {
+      rank: false,
+    }),
+  })
+  const filter = await createEventFilter(fallbackClient)
+  expect(filter).toBeDefined()
+  expect(count1).toBe(1)
+  expect(count2).toBe(1)
+
+  await filter.request({ method: 'eth_getFilterChanges', params: [filter.id] })
+  expect(count1).toBe(1)
+  expect(count2).toBe(2)
 })

--- a/src/actions/public/createPendingTransactionFilter.test.ts
+++ b/src/actions/public/createPendingTransactionFilter.test.ts
@@ -1,9 +1,48 @@
 import { expect, test } from 'vitest'
 
-import { publicClient } from '../../_test/index.js'
+import { createHttpServer, publicClient } from '../../_test/index.js'
 
 import { createPendingTransactionFilter } from './createPendingTransactionFilter.js'
+import { createPublicClient, fallback, http } from '../../clients/index.js'
 
 test('default', async () => {
   expect(await createPendingTransactionFilter(publicClient)).toBeDefined()
+})
+
+test('fallback client: scopes request', async () => {
+  let count1 = 0
+  const server1 = await createHttpServer((_req, res) => {
+    count1++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(
+      JSON.stringify({
+        error: { code: -32004, message: 'method not supported' },
+      }),
+    )
+  })
+
+  let count2 = 0
+  const server2 = await createHttpServer((_req, res) => {
+    count2++
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+    })
+    res.end(JSON.stringify({ result: '0x1' }))
+  })
+
+  const fallbackClient = createPublicClient({
+    transport: fallback([http(server1.url), http(server2.url)], {
+      rank: false,
+    }),
+  })
+  const filter = await createPendingTransactionFilter(fallbackClient)
+  expect(filter).toBeDefined()
+  expect(count1).toBe(1)
+  expect(count2).toBe(1)
+
+  await filter.request({ method: 'eth_getFilterChanges', params: [filter.id] })
+  expect(count1).toBe(1)
+  expect(count2).toBe(2)
 })

--- a/src/actions/public/createPendingTransactionFilter.ts
+++ b/src/actions/public/createPendingTransactionFilter.ts
@@ -1,4 +1,6 @@
 import type { PublicClient, Transport } from '../../clients/index.js'
+import type { OnResponseFn } from '../../clients/transports/fallback.js'
+import type { Requests } from '../../types/eip1193.js'
 import type { Chain, Filter } from '../../types/index.js'
 
 export type CreatePendingTransactionFilterReturnType = Filter<'transaction'>
@@ -9,8 +11,26 @@ export async function createPendingTransactionFilter<
 >(
   client: PublicClient<TTransport, TChain>,
 ): Promise<CreatePendingTransactionFilterReturnType> {
+  let request = client.request
+
+  // If the transport is a fallback, we want to scope the request function
+  // to the successful child transport. This is because we want to keep the
+  // request function scoped & don't want to apply the fallback behavior to
+  // methods such as `eth_getFilterChanges`, `eth_getFilterLogs`, etc.
+  if (client.transport.type === 'fallback')
+    client.transport.onResponse?.(
+      ({ method, status, transport }: Parameters<OnResponseFn>[0]) => {
+        if (
+          status === 'success' &&
+          method === 'eth_newPendingTransactionFilter'
+        ) {
+          request = transport.request
+        }
+      },
+    )
+
   const id = await client.request({
     method: 'eth_newPendingTransactionFilter',
   })
-  return { id, type: 'transaction' }
+  return { id, request: request as Requests['request'], type: 'transaction' }
 }

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -38,12 +38,12 @@ export async function getFilterChanges<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClient<TTransport, TChain>,
+  _client: PublicClient<TTransport, TChain>,
   {
     filter,
   }: GetFilterChangesParameters<TFilterType, TAbiEvent, TAbi, TEventName>,
 ) {
-  const logs = await client.request({
+  const logs = await filter.request({
     method: 'eth_getFilterChanges',
     params: [filter.id],
   })

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -29,10 +29,10 @@ export async function getFilterLogs<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
 >(
-  client: PublicClient<Transport, TChain>,
+  _client: PublicClient<Transport, TChain>,
   { filter }: GetFilterLogsParameters<TAbiEvent, TAbi, TEventName>,
 ): Promise<GetFilterLogsReturnType<TAbiEvent, TAbi, TEventName>> {
-  const logs = await client.request({
+  const logs = await filter.request({
     method: 'eth_getFilterLogs',
     params: [filter.id],
   })

--- a/src/actions/public/uninstallFilter.test.ts
+++ b/src/actions/public/uninstallFilter.test.ts
@@ -14,6 +14,9 @@ import { mine } from '../test/index.js'
 import { sendTransaction } from '../wallet/index.js'
 import { parseEther } from '../../utils/index.js'
 import type { Hash } from '../../types/index.js'
+import type { Requests } from '../../types/eip1193.js'
+
+const request = (() => {}) as unknown as Requests['request']
 
 test('default', async () => {
   const filter = await createPendingTransactionFilter(publicClient)
@@ -58,7 +61,7 @@ test('pending txns', async () => {
 test('filter does not exist', async () => {
   expect(
     await uninstallFilter(publicClient, {
-      filter: { id: '0x1', type: 'default' },
+      filter: { id: '0x1', request, type: 'default' },
     }),
   ).toBeFalsy()
 })

--- a/src/actions/public/uninstallFilter.ts
+++ b/src/actions/public/uninstallFilter.ts
@@ -10,10 +10,10 @@ export async function uninstallFilter<
   TTransport extends Transport,
   TChain extends Chain | undefined,
 >(
-  client: PublicClient<TTransport, TChain>,
+  _client: PublicClient<TTransport, TChain>,
   { filter }: UninstallFilterParameters,
 ): Promise<UninstallFilterReturnType> {
-  return client.request({
+  return filter.request({
     method: 'eth_uninstallFilter',
     params: [filter.id],
   })

--- a/src/clients/transports/fallback.test.ts
+++ b/src/clients/transports/fallback.test.ts
@@ -7,7 +7,7 @@ import { createPublicClient } from '../createPublicClient.js'
 import { getBlockNumber } from '../../actions/index.js'
 import { wait } from '../../utils/wait.js'
 import type { Transport } from './createTransport.js'
-import type { FallbackTransport } from './fallback.js'
+import type { FallbackTransport, OnResponseFn } from './fallback.js'
 import { fallback, rankTransports } from './fallback.js'
 import { http } from './http.js'
 
@@ -140,6 +140,79 @@ describe('request', () => {
 
     // ensure `retryCount` on transport is adhered
     expect(count).toBe(8)
+  })
+
+  test('onResponse', async () => {
+    let count = 0
+    const server1 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(500)
+      res.end()
+    })
+    const server2 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(500)
+      res.end()
+    })
+    const server3 = await createHttpServer((_req, res) => {
+      count++
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+      })
+      res.end(JSON.stringify({ result: '0x1' }))
+    })
+
+    const transport = fallback(
+      [http(server1.url), http(server2.url), http(server3.url)],
+      {
+        rank: false,
+      },
+    )({
+      chain: localhost,
+    })
+
+    const args: Parameters<OnResponseFn>[0][] = []
+    transport.value?.onResponse((args_) => args.push(args_))
+
+    expect(await transport.request({ method: 'eth_blockNumber' })).toBe('0x1')
+    expect(
+      args.map(({ transport: _transport, ...rest }) => rest),
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "error": [HttpRequestError: HTTP request failed.
+
+      Status: 500
+      URL: http://localhost
+      Request body: {"method":"eth_blockNumber"}
+
+      Details: Internal Server Error
+      Version: viem@1.0.2],
+          "method": "eth_blockNumber",
+          "params": undefined,
+          "type": "error",
+        },
+        {
+          "error": [HttpRequestError: HTTP request failed.
+
+      Status: 500
+      URL: http://localhost
+      Request body: {"method":"eth_blockNumber"}
+
+      Details: Internal Server Error
+      Version: viem@1.0.2],
+          "method": "eth_blockNumber",
+          "params": undefined,
+          "type": "error",
+        },
+        {
+          "method": "eth_blockNumber",
+          "params": undefined,
+          "response": "0x1",
+          "type": "success",
+        },
+      ]
+    `)
   })
 
   test('error (rpc)', async () => {

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -4,6 +4,26 @@ import { wait } from '../../utils/wait.js'
 import type { Transport, TransportConfig } from './createTransport.js'
 import { createTransport } from './createTransport.js'
 
+// TODO: Narrow `method` & `params` types.
+export type OnResponseFn = (
+  args: {
+    method: string
+    params: unknown[]
+    transport: ReturnType<Transport>
+  } & (
+    | {
+        error?: never
+        response: unknown
+        status: 'success'
+      }
+    | {
+        error: Error
+        response?: never
+        status: 'error'
+      }
+  ),
+) => void
+
 type RankOptions = {
   /**
    * The polling interval (in ms) at which the ranker should ping the RPC URL.
@@ -52,7 +72,10 @@ export type FallbackTransportConfig = {
 
 export type FallbackTransport = Transport<
   'fallback',
-  { transports: ReturnType<Transport>[] }
+  {
+    onResponse: (fn: OnResponseFn) => void
+    transports: ReturnType<Transport>[]
+  }
 >
 
 export function fallback(
@@ -69,6 +92,8 @@ export function fallback(
   return ({ chain, pollingInterval = 4_000, timeout }) => {
     let transports = transports_
 
+    let onResponse: OnResponseFn = () => {}
+
     const transport = createTransport(
       {
         key,
@@ -77,11 +102,29 @@ export function fallback(
           const fetch = async (i: number = 0): Promise<any> => {
             const transport = transports[i]({ chain, retryCount: 0, timeout })
             try {
-              return await transport.request({
+              const response = await transport.request({
                 method,
                 params,
               } as any)
+
+              onResponse({
+                method,
+                params: params as unknown[],
+                response,
+                transport,
+                status: 'success',
+              })
+
+              return response
             } catch (err) {
+              onResponse({
+                error: err,
+                method,
+                params: params as unknown[],
+                transport,
+                status: 'error',
+              })
+
               // If the error is deterministic, we don't need to fall back.
               // So throw the error.
               if (isDeterministicError(err as Error)) throw err
@@ -100,6 +143,7 @@ export function fallback(
         type: 'fallback',
       },
       {
+        onResponse: (fn: OnResponseFn) => (onResponse = fn),
         transports: transports.map((fn) => fn({ chain, retryCount: 0 })),
       },
     )

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -118,7 +118,7 @@ export function fallback(
               return response
             } catch (err) {
               onResponse({
-                error: err,
+                error: err as Error,
                 method,
                 params: params as unknown[],
                 transport,

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,6 +1,7 @@
 import type { Abi } from 'abitype'
 import type { MaybeExtractEventArgsFromAbi } from './contract.js'
 import type { Hex } from './misc.js'
+import type { Requests } from './eip1193.js'
 
 export type FilterType = 'transaction' | 'block' | 'event'
 
@@ -13,6 +14,8 @@ export type Filter<
     | undefined = MaybeExtractEventArgsFromAbi<TAbi, TEventName>,
 > = {
   id: Hex
+  // TODO: Narrow to only filter-based methods.
+  request: Requests['request']
   type: TFilterType
 } & (TFilterType extends 'event'
   ? TAbi extends Abi

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -21,7 +21,13 @@ import {
 import { withRetry } from './promise/index.js'
 
 export const isDeterministicError = (error: Error) => {
-  if ('code' in error) return error.code !== -32603 && error.code !== -32005
+  if ('code' in error)
+    return (
+      error.code !== -32603 &&
+      error.code !== -32004 &&
+      error.code !== -32042 &&
+      error.code !== -32005
+    )
   if (error instanceof HttpRequestError && error.status)
     return (
       error.status !== 408 &&
@@ -66,6 +72,7 @@ export function buildRequest<TRequest extends (args: any) => Promise<any>>(
           if (err.code === -32004) throw new MethodNotSupportedRpcError(err)
           if (err.code === -32005) throw new LimitExceededRpcError(err)
           if (err.code === -32006) throw new JsonRpcVersionUnsupportedError(err)
+          if (err.code === -32042) throw new MethodNotSupportedRpcError(err)
           if (err.code === 4001) throw new UserRejectedRequestError(err)
           if (err.code === 4902) throw new SwitchChainError(err)
           if (err_ instanceof BaseError) throw err_


### PR DESCRIPTION
This PR fixes an issue where filter querying (`eth_getFilterChanges`, etc) was not being scoped to their respective transport that created the filter. We need these transports to be the same as the RPC node has context of the filter id. This is easily reproducible using a fallback transport due to the fallback (& ranking) behavior.

We could possibly extend the `onResponse` transport hook to the other transports, but can just leave it as a private API (for this scenario) for now.

