### PR TITLE
feat: add inference to `getLogs` `event`

### DIFF
--- a/.changeset/seven-panthers-admire.md
+++ b/.changeset/seven-panthers-admire.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added inference to `getLogs` `event` type.

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -1,0 +1,96 @@
+import { expectTypeOf, test } from 'vitest'
+
+import { publicClient } from '../../_test/index.js'
+import { getLogs } from './getLogs.js'
+import type { AbiEvent } from 'abitype'
+
+test('event: const assertion', async () => {
+  const event = {
+    inputs: [
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  } as const
+  const logs = await getLogs(publicClient, {
+    event,
+  })
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<{
+    from: `0x${string}`
+    to: `0x${string}`
+    value: bigint
+  }>()
+})
+
+test('event: defined inline', async () => {
+  const logs = await getLogs(publicClient, {
+    event: {
+      inputs: [
+        {
+          indexed: true,
+          name: 'from',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'to',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+      ],
+      name: 'Transfer',
+      type: 'event',
+    },
+  })
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<{
+    from: `0x${string}`
+    to: `0x${string}`
+    value: bigint
+  }>()
+})
+
+test('event: declared as `AbiEvent`', async () => {
+  const event: AbiEvent = {
+    inputs: [
+      {
+        indexed: true,
+        name: 'from',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'to',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  }
+  const logs = await getLogs(publicClient, {
+    event,
+  })
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<readonly unknown[]>()
+})

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -1,4 +1,4 @@
-import type { AbiEvent } from 'abitype'
+import type { AbiEvent, Narrow } from 'abitype'
 import type { PublicClient, Transport } from '../../clients/index.js'
 import type {
   Address,
@@ -28,7 +28,7 @@ export type GetLogsParameters<
   address?: Address | Address[]
 } & (
   | {
-      event: TAbiEvent
+      event: Narrow<TAbiEvent>
       args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName>
     }
   | {
@@ -97,7 +97,7 @@ export async function getLogs<
   if (event)
     topics = encodeEventTopics({
       abi: [event],
-      eventName: event.name,
+      eventName: (event as AbiEvent).name,
       args,
     } as EncodeEventTopicsParameters)
 


### PR DESCRIPTION
Adds type inference to `getLogs` `event` property

https://github.com/wagmi-dev/viem/discussions/359#discussioncomment-5594433

---

### Automated Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f8d114</samp>

This pull request enhances the type inference of the `getLogs` function, which fetches logs from a smart contract event. It uses the `Narrow` and `AbiEvent` types from `abitype` to narrow down the possible types of the `event` parameter and the returned logs. It also adds some type tests using `vitest` and documents the changeset in a markdown file.