### PR TITLE
fix: do not use generic type variables for getAbiItem return type

### DIFF
--- a/.changeset/silly-ravens-cross.md
+++ b/.changeset/silly-ravens-cross.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed getAbiItem to not use a generic type variable for the return type
+Fixed `getAbiItem` to not use a generic type variable for the return type

--- a/.changeset/silly-ravens-cross.md
+++ b/.changeset/silly-ravens-cross.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed getAbiItem to not use a generic type variable for the return type

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -23,22 +23,23 @@ export type GetAbiItemReturnType<
 export function getAbiItem<
   TAbi extends Abi | readonly unknown[],
   TItemName extends string,
-  TReturnType = GetAbiItemReturnType<TAbi, TItemName>,
 >({
   abi,
   args = [],
   name,
-}: GetAbiItemParameters<TAbi, TItemName>): TReturnType {
+}: GetAbiItemParameters<TAbi, TItemName>): GetAbiItemReturnType<
+  TAbi,
+  TItemName
+> {
   const abiItems = (abi as Abi).filter((x) => 'name' in x && x.name === name)
 
-  if (abiItems.length === 0) return undefined as unknown as TReturnType
-  if (abiItems.length === 1) return abiItems[0] as unknown as TReturnType
+  if (abiItems.length === 0) return undefined as any
+  if (abiItems.length === 1) return abiItems[0] as any
 
   for (const abiItem of abiItems) {
     if (!('inputs' in abiItem)) continue
     if (!args || args.length === 0) {
-      if (!abiItem.inputs || abiItem.inputs.length === 0)
-        return abiItem as unknown as TReturnType
+      if (!abiItem.inputs || abiItem.inputs.length === 0) return abiItem as any
       continue
     }
     if (!abiItem.inputs) continue
@@ -48,9 +49,9 @@ export function getAbiItem<
       if (!abiParameter) return false
       return isArgOfType(arg, abiParameter as AbiParameter)
     })
-    if (matched) return abiItem as unknown as TReturnType
+    if (matched) return abiItem as any
   }
-  return abiItems[0] as unknown as TReturnType
+  return abiItems[0] as any
 }
 
 export function isArgOfType(arg: unknown, abiParameter: AbiParameter): boolean {


### PR DESCRIPTION
It's imho good practice to avoid using generic type variables directly in return types. It creates a chicken & egg scenario when the return of such a function is then used in another generic function's input as seen in https://github.com/wagmi-dev/viem/discussions/359

---

### Automated Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db822ea</samp>

This pull request fixes the `getAbiItem` function to simplify its type signature and return type. It also adds a changeset file to document the patch version update and the bug fix for the `viem` package.