### PR TITLE
feat: allow `decodeFunctionData` to accept a single abi function

### DIFF
--- a/src/utils/abi/decodeFunctionData.test.ts
+++ b/src/utils/abi/decodeFunctionData.test.ts
@@ -30,6 +30,18 @@ test('foo()', () => {
       data: '0xc2985578',
     }),
   ).toEqual({ args: undefined, functionName: 'foo' })
+  expect(
+    decodeFunctionData({
+      abi: {
+        inputs: [],
+        name: 'foo',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      } as const,
+      data: '0xc2985578',
+    }),
+  ).toEqual({ args: undefined, functionName: 'foo' })
 })
 
 test('bar(uint256)', () => {
@@ -49,6 +61,26 @@ test('bar(uint256)', () => {
           type: 'function',
         },
       ] as const,
+      data: '0x0423a1320000000000000000000000000000000000000000000000000000000000000001',
+    }),
+  ).toEqual({
+    args: [1n],
+    functionName: 'bar',
+  })
+  expect(
+    decodeFunctionData({
+      abi: {
+        inputs: [
+          {
+            name: 'a',
+            type: 'uint256',
+          },
+        ],
+        name: 'bar',
+        outputs: [],
+        stateMutability: 'nonpayable',
+        type: 'function',
+      } as const,
       data: '0x0423a1320000000000000000000000000000000000000000000000000000000000000001',
     }),
   ).toEqual({


### PR DESCRIPTION
Mild annoyance that I ran into a couple of times... Would be great if we didn't have to wrap single abi declarations in an array needlessly?

@tmm @jxom If you agree with this, we could also do this for `decodeEventLog`, etc.

---

### Automated Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bca0e9</samp>

This pull request enhances the `decodeFunctionData` function in `src/utils/abi/decodeFunctionData.ts` to support single function ABIs and adds tests for this feature. It also improves the error handling for invalid function signatures.