### PR TITLE
refactor: use async import for isomorphic-ws to support edge runtime

### DIFF
--- a/.changeset/thick-mangos-shave.md
+++ b/.changeset/thick-mangos-shave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support edge runtime

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,5 +1,4 @@
-import WebSocket from 'isomorphic-ws'
-import type { MessageEvent } from 'isomorphic-ws'
+import type { WebSocket, MessageEvent } from 'isomorphic-ws'
 import {
   HttpRequestError,
   RpcRequestError,
@@ -145,6 +144,7 @@ export async function getSocket(url_: string) {
   // If the socket already exists, return it.
   if (socket) return socket
 
+  const { WebSocket } = await import('isomorphic-ws')
   const webSocket = new WebSocket(url)
 
   // Set up a cache for incoming "synchronous" requests.


### PR DESCRIPTION
Should we maybe configure different vitest environments (vitest supports jsdom, node, edge, etc.) in a test matrix in CI to ensure support for edge in the future?