### PR TITLE
fix: unable to send transaction with 0 as nonce

### DIFF
--- a/.changeset/two-ties-sort.md
+++ b/.changeset/two-ties-sort.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixes a bug where `serializeTransaction` was incorrectly encoding properties with zeros as values.
+Fixed an issue where `serializeTransaction` was incorrectly encoding zero-ish properties.

--- a/.changeset/two-ties-sort.md
+++ b/.changeset/two-ties-sort.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixes a bug where `serializeTransaction` was incorrectly encoding properties with zeros as values.

--- a/src/utils/transaction/serializeTransaction.test.ts
+++ b/src/utils/transaction/serializeTransaction.test.ts
@@ -1,7 +1,7 @@
-import { assertType, describe, expect, test } from 'vitest'
-import { accounts } from '../../_test/index.js'
-import { serializeTransaction } from './serializeTransaction.js'
-import { parseGwei, parseEther } from '../unit/index.js'
+import { assertType, describe, expect, test } from "vitest";
+import { accounts } from "../../_test/index.js";
+import { serializeTransaction } from "./serializeTransaction.js";
+import { parseGwei, parseEther } from "../unit/index.js";
 import type {
   TransactionSerializableBase,
   TransactionSerializableEIP1559,
@@ -10,525 +10,589 @@ import type {
   TransactionSerializedEIP1559,
   TransactionSerializedEIP2930,
   TransactionSerializedLegacy,
-} from '../../types/index.js'
-import { parseTransaction } from './parseTransaction.js'
-import { keccak256 } from '../hash/index.js'
-import { sign } from '../../accounts/utils/sign.js'
+} from "../../types/index.js";
+import { parseTransaction } from "./parseTransaction.js";
+import { keccak256 } from "../hash/index.js";
+import { sign } from "../../accounts/utils/sign.js";
 
 const base = {
   to: accounts[1].address,
   nonce: 785,
-  value: parseEther('1'),
-} satisfies TransactionSerializableBase
+  value: parseEther("1"),
+} satisfies TransactionSerializableBase;
 
-describe('eip1559', () => {
+describe("eip1559", () => {
   const baseEip1559 = {
     ...base,
     chainId: 1,
-    maxFeePerGas: parseGwei('2'),
-    maxPriorityFeePerGas: parseGwei('2'),
-  }
+    maxFeePerGas: parseGwei("2"),
+    maxPriorityFeePerGas: parseGwei("2"),
+  };
 
-  test('default', () => {
-    const serialized = serializeTransaction(baseEip1559)
-    assertType<TransactionSerializedEIP1559>(serialized)
+  test("default", () => {
+    const serialized = serializeTransaction(baseEip1559);
+    assertType<TransactionSerializedEIP1559>(serialized);
     expect(serialized).toEqual(
-      '0x02ef0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0',
-    )
+      "0x02ef0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip1559,
-      type: 'eip1559',
-    })
-  })
+      type: "eip1559",
+    });
+  });
 
-  test('minimal (w/ maxFeePerGas)', () => {
+  test("default (all zeros)", () => {
+    const baseEip1559Zero = {
+      to: accounts[1].address,
+      nonce: 0,
+      chainId: 1,
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+      value: 0n,
+    } satisfies TransactionSerializableEIP1559;
+
+    const serialized = serializeTransaction(baseEip1559Zero);
+
+    expect(serialized).toEqual(
+      "0x02dd01808080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0"
+    );
+    expect(parseTransaction(serialized)).toEqual({
+      chainId: 1,
+      to: accounts[1].address,
+      type: "eip1559",
+    });
+  });
+
+  test("minimal (w/ maxFeePerGas)", () => {
     const args = {
       chainId: 1,
       maxFeePerGas: 1n,
-    }
-    const serialized = serializeTransaction(args)
-    expect(serialized).toEqual('0x02c90180800180808080c0')
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
-  })
+    };
+    const serialized = serializeTransaction(args);
+    expect(serialized).toEqual("0x02c90180800180808080c0");
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
+  });
 
-  test('minimal (w/ type)', () => {
+  test("minimal (w/ type)", () => {
     const args = {
       chainId: 1,
-      type: 'eip1559',
-    } as const
-    const serialized = serializeTransaction(args)
-    expect(serialized).toEqual('0x02c90180808080808080c0')
-    expect(parseTransaction(serialized)).toEqual(args)
-  })
+      type: "eip1559",
+    } as const;
+    const serialized = serializeTransaction(args);
+    expect(serialized).toEqual("0x02c90180808080808080c0");
+    expect(parseTransaction(serialized)).toEqual(args);
+  });
 
-  test('args: gas', () => {
+  test("args: gas", () => {
     const args = {
       ...baseEip1559,
       gas: 21001n,
-    }
-    const serialized = serializeTransaction(args)
+    };
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x02f101820311847735940084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
-  })
+      "0x02f101820311847735940084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
+  });
 
-  test('args: accessList', () => {
+  test("args: accessList", () => {
     const args = {
       ...baseEip1559,
       accessList: [
         {
-          address: '0x0000000000000000000000000000000000000000',
+          address: "0x0000000000000000000000000000000000000000",
           storageKeys: [
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
-            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           ],
         },
       ],
-    } satisfies TransactionSerializableEIP1559
-    const serialized = serializeTransaction(args)
+    } satisfies TransactionSerializableEIP1559;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x02f88b0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
-  })
+      "0x02f88b0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
+  });
 
-  test('args: data', () => {
+  test("args: data", () => {
     const args = {
       ...baseEip1559,
-      data: '0x1234',
-    } satisfies TransactionSerializableEIP1559
-    const serialized = serializeTransaction(args)
+      data: "0x1234",
+    } satisfies TransactionSerializableEIP1559;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x02f10182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234c0',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
-  })
+      "0x02f10182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234c0"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
+  });
 
-  test('signed', async () => {
+  test("signed", async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseEip1559)),
       privateKey: accounts[0].privateKey,
-    })
-    const serialized = serializeTransaction(baseEip1559, signature)
+    });
+    const serialized = serializeTransaction(baseEip1559, signature);
     expect(serialized).toEqual(
-      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a0ce18214ff9d06ecaacb61811f9d6dc2be922e8cebddeaf6df0b30d5c498f6d33a05f0487c6dbbf2139f7c705d8054dbb16ecac8ae6256ce2c4c6f2e7ef35b3a496',
-    )
+      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a0ce18214ff9d06ecaacb61811f9d6dc2be922e8cebddeaf6df0b30d5c498f6d33a05f0487c6dbbf2139f7c705d8054dbb16ecac8ae6256ce2c4c6f2e7ef35b3a496"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip1559,
       ...signature,
-      type: 'eip1559',
+      type: "eip1559",
       yParity: 1,
-    })
-  })
+    });
+  });
 
-  test('signature', () => {
+  test("signature", () => {
     expect(
       serializeTransaction(
         baseEip1559,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 28n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
+      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
     expect(
       serializeTransaction(
         baseEip1559,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 27n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-  })
+      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+  });
 
-  describe('errors', () => {
-    test('invalid access list (invalid address)', () => {
+  describe("errors", () => {
+    test("invalid access list (invalid address)", () => {
       expect(() =>
         serializeTransaction({
           ...baseEip1559,
           accessList: [
             {
               address:
-                '0x0000000000000000000000000000000000000000000000000000000000000001',
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
               storageKeys: [
-                '0x0000000000000000000000000000000000000000000000000000000000000001',
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
               ],
             },
           ],
-        }),
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
         "Address \\"0x0000000000000000000000000000000000000000000000000000000000000001\\" is invalid.
 
         Version: viem@1.0.2"
-      `)
-    })
+      `);
+    });
 
-    test('invalid access list (invalid storage key)', () => {
+    test("invalid access list (invalid storage key)", () => {
       expect(() =>
         serializeTransaction({
           ...baseEip1559,
           accessList: [
             {
               address:
-                '0x0000000000000000000000000000000000000000000000000000000000000001',
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
               storageKeys: [
-                '0x00000000000000000000000000000000000000000000000000000000000001',
+                "0x00000000000000000000000000000000000000000000000000000000000001",
               ],
             },
           ],
-        }),
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
         "Size for storage key \\"0x00000000000000000000000000000000000000000000000000000000000001\\" is invalid. Expected 32 bytes. Got 31 bytes.
 
         Version: viem@1.0.2"
-      `)
-    })
-  })
-})
+      `);
+    });
+  });
+});
 
-describe('eip2930', () => {
+describe("eip2930", () => {
   const baseEip2930 = {
     ...base,
     chainId: 1,
     accessList: [
       {
-        address: '0x1234512345123451234512345123451234512345',
+        address: "0x1234512345123451234512345123451234512345",
         storageKeys: [
-          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
         ],
       },
     ],
-    gasPrice: parseGwei('2'),
-  } satisfies TransactionSerializableEIP2930
+    gasPrice: parseGwei("2"),
+  } satisfies TransactionSerializableEIP2930;
 
-  test('default', () => {
-    const serialized = serializeTransaction(baseEip2930)
-    assertType<TransactionSerializedEIP2930>(serialized)
+  test("default", () => {
+    const serialized = serializeTransaction(baseEip2930);
+    assertType<TransactionSerializedEIP2930>(serialized);
     expect(serialized).toEqual(
-      '0x01f863018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
+      "0x01f863018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip2930,
-      type: 'eip2930',
-    })
-  })
+      type: "eip2930",
+    });
+  });
 
-  test('minimal (w/ accessList & gasPrice)', () => {
+  test("default (all zeros)", () => {
+    const baseEip2930Zero = {
+      to: accounts[1].address,
+      nonce: 0,
+      chainId: 1,
+      value: 0n,
+      gasPrice: 0n,
+      accessList: [],
+    } satisfies TransactionSerializableEIP2930;
+
+    const serialized = serializeTransaction(baseEip2930Zero);
+
+    expect(serialized).toEqual(
+      "0x01dc018080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0"
+    );
+
+    expect(parseTransaction(serialized)).toEqual({
+      chainId: 1,
+      to: accounts[1].address,
+      type: "eip2930",
+    });
+  });
+
+  test("minimal (w/ accessList & gasPrice)", () => {
     const args = {
       chainId: 1,
       accessList: [
         {
-          address: '0x0000000000000000000000000000000000000000',
+          address: "0x0000000000000000000000000000000000000000",
           storageKeys: [
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
           ],
         },
       ],
-      gasPrice: parseGwei('2'),
-    } satisfies TransactionSerializableEIP2930
-    const serialized = serializeTransaction(args)
+      gasPrice: parseGwei("2"),
+    } satisfies TransactionSerializableEIP2930;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x01f8450180847735940080808080f838f7940000000000000000000000000000000000000000e1a00000000000000000000000000000000000000000000000000000000000000001',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
-  })
+      "0x01f8450180847735940080808080f838f7940000000000000000000000000000000000000000e1a00000000000000000000000000000000000000000000000000000000000000001"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
+  });
 
-  test('minimal (w/ type)', () => {
+  test("minimal (w/ type)", () => {
     const args = {
       chainId: 1,
-      type: 'eip2930',
-    } satisfies TransactionSerializableEIP2930
-    const serialized = serializeTransaction(args)
-    expect(serialized).toEqual('0x01c801808080808080c0')
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
-  })
+      type: "eip2930",
+    } satisfies TransactionSerializableEIP2930;
+    const serialized = serializeTransaction(args);
+    expect(serialized).toEqual("0x01c801808080808080c0");
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
+  });
 
-  test('args: gas', () => {
+  test("args: gas", () => {
     const args = {
       ...baseEip2930,
       gas: 21001n,
-    }
-    const serialized = serializeTransaction(args)
+    };
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x01f8650182031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
-  })
+      "0x01f8650182031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
+  });
 
-  test('args: data', () => {
+  test("args: data", () => {
     const args = {
       ...baseEip2930,
-      data: '0x1234',
-    } satisfies TransactionSerializableEIP2930
-    const serialized = serializeTransaction(args)
+      data: "0x1234",
+    } satisfies TransactionSerializableEIP2930;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0x01f865018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
-  })
+      "0x01f865018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
+  });
 
-  test('signed', async () => {
+  test("signed", async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseEip2930)),
       privateKey: accounts[0].privateKey,
-    })
-    const serialized = serializeTransaction(baseEip2930, signature)
+    });
+    const serialized = serializeTransaction(baseEip2930, signature);
     expect(serialized).toEqual(
-      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a0dc7b3483c0b183823f07d77247c60678d861080acdc4fb8b9fd131770b475c40a040f16567391132746735aff4d5a3fa5ae42ff3d5d538e341870e0259dc40741a',
-    )
+      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a0dc7b3483c0b183823f07d77247c60678d861080acdc4fb8b9fd131770b475c40a040f16567391132746735aff4d5a3fa5ae42ff3d5d538e341870e0259dc40741a"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip2930,
       ...signature,
-      type: 'eip2930',
+      type: "eip2930",
       yParity: 1,
-    })
-  })
+    });
+  });
 
-  test('signature', () => {
+  test("signature", () => {
     expect(
       serializeTransaction(
         baseEip2930,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 28n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
+      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
     expect(
       serializeTransaction(
         baseEip2930,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 27n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-  })
+      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+  });
 
-  describe('errors', () => {
-    test('invalid access list (invalid address)', () => {
+  describe("errors", () => {
+    test("invalid access list (invalid address)", () => {
       expect(() =>
         serializeTransaction({
           ...baseEip2930,
           accessList: [
             {
-              address: '0x0',
+              address: "0x0",
               storageKeys: [
-                '0x0000000000000000000000000000000000000000000000000000000000000001',
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
               ],
             },
           ],
-        }),
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
         "Address \\"0x0\\" is invalid.
 
         Version: viem@1.0.2"
-      `)
-    })
+      `);
+    });
 
-    test('invalid access list (invalid storage key)', () => {
+    test("invalid access list (invalid storage key)", () => {
       expect(() =>
         serializeTransaction({
           ...baseEip2930,
           accessList: [
             {
-              address: '0x0',
+              address: "0x0",
               storageKeys: [
-                '0x0000000000000000000000000000000000000000000000000000000000001',
+                "0x0000000000000000000000000000000000000000000000000000000000001",
               ],
             },
           ],
-        }),
+        })
       ).toThrowErrorMatchingInlineSnapshot(`
         "Size for storage key \\"0x0000000000000000000000000000000000000000000000000000000000001\\" is invalid. Expected 32 bytes. Got 30 bytes.
 
         Version: viem@1.0.2"
-      `)
-    })
-  })
-})
+      `);
+    });
+  });
+});
 
-describe('legacy', () => {
+describe("legacy", () => {
   const baseLegacy = {
     ...base,
-    gasPrice: parseGwei('2'),
-  }
+    gasPrice: parseGwei("2"),
+  };
 
-  test('default', () => {
-    const serialized = serializeTransaction(baseLegacy)
-    assertType<TransactionSerializedLegacy>(serialized)
+  test("default", () => {
+    const serialized = serializeTransaction(baseLegacy);
+    assertType<TransactionSerializedLegacy>(serialized);
     expect(serialized).toEqual(
-      '0xe88203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080',
-    )
+      "0xe88203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseLegacy,
-      type: 'legacy',
-    })
-  })
+      type: "legacy",
+    });
+  });
 
-  test('minimal (w/ gasPrice)', () => {
+  test("default (all zeros)", () => {
+    const baseLegacyZero = {
+      to: accounts[1].address,
+      nonce: 0,
+      value: 0n,
+      gasPrice: 0n,
+    } satisfies TransactionSerializableLegacy;
+
+    const serialized = serializeTransaction(baseLegacyZero);
+
+    expect(serialized).toEqual(
+      "0xda8080809470997970c51812dc3a010c7d01b50e0d17dc79c88080"
+    );
+
+    expect(parseTransaction(serialized)).toEqual({
+      to: accounts[1].address,
+      type: "legacy",
+    });
+  });
+
+  test("minimal (w/ gasPrice)", () => {
     const args = {
-      gasPrice: parseGwei('2'),
-    } satisfies TransactionSerializableLegacy
-    const serialized = serializeTransaction(args)
-    expect(serialized).toEqual('0xca80847735940080808080')
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
-  })
+      gasPrice: parseGwei("2"),
+    } satisfies TransactionSerializableLegacy;
+    const serialized = serializeTransaction(args);
+    expect(serialized).toEqual("0xca80847735940080808080");
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
+  });
 
-  test('minimal (w/ type)', () => {
+  test("minimal (w/ type)", () => {
     const args = {
-      type: 'legacy',
-    } satisfies TransactionSerializableLegacy
-    const serialized = serializeTransaction(args)
-    expect(serialized).toEqual('0xc6808080808080')
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
-  })
+      type: "legacy",
+    } satisfies TransactionSerializableLegacy;
+    const serialized = serializeTransaction(args);
+    expect(serialized).toEqual("0xc6808080808080");
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
+  });
 
-  test('args: gas', () => {
+  test("args: gas", () => {
     const args = {
       ...baseLegacy,
       gas: 21001n,
-    }
-    const serialized = serializeTransaction(args)
+    };
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0xea82031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
-  })
+      "0xea82031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
+  });
 
-  test('args: data', () => {
+  test("args: data", () => {
     const args = {
       ...baseLegacy,
-      data: '0x1234',
-    } satisfies TransactionSerializableLegacy
-    const serialized = serializeTransaction(args)
+      data: "0x1234",
+    } satisfies TransactionSerializableLegacy;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0xea8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
-  })
+      "0xea8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
+  });
 
-  test('args: chainId', () => {
+  test("args: chainId", () => {
     const args = {
       ...baseLegacy,
       chainId: 69,
-    } satisfies TransactionSerializableLegacy
-    const serialized = serializeTransaction(args)
+    } satisfies TransactionSerializableLegacy;
+    const serialized = serializeTransaction(args);
     expect(serialized).toEqual(
-      '0xeb8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080458080',
-    )
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
-  })
+      "0xeb8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080458080"
+    );
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
+  });
 
-  test('signed', async () => {
+  test("signed", async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseLegacy)),
       privateKey: accounts[0].privateKey,
-    })
-    const serialized = serializeTransaction(baseLegacy, signature)
+    });
+    const serialized = serializeTransaction(baseLegacy, signature);
     expect(serialized).toEqual(
-      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca06cb0e8d21e5baf998fb9a05f47acd83692dc148f90b81b332a152f020da0ae98a0344e49bacb1ef7af7c2ffed9e88d3f0ae0aa4945c9da0a660a03717dd5621f98',
-    )
+      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca06cb0e8d21e5baf998fb9a05f47acd83692dc148f90b81b332a152f020da0ae98a0344e49bacb1ef7af7c2ffed9e88d3f0ae0aa4945c9da0a660a03717dd5621f98"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...baseLegacy,
       ...signature,
-      type: 'legacy',
-    })
-  })
+      type: "legacy",
+    });
+  });
 
-  test('signature', () => {
+  test("signature", () => {
     expect(
       serializeTransaction(
         baseLegacy,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 28n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
+      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
     expect(
       serializeTransaction(
         baseLegacy,
 
         {
-          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
           v: 27n,
-        },
-      ),
+        }
+      )
     ).toEqual(
-      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ba060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-    )
-  })
+      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ba060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
+    );
+  });
 
-  test('signed w/ chainId', async () => {
+  test("signed w/ chainId", async () => {
     const args = {
       ...baseLegacy,
       chainId: 69,
-    }
+    };
     const signature = await sign({
       hash: keccak256(serializeTransaction(args)),
       privateKey: accounts[0].privateKey,
-    })
-    const serialized = serializeTransaction(args, signature)
+    });
+    const serialized = serializeTransaction(args, signature);
     expect(serialized).toEqual(
-      '0xf86c8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a76400008081ada02f43314322cf4c5dd645b028aa0b0dadff0fb73c41a6f0620ff1dfb11601ac30a066f37a65e139fa4b6df33a42ab5ccaeaa7a109382e7430caefd1deee63962626',
-    )
+      "0xf86c8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a76400008081ada02f43314322cf4c5dd645b028aa0b0dadff0fb73c41a6f0620ff1dfb11601ac30a066f37a65e139fa4b6df33a42ab5ccaeaa7a109382e7430caefd1deee63962626"
+    );
     expect(parseTransaction(serialized)).toEqual({
       ...args,
       ...signature,
-      type: 'legacy',
+      type: "legacy",
       v: 173n,
-    })
-  })
+    });
+  });
 
-  describe('errors', () => {
-    test('invalid v', () => {
+  describe("errors", () => {
+    test("invalid v", () => {
       expect(() =>
         serializeTransaction(
           baseLegacy,
 
           {
-            r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-            s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+            r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+            s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
             v: 29n,
-          },
-        ),
+          }
+        )
       ).toThrowErrorMatchingInlineSnapshot(`
         "Invalid \`v\` value \\"29\\". Expected 27 or 28.
 
         Version: viem@1.0.2"
-      `)
-    })
-  })
-})
+      `);
+    });
+  });
+});
 
-test('cannot infer type from transaction object', () => {
-  expect(() =>
-    serializeTransaction({ chainId: 1, data: '0x1234', nonce: 69 }),
-  ).toThrowErrorMatchingInlineSnapshot(`
+test("cannot infer type from transaction object", () => {
+  expect(() => serializeTransaction({ chainId: 1, data: "0x1234", nonce: 69 }))
+    .toThrowErrorMatchingInlineSnapshot(`
     "Cannot infer a transaction type from provided transaction.
 
     Provided Transaction:
@@ -545,5 +609,5 @@ test('cannot infer type from transaction object', () => {
     - a Legacy Transaction with \`gasPrice\`
 
     Version: viem@1.0.2"
-  `)
-})
+  `);
+});

--- a/src/utils/transaction/serializeTransaction.test.ts
+++ b/src/utils/transaction/serializeTransaction.test.ts
@@ -1,7 +1,7 @@
-import { assertType, describe, expect, test } from "vitest";
-import { accounts } from "../../_test/index.js";
-import { serializeTransaction } from "./serializeTransaction.js";
-import { parseGwei, parseEther } from "../unit/index.js";
+import { assertType, describe, expect, test } from 'vitest'
+import { accounts } from '../../_test/index.js'
+import { serializeTransaction } from './serializeTransaction.js'
+import { parseGwei, parseEther } from '../unit/index.js'
 import type {
   TransactionSerializableBase,
   TransactionSerializableEIP1559,
@@ -10,38 +10,38 @@ import type {
   TransactionSerializedEIP1559,
   TransactionSerializedEIP2930,
   TransactionSerializedLegacy,
-} from "../../types/index.js";
-import { parseTransaction } from "./parseTransaction.js";
-import { keccak256 } from "../hash/index.js";
-import { sign } from "../../accounts/utils/sign.js";
+} from '../../types/index.js'
+import { parseTransaction } from './parseTransaction.js'
+import { keccak256 } from '../hash/index.js'
+import { sign } from '../../accounts/utils/sign.js'
 
 const base = {
   to: accounts[1].address,
   nonce: 785,
-  value: parseEther("1"),
-} satisfies TransactionSerializableBase;
+  value: parseEther('1'),
+} satisfies TransactionSerializableBase
 
-describe("eip1559", () => {
+describe('eip1559', () => {
   const baseEip1559 = {
     ...base,
     chainId: 1,
-    maxFeePerGas: parseGwei("2"),
-    maxPriorityFeePerGas: parseGwei("2"),
-  };
+    maxFeePerGas: parseGwei('2'),
+    maxPriorityFeePerGas: parseGwei('2'),
+  }
 
-  test("default", () => {
-    const serialized = serializeTransaction(baseEip1559);
-    assertType<TransactionSerializedEIP1559>(serialized);
+  test('default', () => {
+    const serialized = serializeTransaction(baseEip1559)
+    assertType<TransactionSerializedEIP1559>(serialized)
     expect(serialized).toEqual(
-      "0x02ef0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0"
-    );
+      '0x02ef0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip1559,
-      type: "eip1559",
-    });
-  });
+      type: 'eip1559',
+    })
+  })
 
-  test("default (all zeros)", () => {
+  test('default (all zeros)', () => {
     const baseEip1559Zero = {
       to: accounts[1].address,
       nonce: 0,
@@ -49,203 +49,203 @@ describe("eip1559", () => {
       maxFeePerGas: 0n,
       maxPriorityFeePerGas: 0n,
       value: 0n,
-    } satisfies TransactionSerializableEIP1559;
+    } satisfies TransactionSerializableEIP1559
 
-    const serialized = serializeTransaction(baseEip1559Zero);
+    const serialized = serializeTransaction(baseEip1559Zero)
 
     expect(serialized).toEqual(
-      "0x02dd01808080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0"
-    );
+      '0x02dd01808080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0',
+    )
     expect(parseTransaction(serialized)).toEqual({
       chainId: 1,
       to: accounts[1].address,
-      type: "eip1559",
-    });
-  });
+      type: 'eip1559',
+    })
+  })
 
-  test("minimal (w/ maxFeePerGas)", () => {
+  test('minimal (w/ maxFeePerGas)', () => {
     const args = {
       chainId: 1,
       maxFeePerGas: 1n,
-    };
-    const serialized = serializeTransaction(args);
-    expect(serialized).toEqual("0x02c90180800180808080c0");
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
-  });
+    }
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual('0x02c90180800180808080c0')
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
+  })
 
-  test("minimal (w/ type)", () => {
+  test('minimal (w/ type)', () => {
     const args = {
       chainId: 1,
-      type: "eip1559",
-    } as const;
-    const serialized = serializeTransaction(args);
-    expect(serialized).toEqual("0x02c90180808080808080c0");
-    expect(parseTransaction(serialized)).toEqual(args);
-  });
+      type: 'eip1559',
+    } as const
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual('0x02c90180808080808080c0')
+    expect(parseTransaction(serialized)).toEqual(args)
+  })
 
-  test("args: gas", () => {
+  test('args: gas', () => {
     const args = {
       ...baseEip1559,
       gas: 21001n,
-    };
-    const serialized = serializeTransaction(args);
+    }
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x02f101820311847735940084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
-  });
+      '0x02f101820311847735940084773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c0',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
+  })
 
-  test("args: accessList", () => {
+  test('args: accessList', () => {
     const args = {
       ...baseEip1559,
       accessList: [
         {
-          address: "0x0000000000000000000000000000000000000000",
+          address: '0x0000000000000000000000000000000000000000',
           storageKeys: [
-            "0x0000000000000000000000000000000000000000000000000000000000000001",
-            "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           ],
         },
       ],
-    } satisfies TransactionSerializableEIP1559;
-    const serialized = serializeTransaction(args);
+    } satisfies TransactionSerializableEIP1559
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x02f88b0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
-  });
+      '0x02f88b0182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
+  })
 
-  test("args: data", () => {
+  test('args: data', () => {
     const args = {
       ...baseEip1559,
-      data: "0x1234",
-    } satisfies TransactionSerializableEIP1559;
-    const serialized = serializeTransaction(args);
+      data: '0x1234',
+    } satisfies TransactionSerializableEIP1559
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x02f10182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234c0"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip1559" });
-  });
+      '0x02f10182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234c0',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip1559' })
+  })
 
-  test("signed", async () => {
+  test('signed', async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseEip1559)),
       privateKey: accounts[0].privateKey,
-    });
-    const serialized = serializeTransaction(baseEip1559, signature);
+    })
+    const serialized = serializeTransaction(baseEip1559, signature)
     expect(serialized).toEqual(
-      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a0ce18214ff9d06ecaacb61811f9d6dc2be922e8cebddeaf6df0b30d5c498f6d33a05f0487c6dbbf2139f7c705d8054dbb16ecac8ae6256ce2c4c6f2e7ef35b3a496"
-    );
+      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a0ce18214ff9d06ecaacb61811f9d6dc2be922e8cebddeaf6df0b30d5c498f6d33a05f0487c6dbbf2139f7c705d8054dbb16ecac8ae6256ce2c4c6f2e7ef35b3a496',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip1559,
       ...signature,
-      type: "eip1559",
+      type: 'eip1559',
       yParity: 1,
-    });
-  });
+    })
+  })
 
-  test("signature", () => {
+  test('signature', () => {
     expect(
       serializeTransaction(
         baseEip1559,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 28n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
+      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
     expect(
       serializeTransaction(
         baseEip1559,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 27n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-  });
+      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+  })
 
-  describe("errors", () => {
-    test("invalid access list (invalid address)", () => {
+  describe('errors', () => {
+    test('invalid access list (invalid address)', () => {
       expect(() =>
         serializeTransaction({
           ...baseEip1559,
           accessList: [
             {
               address:
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                '0x0000000000000000000000000000000000000000000000000000000000000001',
               storageKeys: [
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                '0x0000000000000000000000000000000000000000000000000000000000000001',
               ],
             },
           ],
-        })
+        }),
       ).toThrowErrorMatchingInlineSnapshot(`
         "Address \\"0x0000000000000000000000000000000000000000000000000000000000000001\\" is invalid.
 
         Version: viem@1.0.2"
-      `);
-    });
+      `)
+    })
 
-    test("invalid access list (invalid storage key)", () => {
+    test('invalid access list (invalid storage key)', () => {
       expect(() =>
         serializeTransaction({
           ...baseEip1559,
           accessList: [
             {
               address:
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                '0x0000000000000000000000000000000000000000000000000000000000000001',
               storageKeys: [
-                "0x00000000000000000000000000000000000000000000000000000000000001",
+                '0x00000000000000000000000000000000000000000000000000000000000001',
               ],
             },
           ],
-        })
+        }),
       ).toThrowErrorMatchingInlineSnapshot(`
         "Size for storage key \\"0x00000000000000000000000000000000000000000000000000000000000001\\" is invalid. Expected 32 bytes. Got 31 bytes.
 
         Version: viem@1.0.2"
-      `);
-    });
-  });
-});
+      `)
+    })
+  })
+})
 
-describe("eip2930", () => {
+describe('eip2930', () => {
   const baseEip2930 = {
     ...base,
     chainId: 1,
     accessList: [
       {
-        address: "0x1234512345123451234512345123451234512345",
+        address: '0x1234512345123451234512345123451234512345',
         storageKeys: [
-          "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
         ],
       },
     ],
-    gasPrice: parseGwei("2"),
-  } satisfies TransactionSerializableEIP2930;
+    gasPrice: parseGwei('2'),
+  } satisfies TransactionSerializableEIP2930
 
-  test("default", () => {
-    const serialized = serializeTransaction(baseEip2930);
-    assertType<TransactionSerializedEIP2930>(serialized);
+  test('default', () => {
+    const serialized = serializeTransaction(baseEip2930)
+    assertType<TransactionSerializedEIP2930>(serialized)
     expect(serialized).toEqual(
-      "0x01f863018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
+      '0x01f863018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip2930,
-      type: "eip2930",
-    });
-  });
+      type: 'eip2930',
+    })
+  })
 
-  test("default (all zeros)", () => {
+  test('default (all zeros)', () => {
     const baseEip2930Zero = {
       to: accounts[1].address,
       nonce: 0,
@@ -253,346 +253,347 @@ describe("eip2930", () => {
       value: 0n,
       gasPrice: 0n,
       accessList: [],
-    } satisfies TransactionSerializableEIP2930;
+    } satisfies TransactionSerializableEIP2930
 
-    const serialized = serializeTransaction(baseEip2930Zero);
+    const serialized = serializeTransaction(baseEip2930Zero)
 
     expect(serialized).toEqual(
-      "0x01dc018080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0"
-    );
+      '0x01dc018080809470997970c51812dc3a010c7d01b50e0d17dc79c88080c0',
+    )
 
     expect(parseTransaction(serialized)).toEqual({
       chainId: 1,
       to: accounts[1].address,
-      type: "eip2930",
-    });
-  });
+      type: 'eip2930',
+    })
+  })
 
-  test("minimal (w/ accessList & gasPrice)", () => {
+  test('minimal (w/ accessList & gasPrice)', () => {
     const args = {
       chainId: 1,
       accessList: [
         {
-          address: "0x0000000000000000000000000000000000000000",
+          address: '0x0000000000000000000000000000000000000000',
           storageKeys: [
-            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
           ],
         },
       ],
-      gasPrice: parseGwei("2"),
-    } satisfies TransactionSerializableEIP2930;
-    const serialized = serializeTransaction(args);
+      gasPrice: parseGwei('2'),
+    } satisfies TransactionSerializableEIP2930
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x01f8450180847735940080808080f838f7940000000000000000000000000000000000000000e1a00000000000000000000000000000000000000000000000000000000000000001"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
-  });
+      '0x01f8450180847735940080808080f838f7940000000000000000000000000000000000000000e1a00000000000000000000000000000000000000000000000000000000000000001',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
+  })
 
-  test("minimal (w/ type)", () => {
+  test('minimal (w/ type)', () => {
     const args = {
       chainId: 1,
-      type: "eip2930",
-    } satisfies TransactionSerializableEIP2930;
-    const serialized = serializeTransaction(args);
-    expect(serialized).toEqual("0x01c801808080808080c0");
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
-  });
+      type: 'eip2930',
+    } satisfies TransactionSerializableEIP2930
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual('0x01c801808080808080c0')
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
+  })
 
-  test("args: gas", () => {
+  test('args: gas', () => {
     const args = {
       ...baseEip2930,
       gas: 21001n,
-    };
-    const serialized = serializeTransaction(args);
+    }
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x01f8650182031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
-  });
+      '0x01f8650182031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
+  })
 
-  test("args: data", () => {
+  test('args: data', () => {
     const args = {
       ...baseEip2930,
-      data: "0x1234",
-    } satisfies TransactionSerializableEIP2930;
-    const serialized = serializeTransaction(args);
+      data: '0x1234',
+    } satisfies TransactionSerializableEIP2930
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0x01f865018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "eip2930" });
-  });
+      '0x01f865018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'eip2930' })
+  })
 
-  test("signed", async () => {
+  test('signed', async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseEip2930)),
       privateKey: accounts[0].privateKey,
-    });
-    const serialized = serializeTransaction(baseEip2930, signature);
+    })
+    const serialized = serializeTransaction(baseEip2930, signature)
     expect(serialized).toEqual(
-      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a0dc7b3483c0b183823f07d77247c60678d861080acdc4fb8b9fd131770b475c40a040f16567391132746735aff4d5a3fa5ae42ff3d5d538e341870e0259dc40741a"
-    );
+      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a0dc7b3483c0b183823f07d77247c60678d861080acdc4fb8b9fd131770b475c40a040f16567391132746735aff4d5a3fa5ae42ff3d5d538e341870e0259dc40741a',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseEip2930,
       ...signature,
-      type: "eip2930",
+      type: 'eip2930',
       yParity: 1,
-    });
-  });
+    })
+  })
 
-  test("signature", () => {
+  test('signature', () => {
     expect(
       serializeTransaction(
         baseEip2930,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 28n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
+      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
     expect(
       serializeTransaction(
         baseEip2930,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 27n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-  });
+      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+  })
 
-  describe("errors", () => {
-    test("invalid access list (invalid address)", () => {
+  describe('errors', () => {
+    test('invalid access list (invalid address)', () => {
       expect(() =>
         serializeTransaction({
           ...baseEip2930,
           accessList: [
             {
-              address: "0x0",
+              address: '0x0',
               storageKeys: [
-                "0x0000000000000000000000000000000000000000000000000000000000000001",
+                '0x0000000000000000000000000000000000000000000000000000000000000001',
               ],
             },
           ],
-        })
+        }),
       ).toThrowErrorMatchingInlineSnapshot(`
         "Address \\"0x0\\" is invalid.
 
         Version: viem@1.0.2"
-      `);
-    });
+      `)
+    })
 
-    test("invalid access list (invalid storage key)", () => {
+    test('invalid access list (invalid storage key)', () => {
       expect(() =>
         serializeTransaction({
           ...baseEip2930,
           accessList: [
             {
-              address: "0x0",
+              address: '0x0',
               storageKeys: [
-                "0x0000000000000000000000000000000000000000000000000000000000001",
+                '0x0000000000000000000000000000000000000000000000000000000000001',
               ],
             },
           ],
-        })
+        }),
       ).toThrowErrorMatchingInlineSnapshot(`
         "Size for storage key \\"0x0000000000000000000000000000000000000000000000000000000000001\\" is invalid. Expected 32 bytes. Got 30 bytes.
 
         Version: viem@1.0.2"
-      `);
-    });
-  });
-});
+      `)
+    })
+  })
+})
 
-describe("legacy", () => {
+describe('legacy', () => {
   const baseLegacy = {
     ...base,
-    gasPrice: parseGwei("2"),
-  };
+    gasPrice: parseGwei('2'),
+  }
 
-  test("default", () => {
-    const serialized = serializeTransaction(baseLegacy);
-    assertType<TransactionSerializedLegacy>(serialized);
+  test('default', () => {
+    const serialized = serializeTransaction(baseLegacy)
+    assertType<TransactionSerializedLegacy>(serialized)
     expect(serialized).toEqual(
-      "0xe88203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080"
-    );
+      '0xe88203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseLegacy,
-      type: "legacy",
-    });
-  });
+      type: 'legacy',
+    })
+  })
 
-  test("default (all zeros)", () => {
+  test('default (all zeros)', () => {
     const baseLegacyZero = {
       to: accounts[1].address,
       nonce: 0,
       value: 0n,
       gasPrice: 0n,
-    } satisfies TransactionSerializableLegacy;
+    } satisfies TransactionSerializableLegacy
 
-    const serialized = serializeTransaction(baseLegacyZero);
+    const serialized = serializeTransaction(baseLegacyZero)
 
     expect(serialized).toEqual(
-      "0xda8080809470997970c51812dc3a010c7d01b50e0d17dc79c88080"
-    );
+      '0xda8080809470997970c51812dc3a010c7d01b50e0d17dc79c88080',
+    )
 
     expect(parseTransaction(serialized)).toEqual({
       to: accounts[1].address,
-      type: "legacy",
-    });
-  });
+      type: 'legacy',
+    })
+  })
 
-  test("minimal (w/ gasPrice)", () => {
+  test('minimal (w/ gasPrice)', () => {
     const args = {
-      gasPrice: parseGwei("2"),
-    } satisfies TransactionSerializableLegacy;
-    const serialized = serializeTransaction(args);
-    expect(serialized).toEqual("0xca80847735940080808080");
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
-  });
+      gasPrice: parseGwei('2'),
+    } satisfies TransactionSerializableLegacy
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual('0xca80847735940080808080')
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
+  })
 
-  test("minimal (w/ type)", () => {
+  test('minimal (w/ type)', () => {
     const args = {
-      type: "legacy",
-    } satisfies TransactionSerializableLegacy;
-    const serialized = serializeTransaction(args);
-    expect(serialized).toEqual("0xc6808080808080");
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
-  });
+      type: 'legacy',
+    } satisfies TransactionSerializableLegacy
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual('0xc6808080808080')
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
+  })
 
-  test("args: gas", () => {
+  test('args: gas', () => {
     const args = {
       ...baseLegacy,
       gas: 21001n,
-    };
-    const serialized = serializeTransaction(args);
+    }
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0xea82031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
-  });
+      '0xea82031184773594008252099470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
+  })
 
-  test("args: data", () => {
+  test('args: data', () => {
     const args = {
       ...baseLegacy,
-      data: "0x1234",
-    } satisfies TransactionSerializableLegacy;
-    const serialized = serializeTransaction(args);
+      data: '0x1234',
+    } satisfies TransactionSerializableLegacy
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0xea8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
-  });
+      '0xea8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000821234',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
+  })
 
-  test("args: chainId", () => {
+  test('args: chainId', () => {
     const args = {
       ...baseLegacy,
       chainId: 69,
-    } satisfies TransactionSerializableLegacy;
-    const serialized = serializeTransaction(args);
+    } satisfies TransactionSerializableLegacy
+    const serialized = serializeTransaction(args)
     expect(serialized).toEqual(
-      "0xeb8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080458080"
-    );
-    expect(parseTransaction(serialized)).toEqual({ ...args, type: "legacy" });
-  });
+      '0xeb8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080458080',
+    )
+    expect(parseTransaction(serialized)).toEqual({ ...args, type: 'legacy' })
+  })
 
-  test("signed", async () => {
+  test('signed', async () => {
     const signature = await sign({
       hash: keccak256(serializeTransaction(baseLegacy)),
       privateKey: accounts[0].privateKey,
-    });
-    const serialized = serializeTransaction(baseLegacy, signature);
+    })
+    const serialized = serializeTransaction(baseLegacy, signature)
     expect(serialized).toEqual(
-      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca06cb0e8d21e5baf998fb9a05f47acd83692dc148f90b81b332a152f020da0ae98a0344e49bacb1ef7af7c2ffed9e88d3f0ae0aa4945c9da0a660a03717dd5621f98"
-    );
+      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca06cb0e8d21e5baf998fb9a05f47acd83692dc148f90b81b332a152f020da0ae98a0344e49bacb1ef7af7c2ffed9e88d3f0ae0aa4945c9da0a660a03717dd5621f98',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...baseLegacy,
       ...signature,
-      type: "legacy",
-    });
-  });
+      type: 'legacy',
+    })
+  })
 
-  test("signature", () => {
+  test('signature', () => {
     expect(
       serializeTransaction(
         baseLegacy,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 28n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
+      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ca060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
     expect(
       serializeTransaction(
         baseLegacy,
 
         {
-          r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-          s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
           v: 27n,
-        }
-      )
+        },
+      ),
     ).toEqual(
-      "0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ba060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe"
-    );
-  });
+      '0xf86b8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a7640000801ba060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+  })
 
-  test("signed w/ chainId", async () => {
+  test('signed w/ chainId', async () => {
     const args = {
       ...baseLegacy,
       chainId: 69,
-    };
+    }
     const signature = await sign({
       hash: keccak256(serializeTransaction(args)),
       privateKey: accounts[0].privateKey,
-    });
-    const serialized = serializeTransaction(args, signature);
+    })
+    const serialized = serializeTransaction(args, signature)
     expect(serialized).toEqual(
-      "0xf86c8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a76400008081ada02f43314322cf4c5dd645b028aa0b0dadff0fb73c41a6f0620ff1dfb11601ac30a066f37a65e139fa4b6df33a42ab5ccaeaa7a109382e7430caefd1deee63962626"
-    );
+      '0xf86c8203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a76400008081ada02f43314322cf4c5dd645b028aa0b0dadff0fb73c41a6f0620ff1dfb11601ac30a066f37a65e139fa4b6df33a42ab5ccaeaa7a109382e7430caefd1deee63962626',
+    )
     expect(parseTransaction(serialized)).toEqual({
       ...args,
       ...signature,
-      type: "legacy",
+      type: 'legacy',
       v: 173n,
-    });
-  });
+    })
+  })
 
-  describe("errors", () => {
-    test("invalid v", () => {
+  describe('errors', () => {
+    test('invalid v', () => {
       expect(() =>
         serializeTransaction(
           baseLegacy,
 
           {
-            r: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
-            s: "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+            r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+            s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
             v: 29n,
-          }
-        )
+          },
+        ),
       ).toThrowErrorMatchingInlineSnapshot(`
         "Invalid \`v\` value \\"29\\". Expected 27 or 28.
 
         Version: viem@1.0.2"
-      `);
-    });
-  });
-});
+      `)
+    })
+  })
+})
 
-test("cannot infer type from transaction object", () => {
-  expect(() => serializeTransaction({ chainId: 1, data: "0x1234", nonce: 69 }))
-    .toThrowErrorMatchingInlineSnapshot(`
+test('cannot infer type from transaction object', () => {
+  expect(() =>
+    serializeTransaction({ chainId: 1, data: '0x1234', nonce: 69 }),
+  ).toThrowErrorMatchingInlineSnapshot(`
     "Cannot infer a transaction type from provided transaction.
 
     Provided Transaction:
@@ -609,5 +610,5 @@ test("cannot infer type from transaction object", () => {
     - a Legacy Transaction with \`gasPrice\`
 
     Version: viem@1.0.2"
-  `);
-});
+  `)
+})

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddressError,
   InvalidLegacyVError,
   InvalidStorageKeySizeError,
-} from "../../errors/index.js";
+} from '../../errors/index.js'
 import type {
   AccessList,
   Hex,
@@ -16,53 +16,53 @@ import type {
   TransactionSerializedEIP2930,
   TransactionSerializedLegacy,
   TransactionType,
-} from "../../types/index.js";
-import { isAddress } from "../address/index.js";
-import { concatHex } from "../data/index.js";
-import { toHex, toRlp } from "../encoding/index.js";
-import type { RecursiveArray } from "../encoding/toRlp.js";
+} from '../../types/index.js'
+import { isAddress } from '../address/index.js'
+import { concatHex } from '../data/index.js'
+import { toHex, toRlp } from '../encoding/index.js'
+import type { RecursiveArray } from '../encoding/toRlp.js'
 import {
   assertTransactionEIP1559,
   assertTransactionEIP2930,
   assertTransactionLegacy,
-} from "./assertTransaction.js";
-import { getTransactionType } from "./getTransactionType.js";
-import type { GetTransactionType } from "./getTransactionType.js";
+} from './assertTransaction.js'
+import { getTransactionType } from './getTransactionType.js'
+import type { GetTransactionType } from './getTransactionType.js'
 
 export type SerializedTransactionReturnType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
-  TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>
-> = TransactionSerialized<TTransactionType>;
+  TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>,
+> = TransactionSerialized<TTransactionType>
 
 export function serializeTransaction<
-  TTransactionSerializable extends TransactionSerializable
+  TTransactionSerializable extends TransactionSerializable,
 >(
   transaction: TTransactionSerializable,
-  signature?: Signature
+  signature?: Signature,
 ): SerializedTransactionReturnType<TTransactionSerializable> {
-  const type = getTransactionType(transaction) as GetTransactionType;
+  const type = getTransactionType(transaction) as GetTransactionType
 
-  if (type === "eip1559")
+  if (type === 'eip1559')
     return serializeTransactionEIP1559(
       transaction as TransactionSerializableEIP1559,
-      signature
-    ) as SerializedTransactionReturnType;
+      signature,
+    ) as SerializedTransactionReturnType
 
-  if (type === "eip2930")
+  if (type === 'eip2930')
     return serializeTransactionEIP2930(
       transaction as TransactionSerializableEIP2930,
-      signature
-    ) as SerializedTransactionReturnType;
+      signature,
+    ) as SerializedTransactionReturnType
 
   return serializeTransactionLegacy(
     transaction as TransactionSerializableLegacy,
-    signature
-  ) as SerializedTransactionReturnType;
+    signature,
+  ) as SerializedTransactionReturnType
 }
 
 function serializeTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,
-  signature?: Signature
+  signature?: Signature,
 ): TransactionSerializedEIP1559 {
   const {
     chainId,
@@ -74,131 +74,131 @@ function serializeTransactionEIP1559(
     maxPriorityFeePerGas,
     accessList,
     data,
-  } = transaction;
+  } = transaction
 
-  assertTransactionEIP1559(transaction);
+  assertTransactionEIP1559(transaction)
 
-  const serializedAccessList = serializeAccessList(accessList);
+  const serializedAccessList = serializeAccessList(accessList)
 
   const serializedTransaction = [
     toHex(chainId),
-    nonce ? toHex(nonce) : "0x",
-    maxPriorityFeePerGas ? toHex(maxPriorityFeePerGas) : "0x",
-    maxFeePerGas ? toHex(maxFeePerGas) : "0x",
-    gas ? toHex(gas) : "0x",
-    to ?? "0x",
-    value ? toHex(value) : "0x",
-    data ?? "0x",
+    nonce ? toHex(nonce) : '0x',
+    maxPriorityFeePerGas ? toHex(maxPriorityFeePerGas) : '0x',
+    maxFeePerGas ? toHex(maxFeePerGas) : '0x',
+    gas ? toHex(gas) : '0x',
+    to ?? '0x',
+    value ? toHex(value) : '0x',
+    data ?? '0x',
     serializedAccessList,
-  ];
+  ]
 
   if (signature)
     serializedTransaction.push(
-      signature.v === 27n ? "0x" : toHex(1), // yParity
+      signature.v === 27n ? '0x' : toHex(1), // yParity
       signature.r,
-      signature.s
-    );
+      signature.s,
+    )
 
   return concatHex([
-    "0x02",
+    '0x02',
     toRlp(serializedTransaction),
-  ]) as TransactionSerializedEIP1559;
+  ]) as TransactionSerializedEIP1559
 }
 
 function serializeTransactionEIP2930(
   transaction: TransactionSerializableEIP2930,
-  signature?: Signature
+  signature?: Signature,
 ): TransactionSerializedEIP2930 {
   const { chainId, gas, data, nonce, to, value, accessList, gasPrice } =
-    transaction;
+    transaction
 
-  assertTransactionEIP2930(transaction);
+  assertTransactionEIP2930(transaction)
 
-  const serializedAccessList = serializeAccessList(accessList);
+  const serializedAccessList = serializeAccessList(accessList)
 
   const serializedTransaction = [
     toHex(chainId),
-    nonce ? toHex(nonce) : "0x",
-    gasPrice ? toHex(gasPrice) : "0x",
-    gas ? toHex(gas) : "0x",
-    to ?? "0x",
-    value ? toHex(value) : "0x",
-    data ?? "0x",
+    nonce ? toHex(nonce) : '0x',
+    gasPrice ? toHex(gasPrice) : '0x',
+    gas ? toHex(gas) : '0x',
+    to ?? '0x',
+    value ? toHex(value) : '0x',
+    data ?? '0x',
     serializedAccessList,
-  ];
+  ]
 
   if (signature)
     serializedTransaction.push(
-      signature.v === 27n ? "0x" : toHex(1), // yParity
+      signature.v === 27n ? '0x' : toHex(1), // yParity
       signature.r,
-      signature.s
-    );
+      signature.s,
+    )
 
   return concatHex([
-    "0x01",
+    '0x01',
     toRlp(serializedTransaction),
-  ]) as TransactionSerializedEIP2930;
+  ]) as TransactionSerializedEIP2930
 }
 
 function serializeTransactionLegacy(
   transaction: TransactionSerializableLegacy,
-  signature?: Signature
+  signature?: Signature,
 ): TransactionSerializedLegacy {
-  const { chainId = 0, gas, data, nonce, to, value, gasPrice } = transaction;
+  const { chainId = 0, gas, data, nonce, to, value, gasPrice } = transaction
 
-  assertTransactionLegacy(transaction);
+  assertTransactionLegacy(transaction)
 
   let serializedTransaction = [
-    nonce ? toHex(nonce) : "0x",
-    gasPrice ? toHex(gasPrice) : "0x",
-    gas ? toHex(gas) : "0x",
-    to ?? "0x",
-    value ? toHex(value) : "0x",
-    data ?? "0x",
-  ];
+    nonce ? toHex(nonce) : '0x',
+    gasPrice ? toHex(gasPrice) : '0x',
+    gas ? toHex(gas) : '0x',
+    to ?? '0x',
+    value ? toHex(value) : '0x',
+    data ?? '0x',
+  ]
 
   if (signature) {
-    let v = 27n + (signature.v === 27n ? 0n : 1n);
-    if (chainId > 0) v = BigInt(chainId * 2) + BigInt(35n + signature.v - 27n);
+    let v = 27n + (signature.v === 27n ? 0n : 1n)
+    if (chainId > 0) v = BigInt(chainId * 2) + BigInt(35n + signature.v - 27n)
     else if (signature.v !== v)
-      throw new InvalidLegacyVError({ v: signature.v });
+      throw new InvalidLegacyVError({ v: signature.v })
 
     serializedTransaction = [
       ...serializedTransaction,
       toHex(v),
       signature.r,
       signature.s,
-    ];
+    ]
   } else if (chainId > 0) {
     serializedTransaction = [
       ...serializedTransaction,
       toHex(chainId),
-      "0x",
-      "0x",
-    ];
+      '0x',
+      '0x',
+    ]
   }
 
-  return toRlp(serializedTransaction);
+  return toRlp(serializedTransaction)
 }
 
 function serializeAccessList(accessList?: AccessList): RecursiveArray<Hex> {
-  if (!accessList || accessList.length === 0) return [];
+  if (!accessList || accessList.length === 0) return []
 
-  const serializedAccessList: RecursiveArray<Hex> = [];
+  const serializedAccessList: RecursiveArray<Hex> = []
   for (let i = 0; i < accessList.length; i++) {
-    const { address, storageKeys } = accessList[i];
+    const { address, storageKeys } = accessList[i]
 
     for (let j = 0; j < storageKeys.length; j++) {
       if (storageKeys[j].length - 2 !== 64) {
-        throw new InvalidStorageKeySizeError({ storageKey: storageKeys[j] });
+        throw new InvalidStorageKeySizeError({ storageKey: storageKeys[j] })
       }
     }
 
     if (!isAddress(address)) {
-      throw new InvalidAddressError({ address });
+      throw new InvalidAddressError({ address })
     }
 
-    serializedAccessList.push([address, storageKeys]);
+    serializedAccessList.push([address, storageKeys])
   }
-  return serializedAccessList;
+  return serializedAccessList
 }

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -2,7 +2,7 @@ import {
   InvalidAddressError,
   InvalidLegacyVError,
   InvalidStorageKeySizeError,
-} from '../../errors/index.js'
+} from "../../errors/index.js";
 import type {
   AccessList,
   Hex,
@@ -16,53 +16,53 @@ import type {
   TransactionSerializedEIP2930,
   TransactionSerializedLegacy,
   TransactionType,
-} from '../../types/index.js'
-import { isAddress } from '../address/index.js'
-import { concatHex } from '../data/index.js'
-import { toHex, toRlp } from '../encoding/index.js'
-import type { RecursiveArray } from '../encoding/toRlp.js'
+} from "../../types/index.js";
+import { isAddress } from "../address/index.js";
+import { concatHex } from "../data/index.js";
+import { toHex, toRlp } from "../encoding/index.js";
+import type { RecursiveArray } from "../encoding/toRlp.js";
 import {
   assertTransactionEIP1559,
   assertTransactionEIP2930,
   assertTransactionLegacy,
-} from './assertTransaction.js'
-import { getTransactionType } from './getTransactionType.js'
-import type { GetTransactionType } from './getTransactionType.js'
+} from "./assertTransaction.js";
+import { getTransactionType } from "./getTransactionType.js";
+import type { GetTransactionType } from "./getTransactionType.js";
 
 export type SerializedTransactionReturnType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
-  TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>,
-> = TransactionSerialized<TTransactionType>
+  TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>
+> = TransactionSerialized<TTransactionType>;
 
 export function serializeTransaction<
-  TTransactionSerializable extends TransactionSerializable,
+  TTransactionSerializable extends TransactionSerializable
 >(
   transaction: TTransactionSerializable,
-  signature?: Signature,
+  signature?: Signature
 ): SerializedTransactionReturnType<TTransactionSerializable> {
-  const type = getTransactionType(transaction) as GetTransactionType
+  const type = getTransactionType(transaction) as GetTransactionType;
 
-  if (type === 'eip1559')
+  if (type === "eip1559")
     return serializeTransactionEIP1559(
       transaction as TransactionSerializableEIP1559,
-      signature,
-    ) as SerializedTransactionReturnType
+      signature
+    ) as SerializedTransactionReturnType;
 
-  if (type === 'eip2930')
+  if (type === "eip2930")
     return serializeTransactionEIP2930(
       transaction as TransactionSerializableEIP2930,
-      signature,
-    ) as SerializedTransactionReturnType
+      signature
+    ) as SerializedTransactionReturnType;
 
   return serializeTransactionLegacy(
     transaction as TransactionSerializableLegacy,
-    signature,
-  ) as SerializedTransactionReturnType
+    signature
+  ) as SerializedTransactionReturnType;
 }
 
 function serializeTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,
-  signature?: Signature,
+  signature?: Signature
 ): TransactionSerializedEIP1559 {
   const {
     chainId,
@@ -74,133 +74,131 @@ function serializeTransactionEIP1559(
     maxPriorityFeePerGas,
     accessList,
     data,
-  } = transaction
+  } = transaction;
 
-  assertTransactionEIP1559(transaction)
+  assertTransactionEIP1559(transaction);
 
-  const serializedAccessList = serializeAccessList(accessList)
+  const serializedAccessList = serializeAccessList(accessList);
 
   const serializedTransaction = [
     toHex(chainId),
-    typeof nonce !== 'undefined' ? toHex(nonce) : '0x',
-    typeof maxPriorityFeePerGas !== 'undefined'
-      ? toHex(maxPriorityFeePerGas)
-      : '0x',
-    typeof maxFeePerGas !== 'undefined' ? toHex(maxFeePerGas) : '0x',
-    typeof gas !== 'undefined' ? toHex(gas) : '0x',
-    to ?? '0x',
-    typeof value !== 'undefined' ? toHex(value) : '0x',
-    data ?? '0x',
+    nonce ? toHex(nonce) : "0x",
+    maxPriorityFeePerGas ? toHex(maxPriorityFeePerGas) : "0x",
+    maxFeePerGas ? toHex(maxFeePerGas) : "0x",
+    gas ? toHex(gas) : "0x",
+    to ?? "0x",
+    value ? toHex(value) : "0x",
+    data ?? "0x",
     serializedAccessList,
-  ]
+  ];
 
   if (signature)
     serializedTransaction.push(
-      signature.v === 27n ? '0x' : toHex(1), // yParity
+      signature.v === 27n ? "0x" : toHex(1), // yParity
       signature.r,
-      signature.s,
-    )
+      signature.s
+    );
 
   return concatHex([
-    '0x02',
+    "0x02",
     toRlp(serializedTransaction),
-  ]) as TransactionSerializedEIP1559
+  ]) as TransactionSerializedEIP1559;
 }
 
 function serializeTransactionEIP2930(
   transaction: TransactionSerializableEIP2930,
-  signature?: Signature,
+  signature?: Signature
 ): TransactionSerializedEIP2930 {
   const { chainId, gas, data, nonce, to, value, accessList, gasPrice } =
-    transaction
+    transaction;
 
-  assertTransactionEIP2930(transaction)
+  assertTransactionEIP2930(transaction);
 
-  const serializedAccessList = serializeAccessList(accessList)
+  const serializedAccessList = serializeAccessList(accessList);
 
   const serializedTransaction = [
     toHex(chainId),
-    typeof nonce !== 'undefined' ? toHex(nonce) : '0x',
-    typeof gasPrice !== 'undefined' ? toHex(gasPrice) : '0x',
-    typeof gas !== 'undefined' ? toHex(gas) : '0x',
-    to ?? '0x',
-    typeof value !== 'undefined' ? toHex(value) : '0x',
-    data ?? '0x',
+    nonce ? toHex(nonce) : "0x",
+    gasPrice ? toHex(gasPrice) : "0x",
+    gas ? toHex(gas) : "0x",
+    to ?? "0x",
+    value ? toHex(value) : "0x",
+    data ?? "0x",
     serializedAccessList,
-  ]
+  ];
 
   if (signature)
     serializedTransaction.push(
-      signature.v === 27n ? '0x' : toHex(1), // yParity
+      signature.v === 27n ? "0x" : toHex(1), // yParity
       signature.r,
-      signature.s,
-    )
+      signature.s
+    );
 
   return concatHex([
-    '0x01',
+    "0x01",
     toRlp(serializedTransaction),
-  ]) as TransactionSerializedEIP2930
+  ]) as TransactionSerializedEIP2930;
 }
 
 function serializeTransactionLegacy(
   transaction: TransactionSerializableLegacy,
-  signature?: Signature,
+  signature?: Signature
 ): TransactionSerializedLegacy {
-  const { chainId = 0, gas, data, nonce, to, value, gasPrice } = transaction
+  const { chainId = 0, gas, data, nonce, to, value, gasPrice } = transaction;
 
-  assertTransactionLegacy(transaction)
+  assertTransactionLegacy(transaction);
 
   let serializedTransaction = [
-    typeof nonce !== 'undefined' ? toHex(nonce) : '0x',
-    typeof gasPrice !== 'undefined' ? toHex(gasPrice) : '0x',
-    typeof gas !== 'undefined' ? toHex(gas) : '0x',
-    to ?? '0x',
-    typeof value !== 'undefined' ? toHex(value) : '0x',
-    data ?? '0x',
-  ]
+    nonce ? toHex(nonce) : "0x",
+    gasPrice ? toHex(gasPrice) : "0x",
+    gas ? toHex(gas) : "0x",
+    to ?? "0x",
+    value ? toHex(value) : "0x",
+    data ?? "0x",
+  ];
 
   if (signature) {
-    let v = 27n + (signature.v === 27n ? 0n : 1n)
-    if (chainId > 0) v = BigInt(chainId * 2) + BigInt(35n + signature.v - 27n)
+    let v = 27n + (signature.v === 27n ? 0n : 1n);
+    if (chainId > 0) v = BigInt(chainId * 2) + BigInt(35n + signature.v - 27n);
     else if (signature.v !== v)
-      throw new InvalidLegacyVError({ v: signature.v })
+      throw new InvalidLegacyVError({ v: signature.v });
 
     serializedTransaction = [
       ...serializedTransaction,
       toHex(v),
       signature.r,
       signature.s,
-    ]
+    ];
   } else if (chainId > 0) {
     serializedTransaction = [
       ...serializedTransaction,
       toHex(chainId),
-      '0x',
-      '0x',
-    ]
+      "0x",
+      "0x",
+    ];
   }
 
-  return toRlp(serializedTransaction)
+  return toRlp(serializedTransaction);
 }
 
 function serializeAccessList(accessList?: AccessList): RecursiveArray<Hex> {
-  if (!accessList || accessList.length === 0) return []
+  if (!accessList || accessList.length === 0) return [];
 
-  const serializedAccessList: RecursiveArray<Hex> = []
+  const serializedAccessList: RecursiveArray<Hex> = [];
   for (let i = 0; i < accessList.length; i++) {
-    const { address, storageKeys } = accessList[i]
+    const { address, storageKeys } = accessList[i];
 
     for (let j = 0; j < storageKeys.length; j++) {
       if (storageKeys[j].length - 2 !== 64) {
-        throw new InvalidStorageKeySizeError({ storageKey: storageKeys[j] })
+        throw new InvalidStorageKeySizeError({ storageKey: storageKeys[j] });
       }
     }
 
     if (!isAddress(address)) {
-      throw new InvalidAddressError({ address })
+      throw new InvalidAddressError({ address });
     }
 
-    serializedAccessList.push([address, storageKeys])
+    serializedAccessList.push([address, storageKeys]);
   }
-  return serializedAccessList
+  return serializedAccessList;
 }


### PR DESCRIPTION
Fixes #382

---

### Automated Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b70ac2</samp>

This pull request fixes a bug in the `serializeTransaction` function that caused incorrect encoding of zero values in transactions. It also adds more test cases to ensure the function works as expected for different transaction types. The change is documented in a `.changeset` file for the `viem` package.