### PR TITLE
feat: add `size` argument to hex/bytes encoding utils

### DIFF
--- a/.changeset/plenty-geckos-exercise.md
+++ b/.changeset/plenty-geckos-exercise.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `size` as an argument to hex/bytes encoding/decoding utilities.

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -1360,6 +1360,52 @@ import { toHex } from 'viem'
 toHex(1)
 ```
 
+### formatBytes32String
+
+#### Ethers
+
+```ts {3}
+import { utils } from 'ethers'
+
+utils.formatBytes32String('Hello world')
+// 0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000
+```
+
+#### viem
+
+```ts {3-6}
+import { stringToHex } from 'viem'
+
+stringToHex(
+  'Hello world', 
+  { size: 32 }
+)
+// 0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000
+```
+
+### parseBytes32String
+
+#### Ethers
+
+```ts {3}
+import { utils } from 'ethers'
+
+utils.parseBytes32String('0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000')
+// "Hello world"
+```
+
+#### viem
+
+```ts {3-6}
+import { hexToString } from 'viem'
+
+hexToString(
+  '0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000', 
+  { size: 32 }
+)
+// "Hello world"
+```
+
 ### concat
 
 #### Ethers

--- a/site/docs/utilities/fromBytes.md
+++ b/site/docs/utilities/fromBytes.md
@@ -16,6 +16,14 @@ head:
 
 Decodes a byte array to a string, hex value, boolean or number.
 
+Shortcut Functions:
+
+- [bytesToHex](#bytestohex)
+- [bytesToString](#bytestostring)
+- [bytesToNumber](#bytestonumber)
+- [bytesToBigint](#bytestobigint)
+- [bytesToBool](#bytestobool)
+
 ## Import
 
 ```ts
@@ -60,11 +68,30 @@ The targeted type.
 
 The byte array to decode.
 
-### to
+### toOrOptions
 
-- **Type:** `"string" | "hex" | "number" | "bigint" | "boolean"`
+- **Type:** `"string" | "hex" | "number" | "bigint" | "boolean" | Options`
 
-The output type.
+The output type or options.
+
+```ts {3}
+fromBytes(
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]), 
+  'string' 
+)
+// 'Hello world'
+```
+
+```ts {3-6}
+fromBytes(
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 
+  {
+    size: 32,
+    to: 'string'
+  }
+)
+// 'Hello world'
+```
 
 ## Shortcut Functions
 
@@ -77,8 +104,16 @@ Decodes a byte array to a hex value.
 ```ts
 import { bytesToHex } from 'viem'
 
-bytesToHex(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])) // [!code focus:2]
+bytesToHex( // [!code focus:4]
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+)
 // '0x48656c6c6f20576f726c6421'
+
+bytesToHex( // [!code focus:5]
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 
+  { size: 32 }
+)
+// '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000'
 ```
 
 ### bytesToString
@@ -90,7 +125,15 @@ Decodes a byte array to a string.
 ```ts
 import { bytesToString } from 'viem'
 
-bytesToString(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])) // [!code focus:2]
+bytesToString( // [!code focus:4]
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+)
+// 'Hello world'
+
+bytesToString( // [!code focus:5]
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), 
+  { size: 32 }
+)
 // 'Hello world'
 ```
 
@@ -105,6 +148,12 @@ import { bytesToNumber } from 'viem'
 
 bytesToNumber(new Uint8Array([1, 164])) // [!code focus:2]
 // 420
+
+bytesToNumber( // [!code focus:5]
+  new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 164]), 
+  { size: 32 }
+)
+// 420
 ```
 
 ### bytesToBigint
@@ -116,7 +165,15 @@ Decodes a byte array to a number.
 ```ts
 import { bytesToBigint } from 'viem'
 
-bytesToBigint(new Uint8Array([12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252, 11, 117])) // [!code focus:2]
+bytesToBigint( // [!code focus:4]
+  new Uint8Array([12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252, 11, 117])
+)
+// 4206942069420694206942069420694206942069n
+
+bytesToBigint( // [!code focus:5]
+  new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252, 11, 117]),
+  { size: 32 }
+)
 // 4206942069420694206942069420694206942069n
 ```
 
@@ -130,5 +187,11 @@ Decodes a byte array to a boolean.
 import { bytesToBool } from 'viem'
 
 bytesToBool(new Uint8Array([1])) // [!code focus:2]
+// true
+
+bytesToBool( // [!code focus:5]
+  new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+  { size: 32 }
+) 
 // true
 ```

--- a/site/docs/utilities/fromHex.md
+++ b/site/docs/utilities/fromHex.md
@@ -16,6 +16,14 @@ head:
 
 Decodes a hex value to a string, number or byte array.
 
+Shortcut Functions:
+
+- [hexToNumber](#hextonumber)
+- [hexToBigInt](#hextobigint)
+- [hexToString](#hextostring)
+- [hexToBytes](#hextobytes)
+- [hexToBool](#hextobool)
+
 ## Import
 
 ```ts
@@ -57,11 +65,30 @@ The targeted type.
 
 The hex value to decode.
 
-### to
+### toOrOptions
 
-- **Type:** `"string" | "bigint" | "number" | "bytes" | "boolean"`
+- **Type:** `"string" | "hex" | "number" | "bigint" | "boolean" | Options`
 
-The output type.
+The output type or options.
+
+```ts {3}
+fromHex(
+  '0x48656c6c6f20776f726c642e', 
+  'string'
+)
+// 'Hello world'
+```
+
+```ts {3-6}
+fromHex(
+  '0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000', 
+  {
+    size: 32,
+    to: 'string'
+  }
+)
+// 'Hello world'
+```
 
 ## Shortcut Functions
 
@@ -76,6 +103,12 @@ import { hexToNumber } from 'viem'
 
 hexToNumber('0x1a4')
 // 420
+
+hexToNumber(
+  '0x00000000000000000000000000000000000000000000000000000000000001a4', 
+  { size: 32 }
+)
+// 420
 ```
 
 ### hexToBigInt
@@ -88,6 +121,12 @@ Decodes a hex value to a bigint.
 import { hexToBigInt } from 'viem'
 
 hexToBigInt('0xc5cf39211876fb5e5884327fa56fc0b75')
+// 4206942069420694206942069420694206942069n
+
+hexToBigInt(
+  '0x0000000000000000000000000000000c5cf39211876fb5e5884327fa56fc0b75', 
+  { size: 32 }
+)
 // 4206942069420694206942069420694206942069n
 ```
 
@@ -102,6 +141,12 @@ import { hexToString } from 'viem'
 
 hexToString('0x48656c6c6f20576f726c6421')
 // "Hello World!"
+
+hexToString(
+  '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000',
+  { size: 32 }
+)
+// "Hello World!"
 ```
 
 ### hexToBytes
@@ -115,6 +160,12 @@ import { hexToBytes } from 'viem'
 
 hexToBytes('0x48656c6c6f20576f726c6421')
 // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+
+hexToBytes(
+  '0x48656c6c6f20576f726c64210000000000000000000000000000000000000000',
+  { size: 32 }
+)
+// Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 ```
 
 ### hexToBool
@@ -124,8 +175,14 @@ hexToBytes('0x48656c6c6f20576f726c6421')
 Decodes a hex value to a boolean.
 
 ```ts
-import { hexToBytes } from 'viem'
+import { hexToBool } from 'viem'
 
-hexToBytes('0x1')
+hexToBool('0x1')
+// true
+
+hexToBool(
+  '0x00000000000000000000000000000000000000000000000000000000000001',
+  { size: 32 }
+)
 // true
 ```

--- a/site/docs/utilities/toBytes.md
+++ b/site/docs/utilities/toBytes.md
@@ -16,6 +16,13 @@ head:
 
 Encodes a string, hex value, number or boolean to a byte array.
 
+Shortcut Functions:
+
+- [hexToBytes](#hextobytes)
+- [stringToBytes](#stringtobytes)
+- [numberToBytes](#numbertobytes)
+- [boolToBytes](#booltobytes)
+
 ## Import
 
 ```ts
@@ -54,6 +61,23 @@ The byte array represented as a `Uint8Array`.
 
 The value to encode as bytes.
 
+```ts {2}
+toBytes(
+  'Hello world'
+)
+// Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+```
+
+### options
+
+```ts {3}
+toBytes(
+  'Hello world', 
+  { size: 32 }
+)
+// Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+```
+
 ## Shortcut Functions
 
 ### hexToBytes
@@ -67,6 +91,9 @@ import { numberToHex } from 'viem'
 
 hexToBytes('0x48656c6c6f20576f726c6421') // [!code focus:2]
 // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+
+hexToBytes('0x48656c6c6f20576f726c6421', { size: 32 }) // [!code focus:2]
+// Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 ```
 
 ### stringToBytes
@@ -80,6 +107,9 @@ import { numberToHex } from 'viem'
 
 stringToBytes('Hello world') // [!code focus:2]
 // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+
+stringToBytes('Hello world', { size: 32 }) // [!code focus:2]
+// Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 ```
 
 ### numberToBytes
@@ -93,6 +123,9 @@ import { numberToHex } from 'viem'
 
 numberToBytes(420) // [!code focus:2]
 // Uint8Array([1, 164])
+
+numberToBytes(420, { size: 32 }) // [!code focus:2]
+// Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 164])
 ```
 
 ### boolToBytes
@@ -106,4 +139,7 @@ import { boolToHex } from 'viem'
 
 boolToBytes(true) // [!code focus:2]
 // Uint8Array([1])
+
+boolToBytes(true, { size: 32 }) // [!code focus:2]
+// Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
 ```

--- a/site/docs/utilities/toHex.md
+++ b/site/docs/utilities/toHex.md
@@ -16,6 +16,13 @@ head:
 
 Encodes a string, number, boolean or byte array to a hex value value.
 
+Shortcut Functions: 
+
+- [numberToHex](#numbertohex)
+- [stringToHex](#stringtohex)
+- [bytesToHex](#bytestohex)
+- [boolToHex](#booltohex)
+
 ## Import
 
 ```ts
@@ -50,11 +57,28 @@ The hex value.
 
 ## Parameters
 
-### Value
+### value
 
 - **Type:** `string | number | bigint | ByteArray`
 
 The value to hex encode.
+
+```ts {2}
+toHex(
+  'Hello world'
+)
+// '0x48656c6c6f20776f726c642e'
+```
+
+### options
+
+```ts {3}
+toHex(
+  'Hello world', 
+  { size: 32 }
+)
+// '0x48656c6c6f20776f726c642e0000000000000000000000000000000000000000'
+```
 
 ## Shortcut Functions
 
@@ -72,6 +96,12 @@ numberToHex(420)
 
 numberToHex(4206942069420694206942069420694206942069n)
 // "0xc5cf39211876fb5e5884327fa56fc0b75"
+
+numberToHex(420, { size: 32 })
+// "0x00000000000000000000000000000000000000000000000000000000000001a4"
+
+numberToHex(4206942069420694206942069420694206942069n, { size: 32 })
+// "0x0000000000000000000000000000000c5cf39211876fb5e5884327fa56fc0b75"
 ```
 
 ### stringToHex
@@ -85,6 +115,9 @@ import { stringToHex } from 'viem'
 
 stringToHex('Hello World!')
 // "0x48656c6c6f20576f726c6421"
+
+stringToHex('Hello World!', { size: 32 })
+// "0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"
 ```
 
 ### bytesToHex
@@ -100,6 +133,12 @@ bytesToHex(
   new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
 )
 // "0x48656c6c6f20576f726c6421"
+
+bytesToHex(
+  new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+  { size: 32 }
+)
+// "0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"
 ```
 
 ### boolToHex
@@ -113,4 +152,7 @@ import { stringToHex } from 'viem'
 
 bytesToHex(true)
 // "0x1"
+
+bytesToHex(true, { size: 32 })
+// "0x0000000000000000000000000000000000000000000000000000000000000001"
 ```

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -81,3 +81,12 @@ export class OffsetOutOfBoundsError extends BaseError {
     )
   }
 }
+
+export class SizeOverflowError extends BaseError {
+  override name = 'SizeOverflowError'
+  constructor({ givenSize, maxSize }: { givenSize: number; maxSize: number }) {
+    super(
+      `Size cannot exceed ${maxSize} bytes. Given size: ${givenSize} bytes.`,
+    )
+  }
+}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -58,6 +58,7 @@ export {
   InvalidHexBooleanError,
   InvalidHexValueError,
   OffsetOutOfBoundsError,
+  SizeOverflowError,
 } from './encoding.js'
 
 export {

--- a/src/utils/encoding/fromBytes.test.ts
+++ b/src/utils/encoding/fromBytes.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
 import {
   bytesToBigint,
@@ -8,129 +8,280 @@ import {
   bytesToString,
   fromBytes,
 } from './fromBytes.js'
+import {
+  boolToBytes,
+  hexToBytes,
+  numberToBytes,
+  stringToBytes,
+} from './toBytes.js'
 
-test('converts bytes to number', () => {
-  expect(fromBytes(new Uint8Array([0]), 'number')).toMatchInlineSnapshot('0')
-  expect(fromBytes(new Uint8Array([7]), 'number')).toMatchInlineSnapshot('7')
-  expect(fromBytes(new Uint8Array([69]), 'number')).toMatchInlineSnapshot('69')
-  expect(fromBytes(new Uint8Array([1, 164]), 'number')).toMatchInlineSnapshot(
-    '420',
-  )
+describe('converts bytes to number', () => {
+  test('default', () => {
+    expect(fromBytes(new Uint8Array([0]), 'number')).toMatchInlineSnapshot('0')
+    expect(fromBytes(new Uint8Array([7]), 'number')).toMatchInlineSnapshot('7')
+    expect(fromBytes(new Uint8Array([69]), 'number')).toMatchInlineSnapshot(
+      '69',
+    )
+    expect(fromBytes(new Uint8Array([1, 164]), 'number')).toMatchInlineSnapshot(
+      '420',
+    )
 
-  expect(bytesToNumber(new Uint8Array([0]))).toMatchInlineSnapshot('0')
-  expect(bytesToNumber(new Uint8Array([7]))).toMatchInlineSnapshot('7')
-  expect(bytesToNumber(new Uint8Array([69]))).toMatchInlineSnapshot('69')
-  expect(bytesToNumber(new Uint8Array([1, 164]))).toMatchInlineSnapshot('420')
+    expect(bytesToNumber(new Uint8Array([0]))).toMatchInlineSnapshot('0')
+    expect(bytesToNumber(new Uint8Array([7]))).toMatchInlineSnapshot('7')
+    expect(bytesToNumber(new Uint8Array([69]))).toMatchInlineSnapshot('69')
+    expect(bytesToNumber(new Uint8Array([1, 164]))).toMatchInlineSnapshot('420')
+  })
+
+  test('args: size', () => {
+    expect(
+      fromBytes(numberToBytes(420, { size: 32 }), { size: 32, to: 'number' }),
+    ).toEqual(420)
+    expect(
+      bytesToNumber(numberToBytes(420, { size: 32 }), {
+        size: 32,
+      }),
+    ).toEqual(420)
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      bytesToNumber(numberToBytes(69420, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts bytes to bigint', () => {
-  expect(fromBytes(new Uint8Array([0]), 'bigint')).toMatchInlineSnapshot('0n')
-  expect(fromBytes(new Uint8Array([7]), 'bigint')).toMatchInlineSnapshot('7n')
-  expect(fromBytes(new Uint8Array([69]), 'bigint')).toMatchInlineSnapshot('69n')
-  expect(fromBytes(new Uint8Array([1, 164]), 'bigint')).toMatchInlineSnapshot(
-    '420n',
-  )
-  expect(
-    fromBytes(
-      new Uint8Array([
-        12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252, 11,
-        117,
-      ]),
-      'bigint',
-    ),
-  ).toMatchInlineSnapshot('4206942069420694206942069420694206942069n')
+describe('converts bytes to bigint', () => {
+  test('default', () => {
+    expect(fromBytes(new Uint8Array([0]), 'bigint')).toMatchInlineSnapshot('0n')
+    expect(fromBytes(new Uint8Array([7]), 'bigint')).toMatchInlineSnapshot('7n')
+    expect(fromBytes(new Uint8Array([69]), 'bigint')).toMatchInlineSnapshot(
+      '69n',
+    )
+    expect(fromBytes(new Uint8Array([1, 164]), 'bigint')).toMatchInlineSnapshot(
+      '420n',
+    )
+    expect(
+      fromBytes(
+        new Uint8Array([
+          12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252,
+          11, 117,
+        ]),
+        'bigint',
+      ),
+    ).toMatchInlineSnapshot('4206942069420694206942069420694206942069n')
 
-  expect(bytesToBigint(new Uint8Array([0]))).toMatchInlineSnapshot('0n')
-  expect(bytesToBigint(new Uint8Array([7]))).toMatchInlineSnapshot('7n')
-  expect(bytesToBigint(new Uint8Array([69]))).toMatchInlineSnapshot('69n')
-  expect(bytesToBigint(new Uint8Array([1, 164]))).toMatchInlineSnapshot('420n')
-  expect(
-    bytesToBigint(
-      new Uint8Array([
-        12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252, 11,
-        117,
-      ]),
-    ),
-  ).toMatchInlineSnapshot('4206942069420694206942069420694206942069n')
+    expect(bytesToBigint(new Uint8Array([0]))).toMatchInlineSnapshot('0n')
+    expect(bytesToBigint(new Uint8Array([7]))).toMatchInlineSnapshot('7n')
+    expect(bytesToBigint(new Uint8Array([69]))).toMatchInlineSnapshot('69n')
+    expect(bytesToBigint(new Uint8Array([1, 164]))).toMatchInlineSnapshot(
+      '420n',
+    )
+    expect(
+      bytesToBigint(
+        new Uint8Array([
+          12, 92, 243, 146, 17, 135, 111, 181, 229, 136, 67, 39, 250, 86, 252,
+          11, 117,
+        ]),
+      ),
+    ).toMatchInlineSnapshot('4206942069420694206942069420694206942069n')
+  })
+
+  test('args: size', () => {
+    expect(
+      fromBytes(numberToBytes(420n, { size: 32 }), { size: 32, to: 'bigint' }),
+    ).toEqual(420n)
+    expect(
+      bytesToBigint(numberToBytes(420n, { size: 32 }), {
+        size: 32,
+      }),
+    ).toEqual(420n)
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      bytesToBigint(numberToBytes(69420, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts bytes to boolean', () => {
-  expect(fromBytes(new Uint8Array([0]), 'boolean')).toMatchInlineSnapshot(
-    'false',
-  )
-  expect(fromBytes(new Uint8Array([1]), 'boolean')).toMatchInlineSnapshot(
-    'true',
-  )
+describe('converts bytes to boolean', () => {
+  test('default', () => {
+    expect(fromBytes(new Uint8Array([0]), 'boolean')).toMatchInlineSnapshot(
+      'false',
+    )
+    expect(fromBytes(new Uint8Array([1]), 'boolean')).toMatchInlineSnapshot(
+      'true',
+    )
 
-  expect(bytesToBool(new Uint8Array([0]))).toMatchInlineSnapshot('false')
-  expect(bytesToBool(new Uint8Array([1]))).toMatchInlineSnapshot('true')
+    expect(bytesToBool(new Uint8Array([0]))).toMatchInlineSnapshot('false')
+    expect(bytesToBool(new Uint8Array([1]))).toMatchInlineSnapshot('true')
+  })
 
-  expect(() =>
-    bytesToBool(new Uint8Array([69])),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    "Bytes value \\"69\\" is not a valid boolean. The bytes array must contain a single byte of either a 0 or 1 value.
+  test('args: size', () => {
+    expect(
+      fromBytes(boolToBytes(true, { size: 32 }), { size: 32, to: 'boolean' }),
+    ).toEqual(true)
+    expect(
+      bytesToBool(boolToBytes(true, { size: 32 }), {
+        size: 32,
+      }),
+    ).toEqual(true)
+  })
 
-    Version: viem@1.0.2"
-  `)
-  expect(() =>
-    bytesToBool(new Uint8Array([1, 2])),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    "Bytes value \\"1,2\\" is not a valid boolean. The bytes array must contain a single byte of either a 0 or 1 value.
+  test('error: size overflow', () => {
+    expect(() =>
+      bytesToBool(boolToBytes(true, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
 
-    Version: viem@1.0.2"
-  `)
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('error: invalid boolean', () => {
+    expect(() =>
+      bytesToBool(new Uint8Array([69])),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Bytes value \\"69\\" is not a valid boolean. The bytes array must contain a single byte of either a 0 or 1 value.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      bytesToBool(new Uint8Array([1, 2])),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Bytes value \\"1,2\\" is not a valid boolean. The bytes array must contain a single byte of either a 0 or 1 value.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts bytes to string', () => {
-  expect(fromBytes(new Uint8Array([]), 'string')).toMatchInlineSnapshot(`""`)
-  expect(fromBytes(new Uint8Array([97]), 'string')).toMatchInlineSnapshot(`"a"`)
-  expect(
-    fromBytes(new Uint8Array([97, 98, 99]), 'string'),
-  ).toMatchInlineSnapshot(`"abc"`)
-  expect(
-    fromBytes(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-      'string',
-    ),
-  ).toMatchInlineSnapshot(`"Hello World!"`)
+describe('converts bytes to string', () => {
+  test('default', () => {
+    expect(fromBytes(new Uint8Array([]), 'string')).toMatchInlineSnapshot(`""`)
+    expect(fromBytes(new Uint8Array([97]), 'string')).toMatchInlineSnapshot(
+      `"a"`,
+    )
+    expect(
+      fromBytes(new Uint8Array([97, 98, 99]), 'string'),
+    ).toMatchInlineSnapshot(`"abc"`)
+    expect(
+      fromBytes(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        'string',
+      ),
+    ).toMatchInlineSnapshot(`"Hello World!"`)
 
-  expect(bytesToString(new Uint8Array([]))).toMatchInlineSnapshot(`""`)
-  expect(bytesToString(new Uint8Array([97]))).toMatchInlineSnapshot(`"a"`)
-  expect(bytesToString(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
-    `"abc"`,
-  )
-  expect(
-    bytesToString(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-    ),
-  ).toMatchInlineSnapshot(`"Hello World!"`)
+    expect(bytesToString(new Uint8Array([]))).toMatchInlineSnapshot(`""`)
+    expect(bytesToString(new Uint8Array([97]))).toMatchInlineSnapshot(`"a"`)
+    expect(bytesToString(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
+      `"abc"`,
+    )
+    expect(
+      bytesToString(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+      ),
+    ).toMatchInlineSnapshot(`"Hello World!"`)
+  })
+
+  test('args: size', () => {
+    expect(
+      fromBytes(stringToBytes('wagmi', { size: 32 }), {
+        size: 32,
+        to: 'string',
+      }),
+    ).toEqual('wagmi')
+    expect(
+      bytesToString(stringToBytes('wagmi', { size: 32 }), {
+        size: 32,
+      }),
+    ).toEqual('wagmi')
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      bytesToString(stringToBytes('wagmi', { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts bytes to hex', () => {
-  expect(fromBytes(new Uint8Array([97, 98, 99]), 'hex')).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(fromBytes(new Uint8Array([97]), 'hex')).toMatchInlineSnapshot('"0x61"')
-  expect(fromBytes(new Uint8Array([97, 98, 99]), 'hex')).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(
-    fromBytes(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-      'hex',
-    ),
-  ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+describe('converts bytes to hex', () => {
+  test('default', () => {
+    expect(
+      fromBytes(new Uint8Array([97, 98, 99]), 'hex'),
+    ).toMatchInlineSnapshot('"0x616263"')
+    expect(fromBytes(new Uint8Array([97]), 'hex')).toMatchInlineSnapshot(
+      '"0x61"',
+    )
+    expect(
+      fromBytes(new Uint8Array([97, 98, 99]), 'hex'),
+    ).toMatchInlineSnapshot('"0x616263"')
+    expect(
+      fromBytes(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        'hex',
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
 
-  expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(bytesToHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
-  expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(
-    bytesToHex(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-    ),
-  ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+    expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
+      '"0x616263"',
+    )
+    expect(bytesToHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
+    expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
+      '"0x616263"',
+    )
+    expect(
+      bytesToHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+  })
+
+  test('args: size', () => {
+    expect(
+      fromBytes(hexToBytes('0x420696', { size: 32 }), {
+        size: 32,
+        to: 'hex',
+      }),
+    ).toMatchInlineSnapshot(
+      '"0x4206960000000000000000000000000000000000000000000000000000000000"',
+    )
+    expect(
+      bytesToHex(hexToBytes('0x420696', { size: 32 }), {
+        size: 32,
+      }),
+    ).toMatchInlineSnapshot(
+      '"0x4206960000000000000000000000000000000000000000000000000000000000"',
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      bytesToHex(hexToBytes('0x420696', { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -4,7 +4,9 @@ import { trim } from '../data/trim.js'
 import { assertSize, hexToBigInt, hexToNumber } from './fromHex.js'
 import { bytesToHex } from './toHex.js'
 
-export type FromBytesParameters<TTo> =
+export type FromBytesParameters<
+  TTo extends 'string' | 'hex' | 'bigint' | 'number' | 'boolean',
+> =
   | TTo
   | {
       /** Size of the bytes. */

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -1,7 +1,17 @@
 import { InvalidBytesBooleanError } from '../../errors/index.js'
 import type { ByteArray, Hex } from '../../types/index.js'
-import { hexToBigInt, hexToNumber } from './fromHex.js'
+import { trim } from '../data/trim.js'
+import { assertSize, hexToBigInt, hexToNumber } from './fromHex.js'
 import { bytesToHex } from './toHex.js'
+
+export type FromBytesParameters<TTo> =
+  | TTo
+  | {
+      /** Size of the bytes. */
+      size?: number
+      /** Type to convert to. */
+      to: TTo
+    }
 
 type FromBytesReturnType<TTo> = TTo extends 'string'
   ? string
@@ -16,30 +26,106 @@ type FromBytesReturnType<TTo> = TTo extends 'string'
   : never
 
 /**
- * @description Decodes a byte array into a UTF-8 string, hex value, number, bigint or boolean.
+ * Decodes a byte array into a UTF-8 string, hex value, number, bigint or boolean.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromBytes.html
+ * - Example: https://viem.sh/docs/utilities/fromBytes.html#usage
+ *
+ * @param bytes Byte array to decode.
+ * @param toOrOpts Type to convert to or options.
+ * @returns Decoded value.
+ *
+ * @example
+ * import { fromBytes } from 'viem'
+ * const data = fromBytes(new Uint8Array([1, 164]), 'number')
+ * // 420
+ *
+ * @example
+ * import { fromBytes } from 'viem'
+ * const data = fromBytes(
+ *   new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
+ *   'string'
+ * )
+ * // 'Hello world'
  */
 export function fromBytes<
   TTo extends 'string' | 'hex' | 'bigint' | 'number' | 'boolean',
->(bytes: ByteArray, to: TTo): FromBytesReturnType<TTo> {
-  if (to === 'number') return bytesToNumber(bytes) as FromBytesReturnType<TTo>
-  if (to === 'bigint') return bytesToBigint(bytes) as FromBytesReturnType<TTo>
-  if (to === 'boolean') return bytesToBool(bytes) as FromBytesReturnType<TTo>
-  if (to === 'string') return bytesToString(bytes) as FromBytesReturnType<TTo>
-  return bytesToHex(bytes) as FromBytesReturnType<TTo>
+>(
+  bytes: ByteArray,
+  toOrOpts: FromBytesParameters<TTo>,
+): FromBytesReturnType<TTo> {
+  const opts = typeof toOrOpts === 'string' ? { to: toOrOpts } : toOrOpts
+  const to = opts.to
+
+  if (to === 'number')
+    return bytesToNumber(bytes, opts) as FromBytesReturnType<TTo>
+  if (to === 'bigint')
+    return bytesToBigint(bytes, opts) as FromBytesReturnType<TTo>
+  if (to === 'boolean')
+    return bytesToBool(bytes, opts) as FromBytesReturnType<TTo>
+  if (to === 'string')
+    return bytesToString(bytes, opts) as FromBytesReturnType<TTo>
+  return bytesToHex(bytes, opts) as FromBytesReturnType<TTo>
+}
+
+export type BytesToBigIntOpts = {
+  /** Whether or not the number of a signed representation. */
+  signed?: boolean
+  /** Size of the bytes. */
+  size?: number
 }
 
 /**
- * @description Decodes a byte array into a bigint.
+ * Decodes a byte array into a bigint.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromBytes.html#bytestobigint
+ *
+ * @param bytes Byte array to decode.
+ * @param opts Options.
+ * @returns BigInt value.
+ *
+ * @example
+ * import { bytesToBigint } from 'viem'
+ * const data = bytesToBigint(new Uint8Array([1, 164]))
+ * // 420n
  */
-export function bytesToBigint(bytes: ByteArray): bigint {
-  const hex = bytesToHex(bytes)
+export function bytesToBigint(
+  bytes: ByteArray,
+  opts: BytesToBigIntOpts = {},
+): bigint {
+  if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
+  const hex = bytesToHex(bytes, opts)
   return hexToBigInt(hex)
 }
 
+export type BytesToBoolOpts = {
+  /** Size of the bytes. */
+  size?: number
+}
+
 /**
- * @description Decodes a byte array into a boolean.
+ * Decodes a byte array into a boolean.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromBytes.html#bytestobool
+ *
+ * @param bytes Byte array to decode.
+ * @param opts Options.
+ * @returns Boolean value.
+ *
+ * @example
+ * import { bytesToBool } from 'viem'
+ * const data = bytesToBool(new Uint8Array([1]))
+ * // true
  */
-export function bytesToBool(bytes: ByteArray): boolean {
+export function bytesToBool(
+  bytes_: ByteArray,
+  opts: BytesToBoolOpts = {},
+): boolean {
+  let bytes = bytes_
+  if (typeof opts.size !== 'undefined') {
+    assertSize(bytes, { size: opts.size })
+    bytes = trim(bytes)
+  }
   if (bytes.length > 1 || bytes[0] > 1)
     throw new InvalidBytesBooleanError(bytes)
   return Boolean(bytes[0])
@@ -47,17 +133,58 @@ export function bytesToBool(bytes: ByteArray): boolean {
 
 export { bytesToHex }
 
+export type BytesToNumberOpts = BytesToBigIntOpts
+
 /**
- * @description Decodes a byte array into a number.
+ * Decodes a byte array into a number.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromBytes.html#bytestonumber
+ *
+ * @param bytes Byte array to decode.
+ * @param opts Options.
+ * @returns Number value.
+ *
+ * @example
+ * import { bytesToNumber } from 'viem'
+ * const data = bytesToNumber(new Uint8Array([1, 164]))
+ * // 420
  */
-export function bytesToNumber(bytes: ByteArray): number {
-  const hex = bytesToHex(bytes)
+export function bytesToNumber(
+  bytes: ByteArray,
+  opts: BytesToNumberOpts = {},
+): number {
+  if (typeof opts.size !== 'undefined') assertSize(bytes, { size: opts.size })
+  const hex = bytesToHex(bytes, opts)
   return hexToNumber(hex)
 }
 
+export type BytesToStringOpts = {
+  /** Size of the bytes. */
+  size?: number
+}
+
 /**
- * @description Decodes a byte array into a UTF-8 string.
+ * Decodes a byte array into a UTF-8 string.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromBytes.html#bytestostring
+ *
+ * @param bytes Byte array to decode.
+ * @param opts Options.
+ * @returns String value.
+ *
+ * @example
+ * import { bytesToString } from 'viem'
+ * const data = bytesToString(new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]))
+ * // 'Hello world'
  */
-export function bytesToString(bytes: ByteArray): string {
+export function bytesToString(
+  bytes_: ByteArray,
+  opts: BytesToStringOpts = {},
+): string {
+  let bytes = bytes_
+  if (typeof opts.size !== 'undefined') {
+    assertSize(bytes, { size: opts.size })
+    bytes = trim(bytes, { dir: 'right' })
+  }
   return new TextDecoder().decode(bytes)
 }

--- a/src/utils/encoding/fromHex.test.ts
+++ b/src/utils/encoding/fromHex.test.ts
@@ -7,6 +7,8 @@ import {
   hexToNumber,
   hexToString,
 } from './fromHex.js'
+import { boolToHex, bytesToHex, numberToHex, stringToHex } from './toHex.js'
+import { hexToBytes } from './toBytes.js'
 
 describe('converts hex to number', () => {
   test('default', () => {
@@ -45,6 +47,25 @@ describe('converts hex to number', () => {
       694206942069420,
     )
   })
+
+  test('args: size', () => {
+    expect(
+      fromHex(numberToHex(69420, { size: 32 }), { size: 32, to: 'number' }),
+    ).toEqual(69420)
+    expect(hexToNumber(numberToHex(69420, { size: 32 }), { size: 32 })).toEqual(
+      69420,
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      hexToNumber(numberToHex(69420, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
 describe('converts hex to bigint', () => {
@@ -66,7 +87,7 @@ describe('converts hex to bigint', () => {
     ).toMatchInlineSnapshot('4206942069420694206942069420694206942069n')
   })
 
-  test('signed', () => {
+  test('args: signed', () => {
     expect(hexToBigInt('0x20', { signed: true })).toBe(32n)
     expect(
       hexToBigInt('0xe0', {
@@ -92,78 +113,244 @@ describe('converts hex to bigint', () => {
       ),
     ).toBe(-12312312312312312412n)
   })
+
+  test('args: size', () => {
+    expect(
+      fromHex(numberToHex(69420n, { size: 32 }), { size: 32, to: 'bigint' }),
+    ).toEqual(69420n)
+    expect(
+      hexToBigInt(numberToHex(69420n, { size: 32 }), { size: 32 }),
+    ).toEqual(69420n)
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      hexToBigInt(numberToHex(69420, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts hex to boolean', () => {
-  expect(fromHex('0x0', 'boolean')).toMatchInlineSnapshot('false')
-  expect(fromHex('0x1', 'boolean')).toMatchInlineSnapshot('true')
+describe('converts hex to boolean', () => {
+  test('default', () => {
+    expect(fromHex('0x0', 'boolean')).toMatchInlineSnapshot('false')
+    expect(fromHex('0x1', 'boolean')).toMatchInlineSnapshot('true')
 
-  expect(hexToBool('0x0')).toMatchInlineSnapshot('false')
-  expect(hexToBool('0x1')).toMatchInlineSnapshot('true')
+    expect(hexToBool('0x0')).toMatchInlineSnapshot('false')
+    expect(hexToBool('0x1')).toMatchInlineSnapshot('true')
+  })
 
-  expect(() => hexToBool('0xa')).toThrowErrorMatchingInlineSnapshot(
-    `
-    "Hex value \\"0xa\\" is not a valid boolean. The hex value must be \\"0x0\\" (false) or \\"0x1\\" (true).
+  test('args: size', () => {
+    expect(
+      fromHex(boolToHex(true, { size: 32 }), { size: 32, to: 'boolean' }),
+    ).toEqual(true)
+    expect(hexToBool(boolToHex(true, { size: 32 }), { size: 32 })).toEqual(true)
+  })
 
-    Version: viem@1.0.2"
-  `,
-  )
+  test('error: size overflow', () => {
+    expect(() =>
+      hexToBool(boolToHex(true, { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('error: invalid boolean', () => {
+    expect(() => hexToBool('0xa')).toThrowErrorMatchingInlineSnapshot(
+      `
+      "Hex value \\"0xa\\" is not a valid boolean. The hex value must be \\"0x0\\" (false) or \\"0x1\\" (true).
+
+      Version: viem@1.0.2"
+    `,
+    )
+  })
 })
 
-test('converts hex to string', () => {
-  expect(fromHex('0x', 'string')).toMatchInlineSnapshot(`""`)
-  expect(fromHex('0x61', 'string')).toMatchInlineSnapshot(`"a"`)
-  expect(fromHex('0x616263', 'string')).toMatchInlineSnapshot(`"abc"`)
-  expect(fromHex('0x48656c6c6f20576f726c6421', 'string')).toMatchInlineSnapshot(
-    `"Hello World!"`,
-  )
+describe('converts hex to string', () => {
+  test('default', () => {
+    expect(fromHex('0x', 'string')).toMatchInlineSnapshot(`""`)
+    expect(fromHex('0x61', 'string')).toMatchInlineSnapshot(`"a"`)
+    expect(fromHex('0x616263', 'string')).toMatchInlineSnapshot(`"abc"`)
+    expect(
+      fromHex('0x48656c6c6f20576f726c6421', 'string'),
+    ).toMatchInlineSnapshot(`"Hello World!"`)
 
-  expect(hexToString('0x')).toMatchInlineSnapshot(`""`)
-  expect(hexToString('0x61')).toMatchInlineSnapshot(`"a"`)
-  expect(hexToString('0x616263')).toMatchInlineSnapshot(`"abc"`)
-  expect(hexToString('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(
-    `"Hello World!"`,
-  )
+    expect(hexToString('0x')).toMatchInlineSnapshot(`""`)
+    expect(hexToString('0x61')).toMatchInlineSnapshot(`"a"`)
+    expect(hexToString('0x616263')).toMatchInlineSnapshot(`"abc"`)
+    expect(hexToString('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(
+      `"Hello World!"`,
+    )
+  })
+
+  test('args: size', () => {
+    expect(
+      fromHex(stringToHex('wagmi', { size: 32 }), {
+        size: 32,
+        to: 'string',
+      }),
+    ).toEqual('wagmi')
+    expect(
+      hexToString(stringToHex('wagmi', { size: 32 }), { size: 32 }),
+    ).toEqual('wagmi')
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      hexToString(stringToHex('wagmi', { size: 64 }), { size: 32 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts hex to bytes', () => {
-  expect(fromHex('0x', 'bytes')).toMatchInlineSnapshot('Uint8Array []')
-  expect(fromHex('0x61', 'bytes')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-    ]
-  `)
-  expect(fromHex('0x616263', 'bytes')).toMatchInlineSnapshot(
-    `
-    Uint8Array [
-      97,
-      98,
-      99,
-    ]
-  `,
-  )
-  expect(fromHex('0x48656c6c6f20576f726c6421', 'bytes')).toMatchInlineSnapshot(`
-    Uint8Array [
-      72,
-      101,
-      108,
-      108,
-      111,
-      32,
-      87,
-      111,
-      114,
-      108,
-      100,
-      33,
-    ]
-  `)
+describe('converts hex to bytes', () => {
+  test('default', () => {
+    expect(fromHex('0x', 'bytes')).toMatchInlineSnapshot('Uint8Array []')
+    expect(fromHex('0x61', 'bytes')).toMatchInlineSnapshot(`
+      Uint8Array [
+        97,
+      ]
+    `)
+    expect(fromHex('0x616263', 'bytes')).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        97,
+        98,
+        99,
+      ]
+    `,
+    )
+    expect(
+      fromHex('0x48656c6c6f20576f726c6421', 'bytes'),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+      ]
+    `)
+  })
 
-  expect(() =>
-    fromHex('0x420fggf11a', 'bytes'),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    "Invalid byte sequence (\\"gg\\" in \\"420fggf11a\\").
+  test('args: size', () => {
+    expect(
+      fromHex(bytesToHex(Uint8Array.from([69, 420]), { size: 32 }), {
+        size: 32,
+        to: 'bytes',
+      }),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        69,
+        164,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `)
+    expect(
+      hexToBytes(bytesToHex(Uint8Array.from([69, 420]), { size: 32 }), {
+        size: 32,
+      }),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        69,
+        164,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `)
+  })
 
-    Version: viem@1.0.2"
-  `)
+  test('error: size overflow', () => {
+    expect(() =>
+      hexToString(bytesToHex(Uint8Array.from([69, 420]), { size: 64 }), {
+        size: 32,
+      }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 32 bytes. Given size: 64 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('error: invalid bytes', () => {
+    expect(() =>
+      fromHex('0x420fggf11a', 'bytes'),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Invalid byte sequence (\\"gg\\" in \\"420fggf11a\\").
+
+      Version: viem@1.0.2"
+    `)
+  })
 })

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -18,7 +18,9 @@ export function assertSize(
     })
 }
 
-export type FromHexParameters<TTo> =
+export type FromHexParameters<
+  TTo extends 'string' | 'bigint' | 'number' | 'bytes' | 'boolean',
+> =
   | TTo
   | {
       /** Size (in bytes) of the hex value. */

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -1,9 +1,33 @@
-import { InvalidHexBooleanError } from '../../errors/index.js'
+import {
+  InvalidHexBooleanError,
+  SizeOverflowError,
+} from '../../errors/index.js'
 import type { ByteArray, Hex } from '../../types/index.js'
+import { size as size_ } from '../data/size.js'
 import { trim } from '../data/index.js'
 import { hexToBytes } from './toBytes.js'
 
-type FromHexReturnType<TTo> = TTo extends 'string'
+export function assertSize(
+  hexOrBytes: Hex | ByteArray,
+  { size }: { size: number },
+): void {
+  if (size_(hexOrBytes) > size)
+    throw new SizeOverflowError({
+      givenSize: size_(hexOrBytes),
+      maxSize: size,
+    })
+}
+
+export type FromHexParameters<TTo> =
+  | TTo
+  | {
+      /** Size (in bytes) of the hex value. */
+      size?: number
+      /** Type to convert to. */
+      to: TTo
+    }
+
+export type FromHexReturnType<TTo> = TTo extends 'string'
   ? string
   : TTo extends 'bigint'
   ? bigint
@@ -16,28 +40,76 @@ type FromHexReturnType<TTo> = TTo extends 'string'
   : never
 
 /**
- * @description Decodes a hex string into a string, number, bigint, boolean, or bytes32 array.
+ * Decodes a hex string into a string, number, bigint, boolean, or byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromHex.html
+ * - Example: https://viem.sh/docs/utilities/fromHex.html#usage
+ *
+ * @param hex Hex string to decode.
+ * @param toOrOpts Type to convert to or options.
+ * @returns Decoded value.
+ *
+ * @example
+ * import { fromHex } from 'viem'
+ * const data = fromHex('0x1a4', 'number')
+ * // 420
+ *
+ * @example
+ * import { fromHex } from 'viem'
+ * const data = fromHex('0x48656c6c6f20576f726c6421', 'string')
+ * // 'Hello world'
+ *
+ * @example
+ * import { fromHex } from 'viem'
+ * const data = fromHex('0x48656c6c6f20576f726c64210000000000000000000000000000000000000000', {
+ *   size: 32,
+ *   to: 'string'
+ * })
+ * // 'Hello world'
  */
 export function fromHex<
   TTo extends 'string' | 'bigint' | 'number' | 'bytes' | 'boolean',
->(hex: Hex, to: TTo): FromHexReturnType<TTo> {
-  if (to === 'number') return hexToNumber(hex) as FromHexReturnType<TTo>
-  if (to === 'bigint') return hexToBigInt(hex) as FromHexReturnType<TTo>
-  if (to === 'string') return hexToString(hex) as FromHexReturnType<TTo>
-  if (to === 'boolean') return hexToBool(hex) as FromHexReturnType<TTo>
-  return hexToBytes(hex) as FromHexReturnType<TTo>
+>(hex: Hex, toOrOpts: FromHexParameters<TTo>): FromHexReturnType<TTo> {
+  const opts = typeof toOrOpts === 'string' ? { to: toOrOpts } : toOrOpts
+  const to = opts.to
+
+  if (to === 'number') return hexToNumber(hex, opts) as FromHexReturnType<TTo>
+  if (to === 'bigint') return hexToBigInt(hex, opts) as FromHexReturnType<TTo>
+  if (to === 'string') return hexToString(hex, opts) as FromHexReturnType<TTo>
+  if (to === 'boolean') return hexToBool(hex, opts) as FromHexReturnType<TTo>
+  return hexToBytes(hex, opts) as FromHexReturnType<TTo>
 }
 
 export type HexToBigIntOpts = {
-  // Whether or not the number of a signed representation.
+  /** Whether or not the number of a signed representation. */
   signed?: boolean
+  /** Size (in bytes) of the hex value. */
+  size?: number
 }
 
 /**
- * @description Decodes a hex string into a bigint.
+ * Decodes a hex value into a bigint.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromHex.html#hextobigint
+ *
+ * @param hex Hex value to decode.
+ * @param opts Options.
+ * @returns BigInt value.
+ *
+ * @example
+ * import { hexToBigInt } from 'viem'
+ * const data = hexToBigInt('0x1a4', { signed: true })
+ * // 420n
+ *
+ * @example
+ * import { hexToBigInt } from 'viem'
+ * const data = hexToBigInt('0x00000000000000000000000000000000000000000000000000000000000001a4', { size: 32 })
+ * // 420n
  */
 export function hexToBigInt(hex: Hex, opts: HexToBigIntOpts = {}): bigint {
   const { signed } = opts
+
+  if (opts.size) assertSize(hex, { size: opts.size })
 
   const value = BigInt(hex)
   if (!signed) return value
@@ -49,28 +121,97 @@ export function hexToBigInt(hex: Hex, opts: HexToBigIntOpts = {}): bigint {
   return value - BigInt(`0x${'f'.padStart(size * 2, 'f')}`) - 1n
 }
 
+export type HexToBoolOpts = {
+  /** Size (in bytes) of the hex value. */
+  size?: number
+}
+
 /**
- * @description Decodes a hex string into a boolean.
+ * Decodes a hex value into a boolean.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromHex.html#hextobool
+ *
+ * @param hex Hex value to decode.
+ * @param opts Options.
+ * @returns Boolean value.
+ *
+ * @example
+ * import { hexToBool } from 'viem'
+ * const data = hexToBool('0x1')
+ * // true
+ *
+ * @example
+ * import { hexToBool } from 'viem'
+ * const data = hexToBool('0x0000000000000000000000000000000000000000000000000000000000000001', { size: 32 })
+ * // true
  */
-export function hexToBool(hex: Hex): boolean {
+export function hexToBool(hex_: Hex, opts: HexToBoolOpts = {}): boolean {
+  let hex = hex_
+  if (opts.size) {
+    assertSize(hex, { size: opts.size })
+    hex = trim(hex)
+  }
   if (trim(hex) === '0x0') return false
   if (trim(hex) === '0x1') return true
   throw new InvalidHexBooleanError(hex)
 }
 
-type NumberToHexOpts = HexToBigIntOpts
+export type HexToNumberOpts = HexToBigIntOpts
 
 /**
- * @description Decodes a hex string into a number.
+ * Decodes a hex string into a number.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromHex.html#hextonumber
+ *
+ * @param hex Hex value to decode.
+ * @param opts Options.
+ * @returns Number value.
+ *
+ * @example
+ * import { hexToNumber } from 'viem'
+ * const data = hexToNumber('0x1a4')
+ * // 420
+ *
+ * @example
+ * import { hexToNumber } from 'viem'
+ * const data = hexToBigInt('0x00000000000000000000000000000000000000000000000000000000000001a4', { size: 32 })
+ * // 420
  */
-export function hexToNumber(hex: Hex, opts: NumberToHexOpts = {}): number {
+export function hexToNumber(hex: Hex, opts: HexToNumberOpts = {}): number {
   return Number(hexToBigInt(hex, opts))
 }
 
+export type HexToStringOpts = {
+  /** Size (in bytes) of the hex value. */
+  size?: number
+}
+
 /**
- * @description Decodes a hex string into a UTF-8 string.
+ * Decodes a hex value into a UTF-8 string.
+ *
+ * - Docs: https://viem.sh/docs/utilities/fromHex.html#hextostring
+ *
+ * @param hex Hex value to decode.
+ * @param opts Options.
+ * @returns String value.
+ *
+ * @example
+ * import { hexToString } from 'viem'
+ * const data = hexToString('0x48656c6c6f20576f726c6421')
+ * // 'Hello world!'
+ *
+ * @example
+ * import { hexToString } from 'viem'
+ * const data = hexToString('0x48656c6c6f20576f726c64210000000000000000000000000000000000000000', {
+ *  size: 32,
+ * })
+ * // 'Hello world'
  */
-export function hexToString(hex: Hex): string {
-  const bytes = hexToBytes(hex)
+export function hexToString(hex: Hex, opts: HexToStringOpts = {}): string {
+  let bytes = hexToBytes(hex)
+  if (opts.size) {
+    assertSize(bytes, { size: opts.size })
+    bytes = trim(bytes, { dir: 'right' })
+  }
   return new TextDecoder().decode(bytes)
 }

--- a/src/utils/encoding/toBytes.test.ts
+++ b/src/utils/encoding/toBytes.test.ts
@@ -83,6 +83,42 @@ describe('converts numbers to bytes', () => {
         44,
       ]
     `)
+    expect(numberToBytes(69420, { size: 32 })).toMatchInlineSnapshot(`
+      Uint8Array [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        15,
+        44,
+      ]
+    `)
 
     expect(() =>
       numberToBytes(-7, { size: 1 }),
@@ -563,79 +599,189 @@ describe('converts bigints to bytes', () => {
   })
 })
 
-test('converts boolean to bytes', () => {
-  expect(toBytes(true)).toMatchInlineSnapshot(`
-    Uint8Array [
-      1,
-    ]
-  `)
-  expect(toBytes(false)).toMatchInlineSnapshot(`
-    Uint8Array [
-      0,
-    ]
-  `)
+describe('converts boolean to bytes', () => {
+  test('default', () => {
+    expect(toBytes(true)).toMatchInlineSnapshot(`
+      Uint8Array [
+        1,
+      ]
+    `)
+    expect(toBytes(false)).toMatchInlineSnapshot(`
+      Uint8Array [
+        0,
+      ]
+    `)
 
-  expect(boolToBytes(true)).toMatchInlineSnapshot(`
-    Uint8Array [
-      1,
-    ]
-  `)
-  expect(boolToBytes(false)).toMatchInlineSnapshot(`
-    Uint8Array [
-      0,
-    ]
-  `)
+    expect(boolToBytes(true)).toMatchInlineSnapshot(`
+      Uint8Array [
+        1,
+      ]
+    `)
+    expect(boolToBytes(false)).toMatchInlineSnapshot(`
+      Uint8Array [
+        0,
+      ]
+    `)
+  })
+
+  test('args: size', () => {
+    expect(toBytes(true, { size: 16 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ]
+    `,
+    )
+    expect(toBytes(true, { size: 32 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ]
+    `,
+    )
+    expect(boolToBytes(false, { size: 16 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+    expect(boolToBytes(false, { size: 32 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() => toBytes(true, { size: 0 })).toThrowErrorMatchingInlineSnapshot(
+      `
+      "Size cannot exceed 0 bytes. Given size: 1 bytes.
+
+      Version: viem@1.0.2"
+    `,
+    )
+    expect(() =>
+      boolToBytes(false, { size: 0 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 0 bytes. Given size: 1 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts hex to bytes', () => {
-  expect(toBytes('0x')).toMatchInlineSnapshot('Uint8Array []')
-  expect(toBytes('0x61')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-    ]
-  `)
-  expect(toBytes('0x616263')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-      98,
-      99,
-    ]
-  `)
-  expect(toBytes('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(
-    `
-    Uint8Array [
-      72,
-      101,
-      108,
-      108,
-      111,
-      32,
-      87,
-      111,
-      114,
-      108,
-      100,
-      33,
-    ]
-  `,
-  )
-
-  expect(hexToBytes('0x')).toMatchInlineSnapshot('Uint8Array []')
-  expect(hexToBytes('0x61')).toMatchInlineSnapshot(`
+describe('converts hex to bytes', () => {
+  test('default', () => {
+    expect(toBytes('0x')).toMatchInlineSnapshot('Uint8Array []')
+    expect(toBytes('0x61')).toMatchInlineSnapshot(`
       Uint8Array [
         97,
       ]
     `)
-  expect(hexToBytes('0x616263')).toMatchInlineSnapshot(
-    `
+    expect(toBytes('0x616263')).toMatchInlineSnapshot(`
       Uint8Array [
         97,
         98,
         99,
       ]
-    `,
-  )
-  expect(hexToBytes('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(`
+    `)
+    expect(toBytes('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(
+      `
       Uint8Array [
         72,
         101,
@@ -650,71 +796,391 @@ test('converts hex to bytes', () => {
         100,
         33,
       ]
+    `,
+    )
+
+    expect(hexToBytes('0x')).toMatchInlineSnapshot('Uint8Array []')
+    expect(hexToBytes('0x61')).toMatchInlineSnapshot(`
+        Uint8Array [
+          97,
+        ]
+      `)
+    expect(hexToBytes('0x616263')).toMatchInlineSnapshot(
+      `
+        Uint8Array [
+          97,
+          98,
+          99,
+        ]
+      `,
+    )
+    expect(hexToBytes('0x48656c6c6f20576f726c6421')).toMatchInlineSnapshot(`
+        Uint8Array [
+          72,
+          101,
+          108,
+          108,
+          111,
+          32,
+          87,
+          111,
+          114,
+          108,
+          100,
+          33,
+        ]
+      `)
+  })
+
+  test('args: size', () => {
+    expect(
+      toBytes('0x48656c6c6f20576f726c6421', { size: 16 }),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+      ]
     `)
+    expect(
+      hexToBytes('0x48656c6c6f20576f726c6421', { size: 16 }),
+    ).toMatchInlineSnapshot(`
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `)
+    expect(
+      toBytes('0x48656c6c6f20576f726c6421', { size: 32 }),
+    ).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+    expect(
+      hexToBytes('0x48656c6c6f20576f726c6421', { size: 32 }),
+    ).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      toBytes('0x48656c6c6f20576f726c6421', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      hexToBytes('0x48656c6c6f20576f726c6421', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts string to bytes', () => {
-  expect(toBytes('')).toMatchInlineSnapshot('Uint8Array []')
-  expect(toBytes('a')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-    ]
-  `)
-  expect(toBytes('abc')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-      98,
-      99,
-    ]
-  `)
-  expect(toBytes('Hello World!')).toMatchInlineSnapshot(
-    `
-    Uint8Array [
-      72,
-      101,
-      108,
-      108,
-      111,
-      32,
-      87,
-      111,
-      114,
-      108,
-      100,
-      33,
-    ]
-  `,
-  )
+describe('converts string to bytes', () => {
+  test('default', () => {
+    expect(toBytes('')).toMatchInlineSnapshot('Uint8Array []')
+    expect(toBytes('a')).toMatchInlineSnapshot(`
+      Uint8Array [
+        97,
+      ]
+    `)
+    expect(toBytes('abc')).toMatchInlineSnapshot(`
+      Uint8Array [
+        97,
+        98,
+        99,
+      ]
+    `)
+    expect(toBytes('Hello World!')).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+      ]
+    `,
+    )
 
-  expect(stringToBytes('')).toMatchInlineSnapshot('Uint8Array []')
-  expect(stringToBytes('a')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-    ]
-  `)
-  expect(stringToBytes('abc')).toMatchInlineSnapshot(`
-    Uint8Array [
-      97,
-      98,
-      99,
-    ]
-  `)
-  expect(stringToBytes('Hello World!')).toMatchInlineSnapshot(
-    `
-    Uint8Array [
-      72,
-      101,
-      108,
-      108,
-      111,
-      32,
-      87,
-      111,
-      114,
-      108,
-      100,
-      33,
-    ]
-  `,
-  )
+    expect(stringToBytes('')).toMatchInlineSnapshot('Uint8Array []')
+    expect(stringToBytes('a')).toMatchInlineSnapshot(`
+      Uint8Array [
+        97,
+      ]
+    `)
+    expect(stringToBytes('abc')).toMatchInlineSnapshot(`
+      Uint8Array [
+        97,
+        98,
+        99,
+      ]
+    `)
+    expect(stringToBytes('Hello World!')).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+      ]
+    `,
+    )
+  })
+
+  test('args: size', () => {
+    expect(toBytes('Hello World!', { size: 16 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+    expect(toBytes('Hello World!', { size: 32 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+    expect(stringToBytes('Hello World!', { size: 16 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+    expect(stringToBytes('Hello World!', { size: 32 })).toMatchInlineSnapshot(
+      `
+      Uint8Array [
+        72,
+        101,
+        108,
+        108,
+        111,
+        32,
+        87,
+        111,
+        114,
+        108,
+        100,
+        33,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+      ]
+    `,
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      toBytes('Hello World!', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      stringToBytes('Hello World!', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })

--- a/src/utils/encoding/toBytes.ts
+++ b/src/utils/encoding/toBytes.ts
@@ -1,62 +1,192 @@
 import { BaseError } from '../../errors/index.js'
 import type { ByteArray, Hex } from '../../types/index.js'
 import { isHex } from '../data/isHex.js'
+import { pad } from '../data/pad.js'
+import { assertSize } from './fromHex.js'
 import type { NumberToHexOpts } from './toHex.js'
 import { numberToHex } from './toHex.js'
 
 const encoder = new TextEncoder()
 
-/** @description Encodes a UTF-8 string, hex value, bigint, number or boolean to a byte array. */
-export function toBytes(
-  value: string | bigint | number | boolean | Hex,
-): ByteArray {
-  if (typeof value === 'number' || typeof value === 'bigint')
-    return numberToBytes(value)
-  if (typeof value === 'boolean') return boolToBytes(value)
-  if (isHex(value)) return hexToBytes(value)
-  return stringToBytes(value)
+export type ToBytesParameters = {
+  /** Size of the output bytes. */
+  size?: number
 }
 
 /**
- * @description Encodes a boolean into a byte array.
+ * Encodes a UTF-8 string, hex value, bigint, number or boolean to a byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/toBytes.html
+ * - Example: https://viem.sh/docs/utilities/toBytes.html#usage
+ *
+ * @param value Value to encode.
+ * @param opts Options.
+ * @returns Byte array value.
+ *
+ * @example
+ * import { toBytes } from 'viem'
+ * const data = toBytes('Hello world')
+ * // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+ *
+ * @example
+ * import { toBytes } from 'viem'
+ * const data = toBytes(420)
+ * // Uint8Array([1, 164])
+ *
+ * @example
+ * import { toBytes } from 'viem'
+ * const data = toBytes(420, { size: 4 })
+ * // Uint8Array([0, 0, 1, 164])
  */
-export function boolToBytes(value: boolean) {
+export function toBytes(
+  value: string | bigint | number | boolean | Hex,
+  opts: ToBytesParameters = {},
+): ByteArray {
+  if (typeof value === 'number' || typeof value === 'bigint')
+    return numberToBytes(value, opts)
+  if (typeof value === 'boolean') return boolToBytes(value, opts)
+  if (isHex(value)) return hexToBytes(value, opts)
+  return stringToBytes(value, opts)
+}
+
+export type BoolToHexOpts = {
+  /** Size of the output bytes. */
+  size?: number
+}
+
+/**
+ * Encodes a boolean into a byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/toBytes.html#booltobytes
+ *
+ * @param value Boolean value to encode.
+ * @param opts Options.
+ * @returns Byte array value.
+ *
+ * @example
+ * import { boolToBytes } from 'viem'
+ * const data = boolToBytes(true)
+ * // Uint8Array([1])
+ *
+ * @example
+ * import { boolToBytes } from 'viem'
+ * const data = boolToBytes(true, { size: 32 })
+ * // Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+ */
+export function boolToBytes(value: boolean, opts: BoolToHexOpts = {}) {
   const bytes = new Uint8Array(1)
   bytes[0] = Number(value)
+  if (typeof opts.size === 'number') {
+    assertSize(bytes, { size: opts.size })
+    return pad(bytes, { size: opts.size })
+  }
   return bytes
 }
 
+export type HexToBytesOpts = {
+  /** Size of the output bytes. */
+  size?: number
+}
+
 /**
- * @description Encodes a hex string into a byte array.
+ * Encodes a hex string into a byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/toBytes.html#hextobytes
+ *
+ * @param hex Hex string to encode.
+ * @param opts Options.
+ * @returns Byte array value.
+ *
+ * @example
+ * import { hexToBytes } from 'viem'
+ * const data = hexToBytes('0x48656c6c6f20776f726c6421')
+ * // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])
+ *
+ * @example
+ * import { hexToBytes } from 'viem'
+ * const data = hexToBytes('0x48656c6c6f20776f726c6421', { size: 32 })
+ * // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
  */
-export function hexToBytes(hex_: Hex): ByteArray {
-  let hex = hex_.slice(2) as string
+export function hexToBytes(hex_: Hex, opts: HexToBytesOpts = {}): ByteArray {
+  let hex = hex_
+  if (opts.size) {
+    assertSize(hex, { size: opts.size })
+    hex = pad(hex, { dir: 'right', size: opts.size })
+  }
 
-  if (hex.length % 2) hex = `0${hex}`
+  let hexString = hex.slice(2) as string
+  if (hexString.length % 2) hexString = `0${hexString}`
 
-  const bytes = new Uint8Array(hex.length / 2)
+  const bytes = new Uint8Array(hexString.length / 2)
   for (let index = 0; index < bytes.length; index++) {
     const start = index * 2
-    const hexByte = hex.slice(start, start + 2)
+    const hexByte = hexString.slice(start, start + 2)
     const byte = Number.parseInt(hexByte, 16)
     if (Number.isNaN(byte) || byte < 0)
-      throw new BaseError(`Invalid byte sequence ("${hexByte}" in "${hex}").`)
+      throw new BaseError(
+        `Invalid byte sequence ("${hexByte}" in "${hexString}").`,
+      )
     bytes[index] = byte
   }
   return bytes
 }
 
 /**
- * @description Encodes a number into a byte array.
+ * Encodes a number into a byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/toBytes.html#numbertobytes
+ *
+ * @param value Number to encode.
+ * @param opts Options.
+ * @returns Byte array value.
+ *
+ * @example
+ * import { numberToBytes } from 'viem'
+ * const data = numberToBytes(420)
+ * // Uint8Array([1, 164])
+ *
+ * @example
+ * import { numberToBytes } from 'viem'
+ * const data = numberToBytes(420, { size: 4 })
+ * // Uint8Array([0, 0, 1, 164])
  */
 export function numberToBytes(value: bigint | number, opts?: NumberToHexOpts) {
   const hex = numberToHex(value, opts)
   return hexToBytes(hex)
 }
 
+export type StringToBytesOpts = {
+  /** Size of the output bytes. */
+  size?: number
+}
+
 /**
- * @description Encodes a UTF-8 string into a byte array.
+ * Encodes a UTF-8 string into a byte array.
+ *
+ * - Docs: https://viem.sh/docs/utilities/toBytes.html#stringtobytes
+ *
+ * @param value String to encode.
+ * @param opts Options.
+ * @returns Byte array value.
+ *
+ * @example
+ * import { stringToBytes } from 'viem'
+ * const data = stringToBytes('Hello world!')
+ * // Uint8Array([72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33])
+ *
+ * @example
+ * import { stringToBytes } from 'viem'
+ * const data = stringToBytes('Hello world!', { size: 32 })
+ * // Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
  */
-export function stringToBytes(value: string): ByteArray {
-  return encoder.encode(value)
+export function stringToBytes(
+  value: string,
+  opts: StringToBytesOpts = {},
+): ByteArray {
+  const bytes = encoder.encode(value)
+  if (typeof opts.size === 'number') {
+    assertSize(bytes, { size: opts.size })
+    return pad(bytes, { dir: 'right', size: opts.size })
+  }
+  return bytes
 }

--- a/src/utils/encoding/toHex.test.ts
+++ b/src/utils/encoding/toHex.test.ts
@@ -43,6 +43,9 @@ describe('converts numbers to hex', () => {
     expect(numberToHex(7, { size: 1 })).toBe('0x07')
     expect(numberToHex(10, { size: 2 })).toBe('0x000a')
     expect(numberToHex(69, { size: 4 })).toBe('0x00000045')
+    expect(numberToHex(69, { size: 32 })).toBe(
+      '0x0000000000000000000000000000000000000000000000000000000000000045',
+    )
 
     expect(() =>
       numberToHex(-7, { size: 1 }),
@@ -240,50 +243,190 @@ describe('converts bigints to hex', () => {
   })
 })
 
-test('converts boolean to hex', () => {
-  expect(toHex(true)).toMatchInlineSnapshot('"0x1"')
-  expect(toHex(false)).toMatchInlineSnapshot('"0x0"')
+describe('converts boolean to hex', () => {
+  test('default', () => {
+    expect(toHex(true)).toMatchInlineSnapshot('"0x1"')
+    expect(toHex(false)).toMatchInlineSnapshot('"0x0"')
 
-  expect(boolToHex(true)).toMatchInlineSnapshot('"0x1"')
-  expect(boolToHex(false)).toMatchInlineSnapshot('"0x0"')
+    expect(boolToHex(true)).toMatchInlineSnapshot('"0x1"')
+    expect(boolToHex(false)).toMatchInlineSnapshot('"0x0"')
+  })
+
+  test('args: size', () => {
+    expect(toHex(true, { size: 16 })).toMatchInlineSnapshot(
+      '"0x00000000000000000000000000000001"',
+    )
+    expect(toHex(true, { size: 32 })).toMatchInlineSnapshot(
+      '"0x0000000000000000000000000000000000000000000000000000000000000001"',
+    )
+    expect(boolToHex(false, { size: 16 })).toMatchInlineSnapshot(
+      '"0x00000000000000000000000000000000"',
+    )
+    expect(boolToHex(false, { size: 32 })).toMatchInlineSnapshot(
+      '"0x0000000000000000000000000000000000000000000000000000000000000000"',
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() => toHex(true, { size: 0 })).toThrowErrorMatchingInlineSnapshot(
+      `
+      "Size cannot exceed 0 bytes. Given size: 1 bytes.
+
+      Version: viem@1.0.2"
+    `,
+    )
+    expect(() =>
+      boolToHex(false, { size: 0 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 0 bytes. Given size: 1 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts string to hex', () => {
-  expect(toHex('')).toMatchInlineSnapshot('"0x"')
-  expect(toHex('a')).toMatchInlineSnapshot('"0x61"')
-  expect(toHex('abc')).toMatchInlineSnapshot('"0x616263"')
-  expect(toHex('Hello World!')).toMatchInlineSnapshot(
-    '"0x48656c6c6f20576f726c6421"',
-  )
+describe('converts string to hex', () => {
+  test('default', () => {
+    expect(toHex('')).toMatchInlineSnapshot('"0x"')
+    expect(toHex('a')).toMatchInlineSnapshot('"0x61"')
+    expect(toHex('abc')).toMatchInlineSnapshot('"0x616263"')
+    expect(toHex('Hello World!')).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c6421"',
+    )
 
-  expect(stringToHex('')).toMatchInlineSnapshot('"0x"')
-  expect(stringToHex('a')).toMatchInlineSnapshot('"0x61"')
-  expect(stringToHex('abc')).toMatchInlineSnapshot('"0x616263"')
-  expect(stringToHex('Hello World!')).toMatchInlineSnapshot(
-    '"0x48656c6c6f20576f726c6421"',
-  )
+    expect(stringToHex('')).toMatchInlineSnapshot('"0x"')
+    expect(stringToHex('a')).toMatchInlineSnapshot('"0x61"')
+    expect(stringToHex('abc')).toMatchInlineSnapshot('"0x616263"')
+    expect(stringToHex('Hello World!')).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c6421"',
+    )
+  })
+
+  test('args: size', () => {
+    expect(toHex('Hello World!', { size: 16 })).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c642100000000"',
+    )
+    expect(toHex('Hello World!', { size: 32 })).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"',
+    )
+    expect(stringToHex('Hello World!', { size: 16 })).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c642100000000"',
+    )
+    expect(stringToHex('Hello World!', { size: 32 })).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"',
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      toHex('Hello World!', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      stringToHex('Hello World!', { size: 8 }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })
 
-test('converts bytes to hex', () => {
-  expect(toHex(new Uint8Array([]))).toMatchInlineSnapshot('"0x"')
-  expect(toHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
-  expect(toHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(
-    toHex(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-    ),
-  ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+describe('converts bytes to hex', () => {
+  test('default', () => {
+    expect(toHex(new Uint8Array([]))).toMatchInlineSnapshot('"0x"')
+    expect(toHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
+    expect(toHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
+      '"0x616263"',
+    )
+    expect(
+      toHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
 
-  expect(bytesToHex(new Uint8Array([]))).toMatchInlineSnapshot('"0x"')
-  expect(bytesToHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
-  expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
-    '"0x616263"',
-  )
-  expect(
-    bytesToHex(
-      new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
-    ),
-  ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+    expect(bytesToHex(new Uint8Array([]))).toMatchInlineSnapshot('"0x"')
+    expect(bytesToHex(new Uint8Array([97]))).toMatchInlineSnapshot('"0x61"')
+    expect(bytesToHex(new Uint8Array([97, 98, 99]))).toMatchInlineSnapshot(
+      '"0x616263"',
+    )
+    expect(
+      bytesToHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c6421"')
+  })
+
+  test('args: size', () => {
+    expect(
+      toHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 16 },
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c642100000000"')
+    expect(
+      bytesToHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 16 },
+      ),
+    ).toMatchInlineSnapshot('"0x48656c6c6f20576f726c642100000000"')
+    expect(
+      toHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 32 },
+      ),
+    ).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"',
+    )
+    expect(
+      bytesToHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 32 },
+      ),
+    ).toMatchInlineSnapshot(
+      '"0x48656c6c6f20576f726c64210000000000000000000000000000000000000000"',
+    )
+  })
+
+  test('error: size overflow', () => {
+    expect(() =>
+      toHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 8 },
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      bytesToHex(
+        new Uint8Array([
+          72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33,
+        ]),
+        { size: 8 },
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Size cannot exceed 8 bytes. Given size: 12 bytes.
+
+      Version: viem@1.0.2"
+    `)
+  })
 })


### PR DESCRIPTION
Adds `size` as an argument to hex/bytes encoding/decoding utilities to replace ethers.js `parseBytes32String` and `formatBytes32String`.

<!-- start pr-codex -->

---

## PR-Codex overview


> The following files were skipped due to too many changes: `src/utils/encoding/fromBytes.ts`, `src/utils/encoding/toHex.ts`, `src/utils/encoding/toBytes.ts`, `src/utils/encoding/fromHex.ts`, `src/utils/encoding/toHex.test.ts`, `src/utils/encoding/fromHex.test.ts`, `src/utils/encoding/toBytes.test.ts`, `src/utils/encoding/fromBytes.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->