### PR TITLE
chore: remove esModuleInterop setting

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,6 @@
     "checkJs": false,
 
     // Interop constraints
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": true,
 


### PR DESCRIPTION
I missed this. We should imho not have that configured.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `esModuleInterop` flag and adds `verbatimModuleSyntax` to `tsconfig.base.json`.
### Detailed summary
- Removed `esModuleInterop` flag from `tsconfig.base.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->