### PR TITLE
feat: make payable value required

### DIFF
--- a/.changeset/clever-drinks-rule.md
+++ b/.changeset/clever-drinks-rule.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Made `value` required for payable functions.

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -704,8 +704,11 @@ test('argument permutations', async () => {
   // estimateGas
   contract.estimateGas.nonpayableWithoutArgs({ account: '0x' })
   contract.estimateGas.nonpayableWithArgs(['foo', 69n], { account: '0x' })
-  contract.estimateGas.payableWithoutArgs({ account: '0x' })
-  contract.estimateGas.payableWithArgs(['foo', 69n], { account: '0x' })
+  contract.estimateGas.payableWithoutArgs({ account: '0x', value: 1n })
+  contract.estimateGas.payableWithArgs(['foo', 69n], {
+    account: '0x',
+    value: 1n,
+  })
 
   contract.estimateGas.overloadedNonpayable({ account: '0x' })
   contract.estimateGas.overloadedNonpayable(['foo'], { account: '0x' })
@@ -733,8 +736,8 @@ test('argument permutations', async () => {
   // simulate
   contract.simulate.nonpayableWithoutArgs({ account: '0x' })
   contract.simulate.nonpayableWithArgs(['foo', 69n], { account: '0x' })
-  contract.simulate.payableWithoutArgs({ account: '0x' })
-  contract.simulate.payableWithArgs(['foo', 69n], { account: '0x' })
+  contract.simulate.payableWithoutArgs({ account: '0x', value: 1n })
+  contract.simulate.payableWithArgs(['foo', 69n], { account: '0x', value: 1n })
 
   contract.simulate.overloadedNonpayable({ account: '0x' })
   contract.simulate.overloadedNonpayable(['foo'], { account: '0x' })

--- a/src/actions/public/estimateContractGas.test.ts
+++ b/src/actions/public/estimateContractGas.test.ts
@@ -183,6 +183,7 @@ describe('BAYC', () => {
           functionName: 'mintApe',
           account: accounts[0].address,
           args: [1n],
+          value: 1n,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function \\"mintApe\\" reverted with the following reason:

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -216,6 +216,7 @@ describe('BAYC', () => {
           functionName: 'mintApe',
           account: accounts[0].address,
           args: [1n],
+          value: 1n,
         }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(`
         "The contract function \\"mintApe\\" reverted with the following reason:

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -167,7 +167,7 @@ test('GetFunctionArgs', () => {
 test('GetValue', () => {
   // payable
   type Result = GetValue<typeof seaportAbi, 'fulfillAdvancedOrder'>
-  expectTypeOf<Result>().toEqualTypeOf<{ value?: bigint | undefined }>()
+  expectTypeOf<Result>().toEqualTypeOf<{ value: bigint }>()
 
   // other
   expectTypeOf<GetValue<typeof seaportAbi, 'getOrderStatus'>>().toEqualTypeOf<{

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -19,7 +19,7 @@ import type {
 } from 'abitype'
 import type { Hex, LogTopic } from './misc.js'
 import type { TransactionRequest } from './transaction.js'
-import type { Filter, MaybeRequired } from './utils.js'
+import type { Filter, MaybeRequired, NoUndefined } from './utils.js'
 
 export type AbiItem = Abi[number]
 
@@ -64,9 +64,9 @@ export type GetValue<
     ? ExtractAbiFunction<TAbi, TFunctionName>
     : AbiFunction,
 > = TAbiFunction['stateMutability'] extends 'payable'
-  ? { value?: TValueType }
+  ? { value: NoUndefined<TValueType> }
   : TAbiFunction['payable'] extends true
-  ? { value?: TValueType }
+  ? { value: NoUndefined<TValueType> }
   : { value?: never }
 
 export type MaybeAbiEventName<TAbiEvent extends AbiEvent | undefined> =


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a required `value` parameter for payable functions. 

### Detailed summary
- Added `value` parameter for payable function calls in `simulateContract.test.ts` and `estimateContractGas.test.ts`
- Modified `contract.ts` and `contract.test-d.ts` to make `value` a required parameter for payable functions
- Modified `clever-drinks-rule.md` to reflect the changes made in this PR

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->