### PR TITLE
feat: multicall chunk size

### DIFF
--- a/.changeset/seven-eggs-tickle.md
+++ b/.changeset/seven-eggs-tickle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added a new `batchSize` parameter to `multicall` which limits the size of each calldata chunk.

--- a/site/docs/clients/public.md
+++ b/site/docs/clients/public.md
@@ -148,6 +148,8 @@ const client = createPublicClient({
 
 The maximum size (in bytes) for each multicall (`aggregate3`) calldata chunk.
 
+> Note: Some RPC Providers limit the amount of calldata that can be sent in a single request. It is best to check with your RPC Provider to see if there are any calldata size limits to `eth_call` requests.
+
 ```ts
 const client = createPublicClient({
   batch: {

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -230,6 +230,8 @@ const results = await publicClient.multicall({
 
 The maximum size (in bytes) for each calldata chunk. Set to `0` to disable the size limit.
 
+> Note: Some RPC Providers limit the amount of calldata (`data`) that can be sent in a single `eth_call` request. It is best to check with your RPC Provider to see if there are any calldata size limits to `eth_call` requests.
+
 ```ts
 const results = await publicClient.multicall({
   contracts: [

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -223,6 +223,27 @@ const results = await publicClient.multicall({
 })
 ```
 
+### batchSize (optional)
+
+- **Type:** `number`
+- **Default:** [`client.batch.multicall.batchSize`](/docs/clients/public.html#batch-multicall-batchsize-optional) (if set) or `1024`
+
+The maximum size (in bytes) for each calldata chunk. Set to `0` to disable the size limit.
+
+```ts
+const results = await publicClient.multicall({
+  contracts: [
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: wagmiAbi,
+      functionName: 'totalSupply',
+    },
+    ...
+  ],
+  batchSize: 4096 // 4kB // [!code focus]
+})
+```
+
 ### multicallAddress (optional)
 
 - **Type:** [`Address`](/docs/glossary/types#address)

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -10,6 +10,7 @@ import { createPublicClient, http } from '../../clients/index.js'
 import {
   accounts,
   address,
+  anvilChain,
   initialBlockNumber,
   localHttpUrl,
   publicClient,
@@ -622,7 +623,7 @@ test('multicall contract deployed on later block', async () => {
   `)
 })
 
-test('stress', async () => {
+test.only('stress', async () => {
   const client = createPublicClient({
     chain: mainnet,
     transport: http(),
@@ -638,6 +639,30 @@ test('stress', async () => {
 
   await multicall(client, {
     batchSize: 1024,
+    contracts,
+  })
+})
+
+test('batchSize on client', async () => {
+  const client = createPublicClient({
+    batch: {
+      multicall: {
+        batchSize: 1024,
+      },
+    },
+    chain: anvilChain,
+    transport: http(),
+  })
+
+  const contracts = []
+  for (let i = 0; i < 1_000; i++) {
+    contracts.push({
+      ...usdcContractConfig,
+      functionName: 'totalSupply',
+    })
+  }
+
+  await multicall(client, {
     contracts,
   })
 })

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -623,7 +623,7 @@ test('multicall contract deployed on later block', async () => {
   `)
 })
 
-test.only('stress', async () => {
+test('stress', async () => {
   const client = createPublicClient({
     chain: mainnet,
     transport: http(),

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -621,3 +621,23 @@ test('multicall contract deployed on later block', async () => {
     Version: viem@1.0.2"
   `)
 })
+
+test('stress', async () => {
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(),
+  })
+
+  const contracts = []
+  for (let i = 0; i < 10_000; i++) {
+    contracts.push({
+      ...usdcContractConfig,
+      functionName: 'totalSupply',
+    })
+  }
+
+  await multicall(client, {
+    chunkSize: 1024,
+    contracts,
+  })
+})

--- a/src/actions/public/multicall.test.ts
+++ b/src/actions/public/multicall.test.ts
@@ -637,7 +637,7 @@ test('stress', async () => {
   }
 
   await multicall(client, {
-    chunkSize: 1024,
+    batchSize: 1024,
     contracts,
   })
 })

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -117,7 +117,7 @@ export async function multicall<
     callData: Hex
     target: Address
   }[]
-  
+
   const chunkedCalls: Aggregate3Calls[] = [[]]
   let currentChunk = 0
   let currentChunkSize = 0

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -29,8 +29,8 @@ export type MulticallParameters<
   TAllowFailure extends boolean = true,
 > = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
   allowFailure?: TAllowFailure
-  contracts: Narrow<readonly [...MulticallContracts<TContracts>]>
   chunkSize?: number
+  contracts: Narrow<readonly [...MulticallContracts<TContracts>]>
   multicallAddress?: Address
 }
 
@@ -90,8 +90,8 @@ export async function multicall<
     allowFailure = true,
     blockNumber,
     blockTag,
-    contracts: contracts_,
     chunkSize = 0,
+    contracts: contracts_,
     multicallAddress: multicallAddress_,
   } = args
 

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -29,7 +29,7 @@ export type MulticallParameters<
   TAllowFailure extends boolean = true,
 > = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
   allowFailure?: TAllowFailure
-  chunkSize?: number
+  batchSize?: number
   contracts: Narrow<readonly [...MulticallContracts<TContracts>]>
   multicallAddress?: Address
 }
@@ -88,9 +88,9 @@ export async function multicall<
 ): Promise<MulticallReturnType<TContracts, TAllowFailure>> {
   const {
     allowFailure = true,
+    batchSize = 0,
     blockNumber,
     blockTag,
-    chunkSize = 0,
     contracts: contracts_,
     multicallAddress: multicallAddress_,
   } = args
@@ -131,7 +131,7 @@ export async function multicall<
       } as unknown as EncodeFunctionDataParameters)
 
       currentChunkSize += callData.length
-      if (chunkSize > 0 && currentChunkSize > chunkSize) {
+      if (batchSize > 0 && currentChunkSize > batchSize) {
         currentChunk++
         currentChunkSize = (callData.length - 2) / 2
         chunkedCalls[currentChunk] = []


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new `batchSize` parameter to `multicall` which limits the size of each calldata chunk. It also includes documentation updates and tests.

### Detailed summary
- Added `batchSize` parameter to `multicall` function
- Updated documentation for `multicall` and `publicClient`
- Added tests for `multicall` function with `batchSize` parameter and `publicClient` with `batchSize` parameter set in batch configuration

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->