### PR TITLE
Adding QuickNode Ethers Migration Docs

### DIFF
--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -117,6 +117,28 @@ const client = createPublicClient({
 
 > viem does not have custom API Provider clients – you can just pass in their RPC URL.
 
+### QuickNode
+
+#### Ethers
+
+```ts {3}
+import { providers } from 'ethers'
+
+const provider = new providers.QuickNodeProvider('homestead', '<apiKey>')
+```
+
+#### viem
+
+```ts {4-7}
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http('https://your-node-service.network.quiknode.pro/<apiKey>')
+})
+```
+
 ### AlchemyProvider
 
 #### Ethers


### PR DESCRIPTION
Hello ya'll,

I would like to propose adding QuickNode to the list of Ethereum providers in the Ethers Migration documentation (https://viem.sh/docs/ethers-migration.html). QuickNode is a dependable and high-speed Ethereum node service, boasting over five years of experience in providing exceptional support to some of the most prominent platforms in the industry.

Link to the etherjs docs referencing the provider: https://docs.ethers.org/v6/api/providers/thirdparty/#providers-quicknode
Official Website: https://www.quicknode.com/

Here's a summary of the changes I've made in this pull request:
1.) Added a new section for QuickNode in the "Provider Options" part of the migration documentation.
2.) Provided an example on how to connect to QuickNode using Ethers and Viem separately, using the providers import style.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds code snippets to the `ethers-migration.md` file for using `QuickNodeProvider` and `viem` with `ethers`, and adds `AlchemyProvider` section.

### Detailed summary
- Added code snippets for using `QuickNodeProvider` with `ethers`
- Added code snippets for using `viem` with `ethers`
- Added `AlchemyProvider` section to `ethers-migration.md` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->