### PR TITLE
feat: support eip-1191

### DIFF
--- a/.changeset/serious-kids-relax.md
+++ b/.changeset/serious-kids-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+support eip-1191 address checksum

--- a/.changeset/serious-kids-relax.md
+++ b/.changeset/serious-kids-relax.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-support eip-1191 address checksum
+Added support for EIP-1191 address checksum.

--- a/site/docs/utilities/getAddress.md
+++ b/site/docs/utilities/getAddress.md
@@ -14,7 +14,7 @@ head:
 
 # getAddress
 
-Converts an address into an address that is [checksum encoded](https://eips.ethereum.org/EIPS/eip-55).
+Converts an address into an address that is [checksum encoded](https://eips.ethereum.org/EIPS/eip-55), support [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191).
 
 ## Import
 
@@ -29,6 +29,10 @@ import { getAddress } from 'viem'
 
 getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac') // [!code focus:2]
 // '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
+
+// EIP-1191 defined checksum address
+getAddress('0x27b1fdb04752bbc536007a920d24acb045561c26', 30)
+// '0x27b1FdB04752BBc536007A920D24ACB045561c26'
 ```
 
 ## Returns
@@ -44,3 +48,9 @@ The checksummed address.
 - **Type:** `string`
 
 An Ethereum address.
+
+### chainId (optional)
+
+- **Type:** `number`
+
+The chain ID of the network the address is on. Only required for [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191) checksum addresses.

--- a/site/docs/utilities/getAddress.md
+++ b/site/docs/utilities/getAddress.md
@@ -14,7 +14,7 @@ head:
 
 # getAddress
 
-Converts an address into an address that is [checksum encoded](https://eips.ethereum.org/EIPS/eip-55), support [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191).
+Converts an address into an address that is [checksum encoded](https://eips.ethereum.org/EIPS/eip-55). Supports [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191).
 
 ## Import
 
@@ -30,7 +30,7 @@ import { getAddress } from 'viem'
 getAddress('0xa5cc3c03994db5b0d9a5eEdD10Cabab0813678ac') // [!code focus:2]
 // '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'
 
-// EIP-1191 defined checksum address
+// EIP-1191 address
 getAddress('0x27b1fdb04752bbc536007a920d24acb045561c26', 30)
 // '0x27b1FdB04752BBc536007A920D24ACB045561c26'
 ```
@@ -53,4 +53,4 @@ An Ethereum address.
 
 - **Type:** `number`
 
-The chain ID of the network the address is on. Only required for [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191) checksum addresses.
+The chain ID of the network the address is on. Complies to [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191).

--- a/src/utils/address/getAddress.test.ts
+++ b/src/utils/address/getAddress.test.ts
@@ -24,6 +24,12 @@ test('checksums address', () => {
   expect(
     getAddress('0x15d34aaf54267db7d7c367839aaf71a00a2c6a65'),
   ).toMatchInlineSnapshot('"0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"')
+  expect(
+    getAddress('0x27b1fdb04752bbc536007a920d24acb045561c26', 30),
+  ).toMatchInlineSnapshot('"0x27b1FdB04752BBc536007A920D24ACB045561c26"')
+  expect(
+    getAddress('0x3599689e6292b81b2d85451025146515070129bb', 30),
+  ).toMatchInlineSnapshot('"0x3599689E6292B81B2D85451025146515070129Bb"')
 })
 
 describe('errors', () => {

--- a/src/utils/address/getAddress.ts
+++ b/src/utils/address/getAddress.ts
@@ -4,11 +4,15 @@ import { stringToBytes } from '../encoding/index.js'
 import { keccak256 } from '../hash/index.js'
 import { isAddress } from './isAddress.js'
 
-export function checksumAddress(address_: Address): Address {
-  const hexAddress = address_.substring(2).toLowerCase()
+export function checksumAddress(address_: Address, chainId?: number): Address {
+  const hexAddress = chainId
+    ? `${chainId}${address_.toLowerCase()}`
+    : address_.substring(2).toLowerCase()
   const hash = keccak256(stringToBytes(hexAddress), 'bytes')
 
-  const address = hexAddress.split('')
+  const address = (
+    chainId ? hexAddress.substring(`${chainId}0x`.length) : hexAddress
+  ).split('')
   for (let i = 0; i < 40; i += 2) {
     if (hash[i >> 1] >> 4 >= 8 && address[i]) {
       address[i] = address[i].toUpperCase()
@@ -21,7 +25,7 @@ export function checksumAddress(address_: Address): Address {
   return `0x${address.join('')}`
 }
 
-export function getAddress(address: string): Address {
+export function getAddress(address: string, chainId?: number): Address {
   if (!isAddress(address)) throw new InvalidAddressError({ address })
-  return checksumAddress(address)
+  return checksumAddress(address, chainId)
 }


### PR DESCRIPTION
support [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for EIP-1191 address checksum to the `getAddress` utility function. It also updates the related test and documentation files.

### Detailed summary
- Added support for EIP-1191 address checksum to the `getAddress` function.
- Updated the `getAddress` test file to include tests for EIP-1191 addresses.
- Updated the `getAddress` documentation file to mention EIP-1191 support.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->