### PR TITLE
fix: skip return for test functions that claim to return `void`

### DIFF
--- a/src/actions/test/dropTransaction.test.ts
+++ b/src/actions/test/dropTransaction.test.ts
@@ -27,7 +27,7 @@ test('drops transaction', async () => {
     to: targetAccount.address,
     value: parseEther('2'),
   })
-  await dropTransaction(testClient, { hash })
+  await expect(dropTransaction(testClient, { hash })).resolves.toBeUndefined()
   await mine(testClient, { blocks: 1 })
   expect(
     await getBalance(publicClient, {

--- a/src/actions/test/dropTransaction.ts
+++ b/src/actions/test/dropTransaction.ts
@@ -36,7 +36,7 @@ export async function dropTransaction<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { hash }: DropTransactionParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_dropTransaction`,
     params: [hash],
   })

--- a/src/actions/test/impersonateAccount.test.ts
+++ b/src/actions/test/impersonateAccount.test.ts
@@ -19,7 +19,9 @@ test('impersonates account', async () => {
     }),
   ).rejects.toThrowError('No Signer available')
 
-  await impersonateAccount(testClient, { address: address.vitalik })
+  await expect(
+    impersonateAccount(testClient, { address: address.vitalik }),
+  ).resolves.toBeUndefined()
 
   expect(
     await sendTransaction(walletClient, {

--- a/src/actions/test/impersonateAccount.ts
+++ b/src/actions/test/impersonateAccount.ts
@@ -36,7 +36,7 @@ export async function impersonateAccount<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address }: ImpersonateAccountParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_impersonateAccount`,
     params: [address],
   })

--- a/src/actions/test/mine.test.ts
+++ b/src/actions/test/mine.test.ts
@@ -7,7 +7,7 @@ import { mine } from './mine.js'
 
 test('mines 1 block', async () => {
   const currentBlockNumber = await getBlockNumber(publicClient, { maxAge: 0 })
-  await mine(testClient, { blocks: 1 })
+  await expect(mine(testClient, { blocks: 1 })).resolves.toBeUndefined()
   const nextBlockNumber = await getBlockNumber(publicClient, { maxAge: 0 })
   expect(nextBlockNumber).toEqual(currentBlockNumber + 1n)
 })

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -9,7 +9,9 @@ import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 
 test('removes block timestamp interval', async () => {
   let interval = 86400
-  await setBlockTimestampInterval(testClient, { interval })
+  await expect(
+    setBlockTimestampInterval(testClient, { interval }),
+  ).resolves.toBeUndefined()
   const block1 = await getBlock(publicClient, { blockTag: 'latest' })
   await wait(1000)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })

--- a/src/actions/test/removeBlockTimestampInterval.ts
+++ b/src/actions/test/removeBlockTimestampInterval.ts
@@ -27,7 +27,7 @@ import type {
 export async function removeBlockTimestampInterval<
   TChain extends Chain | undefined,
 >(client: TestClient<TestClientMode, Transport, TChain>) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_removeBlockTimestampInterval`,
   })
 }

--- a/src/actions/test/reset.test.ts
+++ b/src/actions/test/reset.test.ts
@@ -14,9 +14,11 @@ import { reset } from './reset.js'
 test('resets the fork', async () => {
   await setIntervalMining(testClient, { interval: 0 })
   await mine(testClient, { blocks: 10 })
-  await reset(testClient, {
-    blockNumber: initialBlockNumber,
-  })
+  await expect(
+    reset(testClient, {
+      blockNumber: initialBlockNumber,
+    }),
+  ).resolves.toBeUndefined()
   expect(await getBlockNumber(publicClient)).toBe(initialBlockNumber)
   await setIntervalMining(testClient, { interval: 1 })
   await mine(testClient, { blocks: 1 })

--- a/src/actions/test/reset.ts
+++ b/src/actions/test/reset.ts
@@ -36,7 +36,7 @@ export async function reset<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { blockNumber, jsonRpcUrl }: ResetParameters = {},
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_reset`,
     params: [{ forking: { blockNumber: Number(blockNumber), jsonRpcUrl } }],
   })

--- a/src/actions/test/revert.test.ts
+++ b/src/actions/test/revert.test.ts
@@ -35,7 +35,7 @@ test('reverts', async () => {
     }),
   ).not.toBe(balance)
 
-  await revert(testClient, { id })
+  await expect(revert(testClient, { id })).resolves.toBeUndefined()
   expect(
     await getBalance(publicClient, {
       address: sourceAccount.address,

--- a/src/actions/test/revert.ts
+++ b/src/actions/test/revert.ts
@@ -34,7 +34,7 @@ export async function revert<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { id }: RevertParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: 'evm_revert',
     params: [id],
   })

--- a/src/actions/test/setAutomine.test.ts
+++ b/src/actions/test/setAutomine.test.ts
@@ -7,7 +7,7 @@ import { setAutomine } from './setAutomine.js'
 
 // TODO: Anvil sometimes stops interval mining when automining is programatically set.
 test.skip('sets automine status', async () => {
-  await setAutomine(testClient, true)
+  await expect(setAutomine(testClient, true)).resolves.toBeUndefined()
   expect(await getAutomine(testClient)).toEqual(true)
   await setAutomine(testClient, false)
   expect(await getAutomine(testClient)).toEqual(false)

--- a/src/actions/test/setAutomine.ts
+++ b/src/actions/test/setAutomine.ts
@@ -28,7 +28,7 @@ export async function setAutomine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   enabled: boolean,
 ) {
-  return await client.request({
+  await client.request({
     method: 'evm_setAutomine',
     params: [enabled],
   })

--- a/src/actions/test/setBalance.test.ts
+++ b/src/actions/test/setBalance.test.ts
@@ -8,10 +8,12 @@ import { setBalance } from './setBalance.js'
 const targetAccount = accounts[0]
 
 test('sets balance', async () => {
-  await setBalance(testClient, {
-    address: targetAccount.address,
-    value: parseEther('420'),
-  })
+  await expect(
+    setBalance(testClient, {
+      address: targetAccount.address,
+      value: parseEther('420'),
+    }),
+  ).resolves.toBeUndefined()
   expect(
     await getBalance(publicClient, {
       address: targetAccount.address,

--- a/src/actions/test/setBalance.ts
+++ b/src/actions/test/setBalance.ts
@@ -40,7 +40,7 @@ export async function setBalance<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, value }: SetBalanceParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setBalance`,
     params: [address, numberToHex(value)],
   })

--- a/src/actions/test/setBlockGasLimit.test.ts
+++ b/src/actions/test/setBlockGasLimit.test.ts
@@ -11,9 +11,11 @@ test('sets block gas limit', async () => {
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
-  await setBlockGasLimit(testClient, {
-    gasLimit: block1.gasLimit + parseGwei('10'),
-  })
+  await expect(
+    setBlockGasLimit(testClient, {
+      gasLimit: block1.gasLimit + parseGwei('10'),
+    }),
+  ).resolves.toBeUndefined()
   await wait(1000)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.gasLimit).toEqual(block1.gasLimit + parseGwei('10'))

--- a/src/actions/test/setBlockGasLimit.ts
+++ b/src/actions/test/setBlockGasLimit.ts
@@ -35,7 +35,7 @@ export async function setBlockGasLimit<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { gasLimit }: SetBlockGasLimitParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: 'evm_setBlockGasLimit',
     params: [numberToHex(gasLimit)],
   })

--- a/src/actions/test/setBlockTimestampInterval.test.ts
+++ b/src/actions/test/setBlockTimestampInterval.test.ts
@@ -12,7 +12,9 @@ test('sets block timestamp interval', async () => {
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
-  await setBlockTimestampInterval(testClient, { interval: 86400 })
+  await expect(
+    setBlockTimestampInterval(testClient, { interval: 86400 }),
+  ).resolves.toBeUndefined()
   await wait(1000)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)

--- a/src/actions/test/setBlockTimestampInterval.ts
+++ b/src/actions/test/setBlockTimestampInterval.ts
@@ -36,7 +36,7 @@ export async function setBlockTimestampInterval<
   client: TestClient<TestClientMode, Transport, TChain>,
   { interval }: SetBlockTimestampIntervalParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setBlockTimestampInterval`,
     params: [interval],
   })

--- a/src/actions/test/setCode.test.ts
+++ b/src/actions/test/setCode.test.ts
@@ -13,10 +13,12 @@ test('sets code', async () => {
       params: ['0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7', 'latest'],
     })) !== bytecode,
   ).toBeTruthy()
-  await setCode(testClient, {
-    address: '0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7',
-    bytecode,
-  })
+  await expect(
+    setCode(testClient, {
+      address: '0xff9c1b15b16263c61d017ee9f65c50e4ae0113d7',
+      bytecode,
+    }),
+  ).resolves.toBeUndefined()
   expect(
     (await publicClient.request({
       method: 'eth_getCode',

--- a/src/actions/test/setCode.ts
+++ b/src/actions/test/setCode.ts
@@ -39,7 +39,7 @@ export async function setCode<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, bytecode }: SetCodeParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setCode`,
     params: [address, bytecode],
   })

--- a/src/actions/test/setCoinbase.test.ts
+++ b/src/actions/test/setCoinbase.test.ts
@@ -1,11 +1,13 @@
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { testClient } from '../../_test/index.js'
 
 import { setCoinbase } from './setCoinbase.js'
 
 test('set next block base fee per gas', async () => {
-  await setCoinbase(testClient, {
-    address: '0x50821B3b78Da0255Ba2b7B6d62ae1f389EB987A4',
-  })
+  await expect(
+    setCoinbase(testClient, {
+      address: '0x50821B3b78Da0255Ba2b7B6d62ae1f389EB987A4',
+    }),
+  ).resolves.toBeUndefined()
 })

--- a/src/actions/test/setCoinbase.ts
+++ b/src/actions/test/setCoinbase.ts
@@ -36,7 +36,7 @@ export async function setCoinbase<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address }: SetCoinbaseParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setCoinbase`,
     params: [address],
   })

--- a/src/actions/test/setIntervalMining.test.ts
+++ b/src/actions/test/setIntervalMining.test.ts
@@ -11,7 +11,9 @@ test('sets mining interval', async () => {
   await mine(testClient, { blocks: 1 })
 
   const blockNumber1 = await getBlockNumber(publicClient, { maxAge: 0 })
-  await setIntervalMining(testClient, { interval: 1 })
+  await expect(
+    setIntervalMining(testClient, { interval: 1 }),
+  ).resolves.toBeUndefined()
   await wait(2000)
   const blockNumber2 = await getBlockNumber(publicClient, { maxAge: 0 })
   expect(blockNumber2 - blockNumber1).toBe(2n)

--- a/src/actions/test/setIntervalMining.ts
+++ b/src/actions/test/setIntervalMining.ts
@@ -34,7 +34,7 @@ export async function setIntervalMining<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { interval }: SetIntervalMiningParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: 'evm_setIntervalMining',
     params: [interval],
   })

--- a/src/actions/test/setLoggingEnabled.test.ts
+++ b/src/actions/test/setLoggingEnabled.test.ts
@@ -1,10 +1,10 @@
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { testClient } from '../../_test/index.js'
 
 import { setLoggingEnabled } from './setLoggingEnabled.js'
 
 test('sets logging', async () => {
-  await setLoggingEnabled(testClient, false)
+  await expect(setLoggingEnabled(testClient, false)).resolves.toBeUndefined()
   await setLoggingEnabled(testClient, true)
 })

--- a/src/actions/test/setLoggingEnabled.ts
+++ b/src/actions/test/setLoggingEnabled.ts
@@ -28,7 +28,7 @@ export async function setLoggingEnabled<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   enabled: boolean,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setLoggingEnabled`,
     params: [enabled],
   })

--- a/src/actions/test/setMinGasPrice.ts
+++ b/src/actions/test/setMinGasPrice.ts
@@ -39,7 +39,7 @@ export async function setMinGasPrice<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { gasPrice }: SetMinGasPriceParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setMinGasPrice`,
     params: [numberToHex(gasPrice)],
   })

--- a/src/actions/test/setNextBlockBaseFeePerGas.test.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.test.ts
@@ -11,9 +11,11 @@ test('set next block base fee per gas', async () => {
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
-  await setNextBlockBaseFeePerGas(testClient, {
-    baseFeePerGas: block1.baseFeePerGas! + parseGwei('10'),
-  })
+  await expect(
+    setNextBlockBaseFeePerGas(testClient, {
+      baseFeePerGas: block1.baseFeePerGas! + parseGwei('10'),
+    }),
+  ).resolves.toBeUndefined()
   await wait(1000)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.baseFeePerGas).toEqual(block1.baseFeePerGas! + parseGwei('10'))

--- a/src/actions/test/setNextBlockBaseFeePerGas.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.ts
@@ -39,7 +39,7 @@ export async function setNextBlockBaseFeePerGas<
   client: TestClient<TestClientMode, Transport, TChain>,
   { baseFeePerGas }: SetNextBlockBaseFeePerGasParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setNextBlockBaseFeePerGas`,
     params: [numberToHex(baseFeePerGas)],
   })

--- a/src/actions/test/setNextBlockTimestamp.test.ts
+++ b/src/actions/test/setNextBlockTimestamp.test.ts
@@ -10,9 +10,11 @@ test('sets block timestamp interval', async () => {
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
-  await setNextBlockTimestamp(testClient, {
-    timestamp: block1.timestamp + 86400n,
-  })
+  await expect(
+    setNextBlockTimestamp(testClient, {
+      timestamp: block1.timestamp + 86400n,
+    }),
+  ).resolves.toBeUndefined()
   await wait(1000)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)

--- a/src/actions/test/setNextBlockTimestamp.ts
+++ b/src/actions/test/setNextBlockTimestamp.ts
@@ -35,7 +35,7 @@ export async function setNextBlockTimestamp<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { timestamp }: SetNextBlockTimestampParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: 'evm_setNextBlockTimestamp',
     params: [numberToHex(timestamp)],
   })

--- a/src/actions/test/setNonce.test.ts
+++ b/src/actions/test/setNonce.test.ts
@@ -8,10 +8,12 @@ import { mine } from './mine.js'
 const targetAccount = accounts[0]
 
 test('sets nonce', async () => {
-  await setNonce(testClient, {
-    address: targetAccount.address,
-    nonce: 420,
-  })
+  await expect(
+    setNonce(testClient, {
+      address: targetAccount.address,
+      nonce: 420,
+    }),
+  ).resolves.toBeUndefined()
   await mine(testClient, { blocks: 1 })
   expect(
     await getTransactionCount(publicClient, {

--- a/src/actions/test/setNonce.ts
+++ b/src/actions/test/setNonce.ts
@@ -40,7 +40,7 @@ export async function setNonce<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, nonce }: SetNonceParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setNonce`,
     params: [address, numberToHex(nonce)],
   })

--- a/src/actions/test/setRpcUrl.test.ts
+++ b/src/actions/test/setRpcUrl.test.ts
@@ -1,9 +1,11 @@
-import { test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { testClient } from '../../_test/index.js'
 
 import { setRpcUrl } from './setRpcUrl.js'
 
 test('sets the rpc url', async () => {
-  await setRpcUrl(testClient, process.env.VITE_ANVIL_FORK_URL!)
+  await expect(
+    setRpcUrl(testClient, process.env.VITE_ANVIL_FORK_URL!),
+  ).resolves.toBeUndefined()
 })

--- a/src/actions/test/setRpcUrl.ts
+++ b/src/actions/test/setRpcUrl.ts
@@ -29,7 +29,7 @@ export async function setRpcUrl<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   jsonRpcUrl: string,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setRpcUrl`,
     params: [jsonRpcUrl],
   })

--- a/src/actions/test/setStorageAt.test.ts
+++ b/src/actions/test/setStorageAt.test.ts
@@ -6,11 +6,14 @@ import { setStorageAt } from './setStorageAt.js'
 const targetAccount = accounts[0]
 
 test('sets storage', async () => {
-  await setStorageAt(testClient, {
-    address: targetAccount.address,
-    index: 0,
-    value: '0x0000000000000000000000000000000000000000000000000000000000003039',
-  })
+  await expect(
+    setStorageAt(testClient, {
+      address: targetAccount.address,
+      index: 0,
+      value:
+        '0x0000000000000000000000000000000000000000000000000000000000003039',
+    }),
+  ).resolves.toBeUndefined()
   expect(
     await publicClient.request({
       method: 'eth_getStorageAt',

--- a/src/actions/test/setStorageAt.ts
+++ b/src/actions/test/setStorageAt.ts
@@ -43,7 +43,7 @@ export async function setStorageAt<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, index, value }: SetStorageAtParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_setStorageAt`,
     params: [
       address,

--- a/src/actions/test/stopImpersonatingAccount.test.ts
+++ b/src/actions/test/stopImpersonatingAccount.test.ts
@@ -22,7 +22,9 @@ test('stops impersonating account', async () => {
     }),
   ).toBeDefined()
 
-  await stopImpersonatingAccount(testClient, { address: address.vitalik })
+  await expect(
+    stopImpersonatingAccount(testClient, { address: address.vitalik }),
+  ).resolves.toBeUndefined()
 
   await expect(
     sendTransaction(walletClient, {

--- a/src/actions/test/stopImpersonatingAccount.ts
+++ b/src/actions/test/stopImpersonatingAccount.ts
@@ -38,7 +38,7 @@ export async function stopImpersonatingAccount<
   client: TestClient<TestClientMode, Transport, TChain>,
   { address }: StopImpersonatingAccountParameters,
 ) {
-  return await client.request({
+  await client.request({
     method: `${client.mode}_stopImpersonatingAccount`,
     params: [address],
   })

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -55,7 +55,7 @@ describe('smoke test', () => {
       to: accounts[7].address,
       value: parseEther('2'),
     })
-    expect(await testClient.dropTransaction({ hash })).toBeDefined()
+    expect(await testClient.dropTransaction({ hash })).toBeUndefined()
   })
 
   // TODO: Anvil sometimes stops interval mining when automining is programatically set.
@@ -91,18 +91,18 @@ describe('smoke test', () => {
   })
 
   test('removeBlockTimestampInterval', async () => {
-    expect(await testClient.removeBlockTimestampInterval()).toBeDefined()
+    expect(await testClient.removeBlockTimestampInterval()).toBeUndefined()
   })
 
   test('reset', async () => {
     expect(
       await testClient.reset({ blockNumber: initialBlockNumber }),
-    ).toBeDefined()
+    ).toBeUndefined()
   })
 
   test('revert', async () => {
     const id = await testClient.snapshot()
-    expect(await testClient.revert({ id })).toBeDefined()
+    expect(await testClient.revert({ id })).toBeUndefined()
   })
 
   test('sendUnsignedTransaction', async () => {
@@ -117,7 +117,7 @@ describe('smoke test', () => {
 
   // TODO: Anvil sometimes stops interval mining when automining is programatically set.
   test.skip('setAutomine', async () => {
-    expect(await testClient.setAutomine(true)).toBeDefined()
+    expect(await testClient.setAutomine(true)).toBeUndefined()
   })
 
   test('setBalance', async () => {
@@ -126,7 +126,7 @@ describe('smoke test', () => {
         address: accounts[8].address,
         value: parseEther('420'),
       }),
-    ).toBeDefined()
+    ).toBeUndefined()
   })
 
   test('setBlockGasLimit', async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `TestClient` API for interacting with a local blockchain. It replaces the `client.request` method with `await client.request`, and adds error handling to the functions.

### Detailed summary
- Replaces `client.request` with `await client.request` in all functions
- Adds error handling to all functions

> The following files were skipped due to too many changes: `src/actions/test/setStorageAt.test.ts`, `src/clients/decorators/test.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->