### PR TITLE
refactor: remove defineChain export

### DIFF
--- a/.changeset/gold-bikes-reply.md
+++ b/.changeset/gold-bikes-reply.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed the `defineChain` export from `viem/chains`.

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -7,13 +7,7 @@ import {
   testClient,
   walletClient,
 } from '../../_test/index.js'
-import {
-  celo,
-  defineChain,
-  localhost,
-  mainnet,
-  optimism,
-} from '../../chains.js'
+import { celo, localhost, mainnet, optimism } from '../../chains.js'
 import { hexToNumber, parseEther, parseGwei } from '../../utils/index.js'
 import { getBalance, getBlock, getTransaction } from '../index.js'
 import { mine, setBalance, setNextBlockBaseFeePerGas } from '../test/index.js'
@@ -22,6 +16,7 @@ import { sendTransaction } from './sendTransaction.js'
 import { createWalletClient, http } from '../../clients/index.js'
 import { anvilChain, walletClientWithAccount } from '../../_test/utils.js'
 import { privateKeyToAccount } from '../../accounts/index.js'
+import { defineChain } from '../../utils/chain.js'
 
 const sourceAccount = accounts[0]
 const targetAccount = accounts[1]

--- a/src/chains.test.ts
+++ b/src/chains.test.ts
@@ -5,7 +5,6 @@ import * as chains from './chains.js'
 test('exports chains', () => {
   expect(Object.keys(chains)).toMatchInlineSnapshot(`
     [
-      "defineChain",
       "arbitrum",
       "arbitrumGoerli",
       "aurora",

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -10,7 +10,6 @@ import {
 } from './utils/index.js'
 
 export type { Chain } from './types/index.js'
-export { defineChain } from './utils/index.js'
 
 const celoFormatters = {
   block: defineBlock({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes the `defineChain` export from `viem/chains` and removes `defineChain` import from multiple files.

### Detailed summary
- Removed the `defineChain` export from `viem/chains`.
- Removed `defineChain` import from `src/chains.ts`.
- Removed `defineChain` import from `src/actions/wallet/sendTransaction.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->