### PR TITLE
feat: `dataSuffix`

### DIFF
--- a/.changeset/polite-parrots-relax.md
+++ b/.changeset/polite-parrots-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added a `dataSuffix` argument to `writeContract` and `simulateContract`

--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -285,6 +285,22 @@ const { result } = await publicClient.simulateContract({
 })
 ```
 
+### dataSuffix
+
+- **Type:** `Hex`
+
+Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). 
+
+```ts
+const { result } = await publicClient.simulateContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  args: [69420],
+  dataSuffix: '0xdeadbeef' // [!code focus]
+})
+```
+
 ### gasPrice (optional)
 
 - **Type:** `bigint`

--- a/site/docs/contract/writeContract.md
+++ b/site/docs/contract/writeContract.md
@@ -329,6 +329,22 @@ await walletClient.writeContract({
 })
 ```
 
+### dataSuffix
+
+- **Type:** `Hex`
+
+Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). 
+
+```ts
+await walletClient.writeContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  args: [69420],
+  dataSuffix: '0xdeadbeef' // [!code focus]
+})
+```
+
 ### gasPrice (optional)
 
 - **Type:** `bigint`

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -8,7 +8,7 @@
  *        - Custom nonce
  */
 
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import {
   accounts,
   deployBAYC,
@@ -21,6 +21,7 @@ import { baycContractConfig } from '../../_test/abis.js'
 import { encodeFunctionData, parseEther, parseGwei } from '../../utils/index.js'
 import { mine } from '../test/index.js'
 import { sendTransaction } from '../wallet/index.js'
+import * as call from './call.js'
 
 import { simulateContract } from './simulateContract.js'
 import { deployErrorExample } from '../../_test/utils.js'
@@ -152,6 +153,22 @@ describe('wagmi', () => {
       Docs: https://viem.sh/docs/contract/simulateContract.html
       Version: viem@1.0.2"
     `)
+  })
+})
+
+test('args: dataSuffix', async () => {
+  const spy = vi.spyOn(call, 'call')
+  await simulateContract(publicClient, {
+    ...wagmiContractConfig,
+    account: accounts[0].address,
+    functionName: 'mint',
+    dataSuffix: '0x12345678',
+  })
+  expect(spy).toHaveBeenCalledWith(publicClient, {
+    account: accounts[0].address,
+    batch: false,
+    data: '0x1249c58b12345678',
+    to: wagmiContractConfig.address,
   })
 })
 

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -7,6 +7,7 @@ import type {
   ContractFunctionConfig,
   ContractFunctionResult,
   GetValue,
+  Hex,
 } from '../../types/index.js'
 import {
   decodeFunctionResult,
@@ -29,6 +30,7 @@ export type SimulateContractParameters<
   TChainOverride extends Chain | undefined = undefined,
 > = {
   chain?: TChainOverride
+  dataSuffix?: Hex
 } & ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
   Omit<
     CallParameters<TChainOverride extends Chain ? TChainOverride : TChain>,
@@ -99,6 +101,7 @@ export async function simulateContract<
     abi,
     address,
     args,
+    dataSuffix,
     functionName,
     ...callRequest
   }: SimulateContractParameters<TAbi, TFunctionName, TChain, TChainOverride>,
@@ -116,7 +119,7 @@ export async function simulateContract<
   try {
     const { data } = await call(client, {
       batch: false,
-      data: calldata,
+      data: `${calldata}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
       to: address,
       ...callRequest,
     } as unknown as CallParameters<TChain>)

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -30,6 +30,7 @@ export type SimulateContractParameters<
   TChainOverride extends Chain | undefined = undefined,
 > = {
   chain?: TChainOverride
+  /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
   dataSuffix?: Hex
 } & ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
   Omit<

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { optimism } from '../../chains.js'
 import { createWalletClient, http } from '../../clients/index.js'
 import {
@@ -15,6 +15,7 @@ import { simulateContract } from '../public/index.js'
 import { mine } from '../test/index.js'
 
 import { writeContract } from './writeContract.js'
+import * as sendTransaction from './sendTransaction.js'
 
 test('default', async () => {
   expect(
@@ -123,6 +124,21 @@ describe('args: chain', () => {
 
       Version: viem@1.0.2"
     `)
+  })
+})
+
+test('args: dataSuffix', async () => {
+  const spy = vi.spyOn(sendTransaction, 'sendTransaction')
+  await writeContract(walletClient, {
+    ...wagmiContractConfig,
+    account: accounts[0].address,
+    functionName: 'mint',
+    dataSuffix: '0x12345678',
+  })
+  expect(spy).toHaveBeenCalledWith(walletClient, {
+    account: accounts[0].address,
+    data: '0x1249c58b12345678',
+    to: wagmiContractConfig.address,
   })
 })
 

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -7,6 +7,7 @@ import type {
   ContractFunctionConfig,
   GetChain,
   GetValue,
+  Hex,
 } from '../../types/index.js'
 import { encodeFunctionData } from '../../utils/index.js'
 import type { EncodeFunctionDataParameters } from '../../utils/index.js'
@@ -28,7 +29,9 @@ export type WriteContractParameters<
     'chain' | 'to' | 'data' | 'value'
   > &
   GetChain<TChain, TChainOverride> &
-  GetValue<TAbi, TFunctionName, SendTransactionParameters<TChain>['value']>
+  GetValue<TAbi, TFunctionName, SendTransactionParameters<TChain>['value']> & {
+    dataSuffix?: Hex
+  }
 
 export type WriteContractReturnType = SendTransactionReturnType
 
@@ -94,6 +97,7 @@ export async function writeContract<
     abi,
     address,
     args,
+    dataSuffix,
     functionName,
     ...request
   }: WriteContractParameters<
@@ -110,7 +114,7 @@ export async function writeContract<
     functionName,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
   const hash = await sendTransaction(client, {
-    data,
+    data: `${data}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
     to: address,
     ...request,
   } as unknown as SendTransactionParameters<TChain, TAccount, TChainOverride>)

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -30,6 +30,7 @@ export type WriteContractParameters<
   > &
   GetChain<TChain, TChainOverride> &
   GetValue<TAbi, TFunctionName, SendTransactionParameters<TChain>['value']> & {
+    /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
     dataSuffix?: Hex
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a `dataSuffix` argument to `writeContract` and `simulateContract` functions, allowing to append data to the end of the calldata. 

### Detailed summary
- Added a `dataSuffix` argument to `writeContract` and `simulateContract`
- `dataSuffix` is of type `Hex`
- Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f) to the end of the calldata.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->