### PR TITLE
fix: `multicall` return type

### DIFF
--- a/.changeset/tall-pianos-cough.md
+++ b/.changeset/tall-pianos-cough.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `multicall`'s return type was incorrectly flattening when `allowFailure: false`.

--- a/contracts/src/GH434.sol
+++ b/contracts/src/GH434.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+contract GH434 {
+    function foo() public pure returns (uint256 a, bool b) {
+        return (42069, true);
+    }
+
+    function bar() public pure returns (string memory) {
+        return "hi";
+    }
+
+    function baz() public pure returns (uint256) {
+        return 69420;
+    }
+}

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -185,7 +185,7 @@ export async function multicall<
     ),
   )
 
-  return results.flat().flatMap(({ returnData, success }, i) => {
+  return results.flat().map(({ returnData, success }, i) => {
     const calls = chunkedCalls.flat()
     const { callData } = calls[i]
     const { abi, address, functionName, args } = contracts[i]


### PR DESCRIPTION
Fixes #434.

<!-- start pr-codex -->

## PR-Codex overview
This PR fixes an issue where `multicall`'s return type was incorrectly flattening. It also adds a new contract `GH434` and its corresponding test case. 

### Detailed summary
- Fixed an issue where `multicall`'s return type was incorrectly flattening when `allowFailure: false`.
- Added a new contract `GH434` and its corresponding test case.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->