### PR TITLE
refactor: make "name" optional for abi encoding utils & narrow decoding utils types

### DIFF
--- a/.changeset/five-paws-jog.md
+++ b/.changeset/five-paws-jog.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Refactored contract decoding utility types.

--- a/.changeset/poor-rabbits-eat.md
+++ b/.changeset/poor-rabbits-eat.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Made "name" parameter (`eventName`, `functionName`, etc) optional on contract encoding/decoding utilities when only one ABI item is provided.

--- a/site/docs/contract/decodeFunctionResult.md
+++ b/site/docs/contract/decodeFunctionResult.md
@@ -65,6 +65,44 @@ export const publicClient = createPublicClient({
 
 :::
 
+### Without `functionName`
+
+If your `abi` contains only one ABI item, you can omit the `functionName` (it becomes optional):
+
+::: code-group
+
+```ts [example.ts]
+import { decodeFunctionResult } from 'viem'
+
+const abiItem = {
+  inputs: [{ name: 'tokenId', type: 'uint256' }],
+  name: 'ownerOf',
+  outputs: [{ name: '', type: 'address' }],
+  stateMutability: 'view',
+  type: 'function',
+}
+
+const value = decodeFunctionResult({
+  abi: [abiItem],
+  functionName: 'ownerOf', // [!code --]
+  data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac'
+})
+// '0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'
+```
+
+```ts [client.ts]
+import { createPublicClient, http } from 'viem'
+import { mainnet } from 'viem/chains'
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http()
+})
+```
+
+:::
+
+
 ### A more complex example
 
 ::: code-group

--- a/site/docs/contract/encodeErrorResult.md
+++ b/site/docs/contract/encodeErrorResult.md
@@ -26,7 +26,8 @@ import { encodeErrorResult } from 'viem'
 
 ::: code-group
 
-```ts [example.tsencodert { decodeErrorResult } from 'viem'
+```ts [example.ts]
+import { decodeErrorResult } from 'viem'
 
 const value = encodeErrorResult({
   abi: wagmiAbi,
@@ -64,6 +65,27 @@ export const publicClient = createPublicClient({
 ```
 
 :::
+
+### Without `errorName`
+
+If your `abi` contains only one ABI item, you can omit the `errorName` (it becomes optional):
+
+```ts
+import { decodeErrorResult } from 'viem'
+
+const abiItem = {
+  inputs: [{ name: 'reason', type: 'string' }],
+  name: 'InvalidTokenError',
+  type: 'error'
+}
+
+const value = encodeErrorResult({
+  abi: [abiItem],
+  errorName: 'InvalidTokenError', // [!code --]
+  args: ['sold out']
+})
+// 0xb758934b000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b68656c6c6f20776f726c64000000000000000000000000000000000000000000
+```
 
 ## Return Value
 

--- a/site/docs/contract/encodeEventTopics.md
+++ b/site/docs/contract/encodeEventTopics.md
@@ -134,6 +134,38 @@ export const publicClient = createPublicClient({
 
 :::
 
+### Without `eventName`
+
+If your `abi` contains only one ABI item, you can omit the `eventName` (it becomes optional):
+
+```ts
+import { encodeEventTopics } from 'viem'
+
+const abiItem = {
+  inputs: [
+    {
+      indexed: true,
+      name: 'from',
+      type: 'address',
+    },
+    { indexed: true, name: 'to', type: 'address' },
+    {
+      indexed: false,
+      name: 'value',
+      type: 'uint256',
+    },
+  ],
+  name: 'Transfer',
+  type: 'event',
+}
+
+const topics = encodeEventTopics({
+  abi: [abiItem],
+  eventName: 'Transfer' // [!code --]
+})
+// ["0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0"]
+```
+
 ## Return Value
 
 Encoded topics.

--- a/site/docs/contract/encodeFunctionData.md
+++ b/site/docs/contract/encodeFunctionData.md
@@ -111,6 +111,28 @@ export const publicClient = createPublicClient({
 
 :::
 
+### Without `functionName`
+
+If your `abi` contains only one ABI item, you can omit the `functionName` (it becomes optional):
+
+```ts
+import { encodeFunctionData } from 'viem'
+
+const abiItem = {
+  inputs: [{ name: 'owner', type: 'address' }],
+  name: 'balanceOf',
+  outputs: [{ name: '', type: 'uint256' }],
+  stateMutability: 'view',
+  type: 'function',
+}
+
+const data = encodeFunctionData({
+  abi: [abiItem],
+  functionName: 'balanceOf', // [!code --]
+  args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC']
+})
+```
+
 ## Return Value
 
 [`Hex`](/docs/glossary/types#hex)

--- a/site/docs/contract/encodeFunctionResult.md
+++ b/site/docs/contract/encodeFunctionResult.md
@@ -149,6 +149,29 @@ export const publicClient = createPublicClient({
 
 :::
 
+### Without `functionName`
+
+If your `abi` contains only one ABI item, you can omit the `functionName` (it becomes optional):
+
+```ts
+import { encodeFunctionResult } from 'viem';
+
+const abiItem = {
+  inputs: [{ name: 'owner', type: 'address' }],
+  name: 'balanceOf',
+  outputs: [{ name: '', type: 'uint256' }],
+  stateMutability: 'view',
+  type: 'function',
+}
+
+const data = encodeFunctionResult({
+  abi: wagmiAbi,
+  functionName: 'ownerOf', // [!code --]
+  value: ['0xa5cc3c03994db5b0d9a5eedd10cabab0813678ac'],
+});
+// '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac'
+```
+
 ## Return Value
 
 The decoded data. Type is inferred from the ABI.

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -128,7 +128,7 @@ export async function getLogs<
       try {
         const { eventName, args } = event
           ? decodeEventLog({
-              abi: [event],
+              abi: [event] as [AbiEvent],
               data: log.data,
               topics: log.topics as any,
             })

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -91,7 +91,10 @@ export async function readContract<
       args,
       functionName,
       data: data || '0x',
-    } as DecodeFunctionResultParameters<TAbi, TFunctionName>)
+    } as DecodeFunctionResultParameters<
+      TAbi,
+      TFunctionName
+    >) as ReadContractReturnType<TAbi, TFunctionName>
   } catch (err) {
     throw getContractError(err as BaseError, {
       abi: abi as Abi,

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -146,10 +146,10 @@ export class AbiErrorInputsNotFoundError extends BaseError {
 
 export class AbiErrorNotFoundError extends BaseError {
   override name = 'AbiErrorNotFoundError'
-  constructor(errorName: string, { docsPath }: { docsPath: string }) {
+  constructor(errorName?: string, { docsPath }: { docsPath?: string } = {}) {
     super(
       [
-        `Error "${errorName}" not found on ABI.`,
+        `Error ${errorName ? `"${errorName}" ` : ''}not found on ABI.`,
         'Make sure you are using the correct ABI and that the error exists on it.',
       ].join('\n'),
       {
@@ -202,10 +202,10 @@ export class AbiEventSignatureNotFoundError extends BaseError {
 
 export class AbiEventNotFoundError extends BaseError {
   override name = 'AbiEventNotFoundError'
-  constructor(eventName: string, { docsPath }: { docsPath: string }) {
+  constructor(eventName?: string, { docsPath }: { docsPath?: string } = {}) {
     super(
       [
-        `Event "${eventName}" not found on ABI.`,
+        `Event ${eventName ? `"${eventName}" ` : ''}not found on ABI.`,
         'Make sure you are using the correct ABI and that the event exists on it.',
       ].join('\n'),
       {
@@ -217,10 +217,10 @@ export class AbiEventNotFoundError extends BaseError {
 
 export class AbiFunctionNotFoundError extends BaseError {
   override name = 'AbiFunctionNotFoundError'
-  constructor(functionName: string, { docsPath }: { docsPath: string }) {
+  constructor(functionName?: string, { docsPath }: { docsPath?: string } = {}) {
     super(
       [
-        `Function "${functionName}" not found on ABI.`,
+        `Function ${functionName ? `"${functionName}" ` : ''}not found on ABI.`,
         'Make sure you are using the correct ABI and that the function exists on it.',
       ].join('\n'),
       {

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -148,12 +148,10 @@ test('GetEventArgsFromTopics', () => {
     '0x0000000000000000000000000000000000000000000000000000000000000001'
   >
   expectTypeOf<Result>().toEqualTypeOf<{
-    args?:
-      | {
-          from: `0x${string}`
-          to: `0x${string}`
-        }
-      | undefined
+    args: {
+      from: `0x${string}`
+      to: `0x${string}`
+    }
   }>()
 })
 

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -20,7 +20,7 @@ import type {
 
 import type { Hex, LogTopic } from './misc.js'
 import type { TransactionRequest } from './transaction.js'
-import type { Filter, MaybeRequired, NoUndefined } from './utils.js'
+import type { Filter, MaybeRequired, NoUndefined, Prettify } from './utils.js'
 
 export type AbiItem = Abi[number]
 
@@ -83,7 +83,7 @@ export type MaybeExtractEventArgsFromAbi<
 
 export type InferErrorName<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TErrorName extends string = string,
+  TErrorName extends string | undefined = string,
 > = TAbi extends Abi
   ? ExtractAbiErrorNames<TAbi> extends infer AbiErrorNames
     ?
@@ -104,7 +104,7 @@ export type InferEventName<
 
 export type InferFunctionName<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = string,
+  TFunctionName extends string | undefined = string,
   TAbiStateMutability extends AbiStateMutability = AbiStateMutability,
 > = TAbi extends Abi
   ? ExtractAbiFunctionNames<
@@ -241,7 +241,7 @@ export type GetEventArgsFromTopics<
   ? TData extends undefined
     ? { args?: never }
     : { args?: TArgs }
-  : { args?: TArgs }
+  : { args: TArgs }
 
 //////////////////////////////////////////////////////////////////////
 // ABI event types
@@ -363,63 +363,65 @@ export type AbiEventTopicsToPrimitiveTypes<
   TTopics extends LogTopic[] | undefined = undefined,
   TData extends Hex | undefined = undefined,
   TBase = TAbiParameters[0] extends { name: string } ? {} : [],
-> = TAbiParameters extends readonly [
-  infer Head extends AbiParameter,
-  ...infer Tail,
-]
-  ? TTopics extends readonly [infer TopicHead, ...infer TopicTail]
-    ? Head extends { indexed: true }
-      ? Head extends { name: infer Name extends string }
-        ? {
-            [_ in Name]: TopicHead extends LogTopic
-              ? AbiEventTopicToPrimitiveType<Head, TopicHead>
-              : never
-          } & (Tail extends readonly []
-            ? {}
-            : Tail extends readonly AbiParameter[]
-            ? TopicTail extends LogTopic[]
-              ? AbiEventTopicsToPrimitiveTypes<Tail, TopicTail, TData>
-              : {}
-            : {})
-        : [
-            TopicHead extends LogTopic
-              ? AbiEventTopicToPrimitiveType<Head, TopicHead>
-              : never,
-            ...(Tail extends readonly []
-              ? []
-              : Tail extends readonly AbiParameter[]
-              ? TopicTail extends LogTopic[]
-                ? AbiEventTopicsToPrimitiveTypes<Tail, TopicTail, TData>
-                : []
-              : []),
-          ]
-      : TBase
-    : TTopics extends readonly []
-    ? TData extends '0x'
-      ? TBase
-      : TData extends Hex
-      ? Head extends AbiParameter
-        ? Head extends { indexed: true }
-          ? Tail extends readonly AbiParameter[]
-            ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
-            : TBase
-          : Head extends { name: infer Name extends string }
+> = Prettify<
+  TAbiParameters extends readonly [
+    infer Head extends AbiParameter,
+    ...infer Tail,
+  ]
+    ? TTopics extends readonly [infer TopicHead, ...infer TopicTail]
+      ? Head extends { indexed: true }
+        ? Head extends { name: infer Name extends string }
           ? {
-              [_ in Name]: AbiParameterToPrimitiveType<Head>
+              [_ in Name]: TopicHead extends LogTopic
+                ? AbiEventTopicToPrimitiveType<Head, TopicHead>
+                : never
             } & (Tail extends readonly []
               ? {}
               : Tail extends readonly AbiParameter[]
-              ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
+              ? TopicTail extends LogTopic[]
+                ? AbiEventTopicsToPrimitiveTypes<Tail, TopicTail, TData>
+                : {}
               : {})
           : [
-              AbiParameterToPrimitiveType<Head>,
+              TopicHead extends LogTopic
+                ? AbiEventTopicToPrimitiveType<Head, TopicHead>
+                : never,
               ...(Tail extends readonly []
                 ? []
                 : Tail extends readonly AbiParameter[]
-                ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
+                ? TopicTail extends LogTopic[]
+                  ? AbiEventTopicsToPrimitiveTypes<Tail, TopicTail, TData>
+                  : []
                 : []),
             ]
         : TBase
+      : TTopics extends readonly []
+      ? TData extends '0x'
+        ? TBase
+        : TData extends Hex
+        ? Head extends AbiParameter
+          ? Head extends { indexed: true }
+            ? Tail extends readonly AbiParameter[]
+              ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
+              : TBase
+            : Head extends { name: infer Name extends string }
+            ? {
+                [_ in Name]: AbiParameterToPrimitiveType<Head>
+              } & (Tail extends readonly []
+                ? {}
+                : Tail extends readonly AbiParameter[]
+                ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
+                : {})
+            : [
+                AbiParameterToPrimitiveType<Head>,
+                ...(Tail extends readonly []
+                  ? []
+                  : Tail extends readonly AbiParameter[]
+                  ? AbiEventTopicsToPrimitiveTypes<Tail, [], TData>
+                  : []),
+              ]
+          : TBase
+        : TBase
       : TBase
-    : TBase
-  : undefined
+    : undefined
+>

--- a/src/utils/abi/decodeDeployData.test-d.ts
+++ b/src/utils/abi/decodeDeployData.test-d.ts
@@ -1,0 +1,41 @@
+import { decodeDeployData } from './decodeDeployData.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('default', async () => {
+  const { args } = decodeDeployData({
+    abi: [
+      {
+        inputs: [
+          {
+            type: 'uint256',
+          },
+          {
+            type: 'string',
+          },
+        ],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+      },
+    ],
+    bytecode:
+      '0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea2646970667358221220116554d4ba29ee08da9e97dc54ff9a2a65d67a648140d616fc225a25ff08c86364736f6c63430008070033',
+    data: '0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea2646970667358221220116554d4ba29ee08da9e97dc54ff9a2a65d67a648140d616fc225a25ff08c86364736f6c634300080700330000000000000000000000000000000000000000000000000000000000010f2c',
+  })
+  expectTypeOf(args).toEqualTypeOf<[bigint, string]>()
+})
+
+test('no params', async () => {
+  const { args } = decodeDeployData({
+    abi: [
+      {
+        inputs: [],
+        stateMutability: 'nonpayable',
+        type: 'constructor',
+      },
+    ],
+    bytecode:
+      '0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea2646970667358221220116554d4ba29ee08da9e97dc54ff9a2a65d67a648140d616fc225a25ff08c86364736f6c63430008070033',
+    data: '0x6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea2646970667358221220116554d4ba29ee08da9e97dc54ff9a2a65d67a648140d616fc225a25ff08c86364736f6c63430008070033',
+  })
+  expectTypeOf(args).toEqualTypeOf<undefined>()
+})

--- a/src/utils/abi/decodeDeployData.ts
+++ b/src/utils/abi/decodeDeployData.ts
@@ -1,10 +1,10 @@
-import type { Abi } from 'abitype'
+import type { Abi, Narrow } from 'abitype'
 
 import {
   AbiConstructorNotFoundError,
   AbiConstructorParamsNotFoundError,
 } from '../../errors/index.js'
-import type { Hex } from '../../types/index.js'
+import type { GetConstructorArgs, Hex } from '../../types/index.js'
 import { decodeAbiParameters } from './decodeAbiParameters.js'
 
 const docsPath = '/docs/contract/decodeDeployData'
@@ -12,21 +12,22 @@ const docsPath = '/docs/contract/decodeDeployData'
 export type DecodeDeployDataParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
 > = {
-  abi: TAbi
+  abi: Narrow<TAbi>
   bytecode: Hex
   data: Hex
 }
-export type DecodeDeployDataReturnType = {
-  args?: readonly unknown[] | undefined
+export type DecodeDeployDataReturnType<
+  TAbi extends Abi | readonly unknown[] = Abi,
+> = {
   bytecode: Hex
-}
+} & GetConstructorArgs<TAbi>
 
 export function decodeDeployData<TAbi extends Abi | readonly unknown[]>({
   abi,
   bytecode,
   data,
-}: DecodeDeployDataParameters<TAbi>): DecodeDeployDataReturnType {
-  if (data === bytecode) return { bytecode }
+}: DecodeDeployDataParameters<TAbi>): DecodeDeployDataReturnType<TAbi> {
+  if (data === bytecode) return { bytecode } as DecodeDeployDataReturnType<TAbi>
 
   const description = (abi as Abi).find(
     (x) => 'type' in x && x.type === 'constructor',
@@ -41,5 +42,5 @@ export function decodeDeployData<TAbi extends Abi | readonly unknown[]>({
     description.inputs,
     `0x${data.replace(bytecode, '')}`,
   )
-  return { args, bytecode }
+  return { args, bytecode } as unknown as DecodeDeployDataReturnType<TAbi>
 }

--- a/src/utils/abi/decodeErrorResult.test-d.ts
+++ b/src/utils/abi/decodeErrorResult.test-d.ts
@@ -1,0 +1,103 @@
+import { decodeErrorResult } from './decodeErrorResult.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('default', async () => {
+  const result = decodeErrorResult({
+    abi: [
+      {
+        inputs: [
+          {
+            name: 'foo',
+            type: 'string',
+          },
+        ],
+        name: 'FooError',
+        type: 'error',
+      },
+    ],
+    data: '0x83aa206e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a796f7520646f206e6f7420686176652061636365737320736572000000000000',
+  })
+
+  expectTypeOf(result).toEqualTypeOf<{
+    abiItem: {
+      inputs: [
+        {
+          name: 'foo'
+          type: 'string'
+        },
+      ]
+      name: 'FooError'
+      type: 'error'
+    }
+    errorName: 'FooError'
+    args: [string]
+  }>()
+})
+
+test('multiple', async () => {
+  const result = decodeErrorResult({
+    abi: [
+      {
+        inputs: [
+          {
+            name: 'foo',
+            type: 'string',
+          },
+        ],
+        name: 'FooError',
+        type: 'error',
+      },
+      {
+        inputs: [
+          {
+            name: 'bar',
+            type: 'uint256',
+          },
+        ],
+        name: 'BarError',
+        type: 'error',
+      },
+    ],
+    data: '0x83aa206e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a796f7520646f206e6f7420686176652061636365737320736572000000000000',
+  })
+
+  expectTypeOf(result).toEqualTypeOf<
+    | {
+        abiItem: {
+          inputs: [
+            {
+              name: 'bar'
+              type: 'uint256'
+            },
+          ]
+          name: 'BarError'
+          type: 'error'
+        }
+        errorName: 'BarError'
+        args: [bigint]
+      }
+    | {
+        abiItem: {
+          inputs: [
+            {
+              name: 'foo'
+              type: 'string'
+            },
+          ]
+          name: 'FooError'
+          type: 'error'
+        }
+        errorName: 'FooError'
+        args: [string]
+      }
+  >()
+})
+
+test('no abi', async () => {
+  const result = decodeErrorResult({
+    abi: [],
+    data: '0x83aa206e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a796f7520646f206e6f7420686176652061636365737320736572000000000000',
+  })
+
+  expectTypeOf(result).toEqualTypeOf<never>()
+})

--- a/src/utils/abi/decodeErrorResult.test.ts
+++ b/src/utils/abi/decodeErrorResult.test.ts
@@ -26,7 +26,6 @@ test('revert SoldOutError()', () => {
   expect(
     decodeErrorResult({
       abi: [
-        // @ts-expect-error
         {
           name: 'SoldOutError',
           type: 'error',

--- a/src/utils/abi/decodeEventLog.test-d.ts
+++ b/src/utils/abi/decodeEventLog.test-d.ts
@@ -1,0 +1,193 @@
+import { decodeEventLog } from './decodeEventLog.js'
+import type { Address } from 'abitype'
+import { expectTypeOf, test } from 'vitest'
+
+test('named', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'tokenId',
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+        ],
+        name: 'Foo',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    eventName: 'Transfer',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<{
+    args: {
+      from: Address
+      to: Address
+      tokenId: bigint
+    }
+    eventName: 'Transfer'
+  }>()
+})
+
+test('unnamed', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: false,
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    eventName: 'Transfer',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<{
+    args: [Address, Address, bigint]
+    eventName: 'Transfer'
+  }>()
+})
+
+test('unknown eventName', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'tokenId',
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+        ],
+        name: 'Foo',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<
+    | {
+        args: {
+          from: Address
+          to: Address
+          tokenId: bigint
+        }
+        eventName: 'Transfer'
+      }
+    | {
+        args: {
+          from: Address
+          to: Address
+          value: bigint
+        }
+        eventName: 'Foo'
+      }
+  >()
+})
+
+test('no abi', async () => {
+  const event = decodeEventLog({
+    abi: [],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<never>()
+})

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -12,6 +12,7 @@ import type {
   GetEventArgsFromTopics,
   Hex,
   InferEventName,
+  Prettify,
 } from '../../types/index.js'
 import { getEventSelector } from '../hash/index.js'
 import { decodeAbiParameters } from './decodeAbiParameters.js'
@@ -40,13 +41,17 @@ export type DecodeEventLogReturnType<
       : ExtractAbiEventNames<TAbi>
     : string,
 > = TEventName extends _EventNames[number]
-  ? {
-      eventName: TEventName
-    } & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData>
+  ? Prettify<
+      {
+        eventName: TEventName
+      } & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData>
+    >
   : {
-      [TName in _EventNames]: {
-        eventName: TName
-      } & GetEventArgsFromTopics<TAbi, TName, TTopics, TData>
+      [TName in _EventNames]: Prettify<
+        {
+          eventName: TName
+        } & GetEventArgsFromTopics<TAbi, TName, TTopics, TData>
+      >
     }[_EventNames]
 
 const docsPath = '/docs/contract/decodeEventLog'

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -1,4 +1,4 @@
-import type { Abi, AbiParameter, Narrow } from 'abitype'
+import type { Abi, AbiParameter, ExtractAbiEventNames, Narrow } from 'abitype'
 
 import { DecodeLogDataMismatch } from '../../errors/abi.js'
 import {
@@ -19,7 +19,7 @@ import { formatAbiItem } from './formatAbiItem.js'
 
 export type DecodeEventLogParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string = string,
+  TEventName extends string | undefined = string,
   TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
 > = {
@@ -31,19 +31,30 @@ export type DecodeEventLogParameters<
 
 export type DecodeEventLogReturnType<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string = string,
+  TEventName extends string | undefined = string,
   TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
-> = {
-  eventName: TEventName
-} & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData>
+  _EventNames extends string = TAbi extends Abi
+    ? Abi extends TAbi
+      ? string
+      : ExtractAbiEventNames<TAbi>
+    : string,
+> = TEventName extends _EventNames[number]
+  ? {
+      eventName: TEventName
+    } & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData>
+  : {
+      [TName in _EventNames]: {
+        eventName: TName
+      } & GetEventArgsFromTopics<TAbi, TName, TTopics, TData>
+    }[_EventNames]
 
 const docsPath = '/docs/contract/decodeEventLog'
 
 export function decodeEventLog<
   TAbi extends Abi | readonly unknown[],
-  TEventName extends string,
-  TTopics extends Hex[],
+  TEventName extends string | undefined = undefined,
+  TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
 >({
   abi,

--- a/src/utils/abi/decodeFunctionResult.test-d.ts
+++ b/src/utils/abi/decodeFunctionResult.test-d.ts
@@ -2,7 +2,7 @@ import { decodeFunctionResult } from './decodeFunctionResult.js'
 import type { Address } from 'abitype'
 import { expectTypeOf, test } from 'vitest'
 
-test('default', async () => {
+test('default', () => {
   const data = decodeFunctionResult({
     abi: [
       {

--- a/src/utils/abi/decodeFunctionResult.test-d.ts
+++ b/src/utils/abi/decodeFunctionResult.test-d.ts
@@ -1,0 +1,48 @@
+import { decodeFunctionResult } from './decodeFunctionResult.js'
+import type { Address } from 'abitype'
+import { expectTypeOf, test } from 'vitest'
+
+test('default', async () => {
+  const data = decodeFunctionResult({
+    abi: [
+      {
+        inputs: [],
+        name: 'foo',
+        outputs: [
+          {
+            name: 'sender',
+            type: 'address',
+          },
+        ],
+        stateMutability: 'pure',
+        type: 'function',
+      },
+    ],
+    functionName: 'foo',
+    data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  })
+
+  expectTypeOf(data).toEqualTypeOf<Address>()
+})
+
+test('inferred functionName', () => {
+  expectTypeOf(
+    decodeFunctionResult({
+      abi: [
+        {
+          inputs: [],
+          name: 'foo',
+          outputs: [
+            {
+              name: 'sender',
+              type: 'address',
+            },
+          ],
+          stateMutability: 'pure',
+          type: 'function',
+        },
+      ],
+      data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    }),
+  ).toEqualTypeOf<Address>()
+})

--- a/src/utils/abi/decodeFunctionResult.test.ts
+++ b/src/utils/abi/decodeFunctionResult.test.ts
@@ -251,6 +251,28 @@ test('overloads', () => {
   ).toEqual(105n)
 })
 
+test('inferred functionName', () => {
+  expect(
+    decodeFunctionResult({
+      abi: [
+        {
+          inputs: [],
+          name: 'foo',
+          outputs: [
+            {
+              name: 'sender',
+              type: 'address',
+            },
+          ],
+          stateMutability: 'pure',
+          type: 'function',
+        },
+      ],
+      data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    }),
+  ).toEqual('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC')
+})
+
 test("error: function doesn't exist", () => {
   expect(() =>
     decodeFunctionResult({
@@ -283,7 +305,44 @@ test("error: function doesn't exist", () => {
   )
 })
 
-test("error: function doesn't exist", () => {
+test('error: abi item not a function', () => {
+  expect(() =>
+    // @ts-expect-error
+    decodeFunctionResult({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: false,
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      data: '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Function not found on ABI.
+    Make sure you are using the correct ABI and that the function exists on it.
+
+    Docs: https://viem.sh/docs/contract/decodeFunctionResult.html
+    Version: viem@1.0.2"
+  `,
+  )
+})
+
+test('error: no outputs', () => {
   expect(() =>
     decodeFunctionResult({
       abi: [

--- a/src/utils/abi/decodeFunctionResult.ts
+++ b/src/utils/abi/decodeFunctionResult.ts
@@ -1,10 +1,11 @@
-import type { Abi, Narrow } from 'abitype'
+import type { Abi, ExtractAbiFunctionNames, Narrow } from 'abitype'
 
 import {
   AbiFunctionNotFoundError,
   AbiFunctionOutputsNotFoundError,
 } from '../../errors/index.js'
 import type {
+  AbiItem,
   ContractFunctionResult,
   GetFunctionArgs,
   Hex,
@@ -18,21 +19,34 @@ const docsPath = '/docs/contract/decodeFunctionResult'
 
 export type DecodeFunctionResultParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = string,
+  TFunctionName extends string | undefined = string,
+  _FunctionName = InferFunctionName<TAbi, TFunctionName>,
 > = {
-  abi: Narrow<TAbi>
-  functionName: InferFunctionName<TAbi, TFunctionName>
+  functionName?: _FunctionName
   data: Hex
-} & Partial<GetFunctionArgs<TAbi, TFunctionName>>
+} & (TFunctionName extends string
+  ? { abi: Narrow<TAbi> } & Partial<GetFunctionArgs<TAbi, TFunctionName>>
+  : _FunctionName extends string
+  ? { abi: [Narrow<TAbi[number]>] } & Partial<
+      GetFunctionArgs<TAbi, _FunctionName>
+    >
+  : never)
 
 export type DecodeFunctionResultReturnType<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = string,
-> = ContractFunctionResult<TAbi, TFunctionName>
+  TFunctionName extends string | undefined = string,
+  _FunctionName extends string = TAbi extends Abi
+    ? Abi extends TAbi
+      ? string
+      : ExtractAbiFunctionNames<TAbi>[number]
+    : string,
+> = TFunctionName extends string
+  ? ContractFunctionResult<TAbi, TFunctionName>
+  : ContractFunctionResult<TAbi, _FunctionName>
 
 export function decodeFunctionResult<
   TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string,
+  TFunctionName extends string | undefined = undefined,
 >({
   abi,
   args,
@@ -42,17 +56,22 @@ export function decodeFunctionResult<
   TAbi,
   TFunctionName
 >): DecodeFunctionResultReturnType<TAbi, TFunctionName> {
-  const description = getAbiItem({
-    abi,
-    args,
-    name: functionName,
-  } as GetAbiItemParameters)
-  if (!description)
-    throw new AbiFunctionNotFoundError(functionName, { docsPath })
-  if (!('outputs' in description))
-    throw new AbiFunctionOutputsNotFoundError(functionName, { docsPath })
+  let abiItem = abi[0] as AbiItem
+  if (functionName) {
+    abiItem = getAbiItem({
+      abi,
+      args,
+      name: functionName,
+    } as GetAbiItemParameters)
+    if (!abiItem) throw new AbiFunctionNotFoundError(functionName, { docsPath })
+  }
 
-  const values = decodeAbiParameters(description.outputs, data)
+  if (abiItem.type !== 'function')
+    throw new AbiFunctionNotFoundError(undefined, { docsPath })
+  if (!abiItem.outputs)
+    throw new AbiFunctionOutputsNotFoundError(abiItem.name, { docsPath })
+
+  const values = decodeAbiParameters(abiItem.outputs, data)
   if (values && values.length > 1) return values as any
   if (values && values.length === 1) return values[0] as any
   return undefined as any

--- a/src/utils/abi/encodeErrorResult.test.ts
+++ b/src/utils/abi/encodeErrorResult.test.ts
@@ -99,6 +99,28 @@ test('revert AccessDeniedError((uint256,bool,address,uint256))', () => {
   )
 })
 
+test('inferred errorName', () => {
+  expect(
+    encodeErrorResult({
+      abi: [
+        {
+          inputs: [
+            {
+              name: 'a',
+              type: 'string',
+            },
+          ],
+          name: 'AccessDeniedError',
+          type: 'error',
+        },
+      ],
+      args: ['you do not have access ser'],
+    }),
+  ).toEqual(
+    '0x83aa206e0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a796f7520646f206e6f7420686176652061636365737320736572000000000000',
+  )
+})
+
 test("errors: error doesn't exist", () => {
   expect(() =>
     encodeErrorResult({
@@ -127,6 +149,50 @@ test("errors: error doesn't exist", () => {
     Docs: https://viem.sh/docs/contract/encodeErrorResult.html
     Version: viem@1.0.2"
   `)
+})
+
+test('error: abi item not an error', () => {
+  expect(() =>
+    // @ts-expect-error
+    encodeErrorResult({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: false,
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      args: [
+        {
+          delegate: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+          vote: 41n,
+          voted: true,
+          weight: 69420n,
+        },
+      ],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Error not found on ABI.
+    Make sure you are using the correct ABI and that the error exists on it.
+
+    Docs: https://viem.sh/docs/contract/encodeErrorResult.html
+    Version: viem@1.0.2"
+  `,
+  )
 })
 
 test('errors: no inputs', () => {

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -292,6 +292,44 @@ test('Foo((uint,string))', () => {
   `)
 })
 
+test('inferred eventName', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'tokenId',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      args: {
+        from: null,
+        to: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+      },
+    }),
+  ).toEqual([
+    '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+    null,
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  ])
+})
+
 test("errors: event doesn't exist", () => {
   expect(() =>
     encodeEventTopics({
@@ -313,6 +351,33 @@ test("errors: event doesn't exist", () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
     "Event \\"Bar\\" not found on ABI.
+    Make sure you are using the correct ABI and that the event exists on it.
+
+    Docs: https://viem.sh/docs/contract/encodeEventTopics.html
+    Version: viem@1.0.2"
+  `)
+})
+
+test('errors: abi item not an event', () => {
+  expect(() =>
+    // @ts-expect-error
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'message',
+              type: 'string',
+            },
+          ],
+          name: 'Foo',
+          type: 'function',
+        },
+      ],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Event not found on ABI.
     Make sure you are using the correct ABI and that the event exists on it.
 
     Docs: https://viem.sh/docs/contract/encodeEventTopics.html

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -10,6 +10,7 @@ import {
   FilterTypeNotSupportedError,
 } from '../../errors/index.js'
 import type {
+  AbiItem,
   EventDefinition,
   GetEventArgs,
   Hex,
@@ -24,26 +25,38 @@ import type { GetAbiItemParameters } from './getAbiItem.js'
 
 export type EncodeEventTopicsParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string = string,
+  TEventName extends string | undefined = string,
+  _EventName = InferEventName<TAbi, TEventName>,
 > = {
-  abi: Narrow<TAbi>
-  args?: GetEventArgs<TAbi, TEventName>
-  eventName: InferEventName<TAbi, TEventName>
-}
+  eventName?: _EventName
+} & (TEventName extends string
+  ? { abi: Narrow<TAbi>; args?: GetEventArgs<TAbi, TEventName> }
+  : _EventName extends string
+  ? { abi: [Narrow<TAbi[number]>]; args?: GetEventArgs<TAbi, _EventName> }
+  : never)
 
 export function encodeEventTopics<
   TAbi extends Abi | readonly unknown[],
-  TEventName extends string,
+  TEventName extends string | undefined = undefined,
 >({ abi, eventName, args }: EncodeEventTopicsParameters<TAbi, TEventName>) {
-  const abiItem = getAbiItem({
-    abi,
-    args,
-    name: eventName,
-  } as GetAbiItemParameters)
-  if (!abiItem)
-    throw new AbiEventNotFoundError(eventName, {
+  let abiItem = abi[0] as AbiItem
+  if (eventName) {
+    abiItem = getAbiItem({
+      abi,
+      args,
+      name: eventName,
+    } as GetAbiItemParameters)
+    if (!abiItem)
+      throw new AbiEventNotFoundError(eventName, {
+        docsPath: '/docs/contract/encodeEventTopics',
+      })
+  }
+
+  if (abiItem.type !== 'event')
+    throw new AbiEventNotFoundError(undefined, {
       docsPath: '/docs/contract/encodeEventTopics',
     })
+
   const definition = formatAbiItem(abiItem)
   const signature = getEventSelector(definition as EventDefinition)
 

--- a/src/utils/abi/encodeFunctionData.test.ts
+++ b/src/utils/abi/encodeFunctionData.test.ts
@@ -107,6 +107,30 @@ test('getVoter((uint256,bool,address,uint256))', () => {
   )
 })
 
+test('inferred functionName', () => {
+  expect(
+    encodeFunctionData({
+      abi: [
+        {
+          inputs: [
+            {
+              name: 'a',
+              type: 'uint256',
+            },
+          ],
+          name: 'bar',
+          outputs: [],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      args: [1n],
+    }),
+  ).toEqual(
+    '0x0423a1320000000000000000000000000000000000000000000000000000000000000001',
+  )
+})
+
 test("errors: function doesn't exist", () => {
   expect(() =>
     encodeFunctionData({
@@ -124,6 +148,28 @@ test("errors: function doesn't exist", () => {
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
     "Function \\"bar\\" not found on ABI.
+    Make sure you are using the correct ABI and that the function exists on it.
+
+    Docs: https://viem.sh/docs/contract/encodeFunctionData.html
+    Version: viem@1.0.2"
+  `)
+})
+
+test('errors: abi item not a function', () => {
+  expect(() =>
+    // @ts-expect-error
+    encodeFunctionData({
+      abi: [
+        {
+          inputs: [],
+          name: 'Foo',
+          outputs: [],
+          type: 'error',
+        },
+      ],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Function not found on ABI.
     Make sure you are using the correct ABI and that the function exists on it.
 
     Docs: https://viem.sh/docs/contract/encodeFunctionData.html

--- a/src/utils/abi/encodeFunctionResult.test.ts
+++ b/src/utils/abi/encodeFunctionResult.test.ts
@@ -203,6 +203,30 @@ test('returns (Bar, string)', () => {
   )
 })
 
+test('inferred functionName', () => {
+  expect(
+    encodeFunctionResult({
+      abi: [
+        {
+          inputs: [],
+          name: 'foo',
+          outputs: [
+            {
+              name: 'sender',
+              type: 'address',
+            },
+          ],
+          stateMutability: 'pure',
+          type: 'function',
+        },
+      ],
+      result: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+    }),
+  ).toEqual(
+    '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+  )
+})
+
 test("error: function doesn't exist", () => {
   expect(() =>
     encodeFunctionResult({
@@ -259,4 +283,27 @@ test("error: function doesn't exist", () => {
     Version: viem@1.0.2"
   `,
   )
+})
+
+test('errors: abi item not a function', () => {
+  expect(() =>
+    // @ts-expect-error
+    encodeFunctionResult({
+      abi: [
+        {
+          inputs: [],
+          name: 'Foo',
+          outputs: [],
+          type: 'error',
+        },
+      ],
+      result: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Function not found on ABI.
+    Make sure you are using the correct ABI and that the function exists on it.
+
+    Docs: https://viem.sh/docs/contract/encodeFunctionResult.html
+    Version: viem@1.0.2"
+  `)
 })

--- a/src/utils/abi/encodeFunctionResult.ts
+++ b/src/utils/abi/encodeFunctionResult.ts
@@ -5,40 +5,60 @@ import {
   AbiFunctionOutputsNotFoundError,
 } from '../../errors/index.js'
 import type {
+  AbiItem,
   ContractFunctionResult,
   InferFunctionName,
 } from '../../types/index.js'
+import { type GetAbiItemParameters, getAbiItem } from '../index.js'
 import { encodeAbiParameters } from './encodeAbiParameters.js'
 
 const docsPath = '/docs/contract/encodeFunctionResult'
 
 export type EncodeFunctionResultParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
-  TFunctionName extends string = string,
+  TFunctionName extends string | undefined = string,
+  _FunctionName = InferFunctionName<TAbi, TFunctionName>,
 > = {
-  abi: Narrow<TAbi>
-  functionName: InferFunctionName<TAbi, TFunctionName>
-  result?: ContractFunctionResult<TAbi, TFunctionName>
-}
+  functionName?: _FunctionName
+} & (TFunctionName extends string
+  ? { abi: Narrow<TAbi>; result?: ContractFunctionResult<TAbi, TFunctionName> }
+  : _FunctionName extends string
+  ? {
+      abi: [Narrow<TAbi[number]>]
+      result?: ContractFunctionResult<TAbi, _FunctionName>
+    }
+  : never)
 
 export function encodeFunctionResult<
   TAbi extends Abi | readonly unknown[],
-  TFunctionName extends string,
+  TFunctionName extends string | undefined = undefined,
 >({
   abi,
   functionName,
   result,
 }: EncodeFunctionResultParameters<TAbi, TFunctionName>) {
-  const description = (abi as Abi).find(
-    (x) => 'name' in x && x.name === functionName,
-  )
-  if (!description)
-    throw new AbiFunctionNotFoundError(functionName, { docsPath })
-  if (!('outputs' in description))
-    throw new AbiFunctionOutputsNotFoundError(functionName, { docsPath })
+  let abiItem = abi[0] as AbiItem
+  if (functionName) {
+    abiItem = getAbiItem({
+      abi,
+      name: functionName,
+    } as GetAbiItemParameters)
+    if (!abiItem)
+      throw new AbiFunctionNotFoundError(functionName, {
+        docsPath: '/docs/contract/encodeFunctionResult',
+      })
+  }
+
+  if (abiItem.type !== 'function')
+    throw new AbiFunctionNotFoundError(undefined, {
+      docsPath: '/docs/contract/encodeFunctionResult',
+    })
+
+  if (!abiItem.outputs)
+    throw new AbiFunctionOutputsNotFoundError(abiItem.name, { docsPath })
 
   let values = Array.isArray(result) ? result : [result]
-  if (description.outputs.length === 0 && !values[0]) values = []
+  if (abiItem.outputs.length === 0 && !values[0]) values = []
 
-  return encodeAbiParameters(description.outputs, values)
+  return encodeAbiParameters(abiItem.outputs, values)
 }


### PR DESCRIPTION
This PR aims to make the "name" parameter (ie. `functionName`, `eventName`, etc) optional on our contract encoding/decoding utilities. Essentially, if the `abi` is only a singular abi item (single element array), the `functionName` parameter will become optional. 

```diff
import { encodeFunctionData } from 'viem'

const data = encodeFunctionData({
  abi: parseAbi(['function balanceOf(address owner)']),
- functionName: 'balanceOf',
  args: ['0x0000000000000000000000000000000000000000']
})
```

TODO:

- Docs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR refactors contract decoding utility types and makes `functionName` and `eventName` optional when only one ABI item is provided. Notable changes:

- Refactored contract decoding utility types.
- Made "name" parameter (`eventName`, `functionName`, etc) optional on contract encoding/decoding utilities when only one ABI item is provided.

> The following files were skipped due to too many changes: `src/utils/abi/encodeErrorResult.test.ts`, `src/utils/abi/decodeDeployData.test-d.ts`, `src/utils/abi/decodeDeployData.ts`, `src/errors/abi.ts`, `src/utils/abi/encodeEventTopics.ts`, `src/utils/abi/decodeEventLog.ts`, `src/utils/abi/decodeErrorResult.test-d.ts`, `src/utils/abi/decodeErrorResult.ts`, `src/utils/abi/encodeFunctionResult.ts`, `src/utils/abi/encodeErrorResult.ts`, `src/utils/abi/encodeFunctionData.ts`, `src/utils/abi/decodeFunctionResult.ts`, `src/utils/abi/decodeEventLog.test-d.ts`, `src/types/contract.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->