### PR TITLE
refactor: log types

### DIFF
--- a/.changeset/four-beers-count.md
+++ b/.changeset/four-beers-count.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Refactored inferred types on `Log` (eventName, args, topics), `getLogs`, `getFilterLogs` & `getFilterChanges`.

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -1,11 +1,12 @@
+import type { Abi, AbiEvent, Address } from 'abitype'
 import { describe, expectTypeOf, test } from 'vitest'
 
-import { publicClient, usdcContractConfig } from '../../_test/index.js'
-import type { Address, Log } from '../../types/index.js'
+import { usdcContractConfig } from '../../_test/abis.js'
+import { publicClient } from '../../_test/utils.js'
+import type { Log } from '../../types/log.js'
 import { createContractEventFilter } from './createContractEventFilter.js'
 import { createEventFilter } from './createEventFilter.js'
 import { getFilterChanges } from './getFilterChanges.js'
-import type { Abi, AbiEvent } from 'abitype'
 
 describe('createEventFilter', () => {
   test('default', async () => {

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -1,0 +1,367 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import { publicClient, usdcContractConfig } from '../../_test/index.js'
+import type { Address, Log } from '../../types/index.js'
+import { createContractEventFilter } from './createContractEventFilter.js'
+import { createEventFilter } from './createEventFilter.js'
+import { getFilterChanges } from './getFilterChanges.js'
+import type { Abi, AbiEvent } from 'abitype'
+
+describe('createEventFilter', () => {
+  test('default', async () => {
+    const filter = await createEventFilter(publicClient)
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0]).not.toHaveProperty('eventName')
+    expectTypeOf(logs[0]).not.toHaveProperty('args')
+  })
+
+  test('args: event: defined inline', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: {
+        type: 'event',
+        name: 'Foo',
+        inputs: [
+          {
+            indexed: true,
+            name: 'owner',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'foo',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            indexed: false,
+            name: 'bar',
+            type: 'uint256',
+          },
+        ],
+      },
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: event: defined as const', async () => {
+    const event = {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    } as const
+    const filter = await createEventFilter(publicClient, {
+      event,
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: event: defined as `AbiEvent`', async () => {
+    const event: AbiEvent = {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    }
+    const filter = await createEventFilter(publicClient, {
+      event,
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[]>()
+  })
+})
+
+describe('createContractEventFilter', () => {
+  const abi = [
+    ...usdcContractConfig.abi,
+    {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    },
+  ] as const
+
+  test('default', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs).toEqualTypeOf<
+      Log<bigint, number, undefined, typeof abi>[]
+    >()
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      | [`0x${string}`, `0x${string}`, `0x${string}`]
+      | [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<
+      'Transfer' | 'Approval' | 'Foo'
+    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from: Address
+          to: Address
+          value: bigint
+        }
+      | {
+          owner: Address
+          spender: Address
+          value: bigint
+        }
+      | {
+          owner: Address
+          spender: Address
+          foo: Address
+          value: bigint
+          bar: bigint
+        }
+    >()
+  })
+
+  test('args: eventName', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+      eventName: 'Foo',
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: abi: defined inline', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi: [
+        {
+          type: 'event',
+          name: 'Foo',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'foo',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+            {
+              indexed: false,
+              name: 'bar',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: abi: declared as `Abi`', async () => {
+    const abi: Abi = [
+      {
+        type: 'event',
+        name: 'Foo',
+        inputs: [
+          {
+            indexed: true,
+            name: 'owner',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'foo',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            indexed: false,
+            name: 'bar',
+            type: 'uint256',
+          },
+        ],
+      },
+    ]
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[]>()
+  })
+})

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -1,4 +1,11 @@
-import { assertType, beforeAll, describe, expect, test } from 'vitest'
+import {
+  assertType,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+} from 'vitest'
 
 import { usdcContractConfig } from '../../_test/abis.js'
 import { accounts, address, forkBlockNumber } from '../../_test/constants.js'
@@ -562,7 +569,17 @@ describe('events', () => {
     await mine(testClient, { blocks: 1 })
 
     let logs = await getFilterChanges(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+
+    expectTypeOf(logs).toEqualTypeOf<
+      Log<bigint, number, typeof event.default>[]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from: Address
+      to: Address
+      value: bigint
+    }>()
+
     expect(logs.length).toBe(2)
     expect(logs[0].args).toEqual({
       from: getAddress(address.vitalik),

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 import {
   assertType,
   beforeAll,

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -1,11 +1,12 @@
 import { describe, expectTypeOf, test } from 'vitest'
 
-import { publicClient, usdcContractConfig } from '../../_test/index.js'
-import type { Address, Log } from '../../types/index.js'
+import { usdcContractConfig } from '../../_test/abis.js'
+import { publicClient } from '../../_test/utils.js'
+import type { Log } from '../../types/log.js'
 import { createContractEventFilter } from './createContractEventFilter.js'
 import { createEventFilter } from './createEventFilter.js'
 import { getFilterLogs } from './getFilterLogs.js'
-import type { Abi, AbiEvent } from 'abitype'
+import type { Abi, AbiEvent, Address } from 'abitype'
 
 describe('createEventFilter', () => {
   test('default', async () => {

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -1,0 +1,367 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
+import { publicClient, usdcContractConfig } from '../../_test/index.js'
+import type { Address, Log } from '../../types/index.js'
+import { createContractEventFilter } from './createContractEventFilter.js'
+import { createEventFilter } from './createEventFilter.js'
+import { getFilterLogs } from './getFilterLogs.js'
+import type { Abi, AbiEvent } from 'abitype'
+
+describe('createEventFilter', () => {
+  test('default', async () => {
+    const filter = await createEventFilter(publicClient)
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0]).not.toHaveProperty('eventName')
+    expectTypeOf(logs[0]).not.toHaveProperty('args')
+  })
+
+  test('args: event: defined inline', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: {
+        type: 'event',
+        name: 'Foo',
+        inputs: [
+          {
+            indexed: true,
+            name: 'owner',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'foo',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            indexed: false,
+            name: 'bar',
+            type: 'uint256',
+          },
+        ],
+      },
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: event: defined as const', async () => {
+    const event = {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    } as const
+    const filter = await createEventFilter(publicClient, {
+      event,
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: event: defined as `AbiEvent`', async () => {
+    const event: AbiEvent = {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    }
+    const filter = await createEventFilter(publicClient, {
+      event,
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[]>()
+  })
+})
+
+describe('createContractEventFilter', () => {
+  const abi = [
+    ...usdcContractConfig.abi,
+    {
+      type: 'event',
+      name: 'Foo',
+      inputs: [
+        {
+          indexed: true,
+          name: 'owner',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'spender',
+          type: 'address',
+        },
+        {
+          indexed: true,
+          name: 'foo',
+          type: 'address',
+        },
+        {
+          indexed: false,
+          name: 'value',
+          type: 'uint256',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'uint256',
+        },
+      ],
+    },
+  ] as const
+
+  test('default', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs).toEqualTypeOf<
+      Log<bigint, number, undefined, typeof abi>[]
+    >()
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      | [`0x${string}`, `0x${string}`, `0x${string}`]
+      | [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<
+      'Transfer' | 'Approval' | 'Foo'
+    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from: Address
+          to: Address
+          value: bigint
+        }
+      | {
+          owner: Address
+          spender: Address
+          value: bigint
+        }
+      | {
+          owner: Address
+          spender: Address
+          foo: Address
+          value: bigint
+          bar: bigint
+        }
+    >()
+  })
+
+  test('args: eventName', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+      eventName: 'Foo',
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: abi: defined inline', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi: [
+        {
+          type: 'event',
+          name: 'Foo',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'foo',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+            {
+              indexed: false,
+              name: 'bar',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner: Address
+      spender: Address
+      foo: Address
+      value: bigint
+      bar: bigint
+    }>()
+  })
+
+  test('args: abi: declared as `Abi`', async () => {
+    const abi: Abi = [
+      {
+        type: 'event',
+        name: 'Foo',
+        inputs: [
+          {
+            indexed: true,
+            name: 'owner',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'spender',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'foo',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+          {
+            indexed: false,
+            name: 'bar',
+            type: 'uint256',
+          },
+        ],
+      },
+    ]
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [] | [`0x${string}`, ...`0x${string}`[]]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[]>()
+  })
+})

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 import {
   assertType,
   beforeAll,

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -1,4 +1,11 @@
-import { assertType, beforeAll, describe, expect, test } from 'vitest'
+import {
+  assertType,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+} from 'vitest'
 
 import { usdcContractConfig } from '../../_test/abis.js'
 import { accounts, address, forkBlockNumber } from '../../_test/constants.js'
@@ -146,9 +153,23 @@ describe('contract events', () => {
       filter,
     })
 
-    assertType<Log<bigint, number, undefined, typeof usdcContractConfig.abi>[]>(
-      logs,
-    )
+    expectTypeOf(logs).toEqualTypeOf<
+      Log<bigint, number, undefined, typeof usdcContractConfig.abi>[]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from: Address
+          to: Address
+          value: bigint
+        }
+      | {
+          owner: Address
+          spender: Address
+          value: bigint
+        }
+    >()
+
     expect(logs.length).toBe(3)
     expect(logs[0].args).toEqual({
       from: getAddress(address.vitalik),

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -23,6 +23,16 @@ test('event: const assertion', async () => {
         name: 'value',
         type: 'uint256',
       },
+      {
+        indexed: false,
+        name: 'foo',
+        type: 'string',
+      },
+      {
+        indexed: false,
+        name: 'bar',
+        type: 'string',
+      },
     ],
     name: 'Transfer',
     type: 'event',
@@ -30,10 +40,17 @@ test('event: const assertion', async () => {
   const logs = await getLogs(publicClient, {
     event,
   })
+  logs[0].topics
+  expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
+  expectTypeOf(logs[0]['topics']).toEqualTypeOf<
+    [`0x${string}`, `0x${string}`, `0x${string}`]
+  >()
   expectTypeOf(logs[0]['args']).toEqualTypeOf<{
     from: `0x${string}`
     to: `0x${string}`
     value: bigint
+    foo: string
+    bar: string
   }>()
 })
 
@@ -56,15 +73,31 @@ test('event: defined inline', async () => {
           name: 'value',
           type: 'uint256',
         },
+        {
+          indexed: false,
+          name: 'foo',
+          type: 'string',
+        },
+        {
+          indexed: false,
+          name: 'bar',
+          type: 'string',
+        },
       ],
       name: 'Transfer',
       type: 'event',
     },
   })
+  expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
+  expectTypeOf(logs[0]['topics']).toEqualTypeOf<
+    [`0x${string}`, `0x${string}`, `0x${string}`]
+  >()
   expectTypeOf(logs[0]['args']).toEqualTypeOf<{
     from: `0x${string}`
     to: `0x${string}`
     value: bigint
+    foo: string
+    bar: string
   }>()
 })
 
@@ -93,5 +126,22 @@ test('event: declared as `AbiEvent`', async () => {
   const logs = await getLogs(publicClient, {
     event,
   })
+  expectTypeOf(logs[0]['eventName']).toEqualTypeOf<string>()
+  expectTypeOf(logs[0]['topics']).toEqualTypeOf<
+    [] | [`0x${string}`, ...`0x${string}`[]]
+  >()
   expectTypeOf(logs[0]['args']).toEqualTypeOf<readonly unknown[]>()
+})
+
+test('inputs: no inputs', async () => {
+  const logs = await getLogs(publicClient, {
+    event: {
+      inputs: [],
+      name: 'Transfer',
+      type: 'event',
+    },
+  })
+  expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
+  expectTypeOf(logs[0]['topics']).toEqualTypeOf<[`0x${string}`]>()
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<never>()
 })

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -1,3 +1,4 @@
+import type { Address } from 'abitype'
 import {
   assertType,
   beforeAll,

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -1,4 +1,11 @@
-import { assertType, beforeAll, describe, expect, test } from 'vitest'
+import {
+  assertType,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  test,
+} from 'vitest'
 
 import { usdcContractConfig } from '../../_test/abis.js'
 import { accounts, address, forkBlockNumber } from '../../_test/constants.js'
@@ -152,7 +159,17 @@ describe('events', () => {
     const logs = await getLogs(publicClient, {
       event: event.default,
     })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+
+    expectTypeOf(logs).toEqualTypeOf<
+      Log<bigint, number, typeof event.default>[]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from: Address
+      to: Address
+      value: bigint
+    }>()
+
     expect(logs.length).toBe(2)
     expect(logs[0].eventName).toEqual('Transfer')
     expect(logs[0].args).toEqual({

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -780,14 +780,11 @@ export type PublicActions<
    */
   getFilterChanges: <
     TFilterType extends FilterType,
-    TAbiEvent extends AbiEvent | undefined,
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
   >(
-    args: GetFilterChangesParameters<TFilterType, TAbiEvent, TAbi, TEventName>,
-  ) => Promise<
-    GetFilterChangesReturnType<TFilterType, TAbiEvent, TAbi, TEventName>
-  >
+    args: GetFilterChangesParameters<TFilterType, TAbi, TEventName>,
+  ) => Promise<GetFilterChangesReturnType<TFilterType, TAbi, TEventName>>
   /**
    * Returns a list of event logs since the filter was created.
    *
@@ -815,12 +812,11 @@ export type PublicActions<
    * const logs = await client.getFilterLogs({ filter })
    */
   getFilterLogs: <
-    TAbiEvent extends AbiEvent | undefined,
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
   >(
-    args: GetFilterLogsParameters<TAbiEvent, TAbi, TEventName>,
-  ) => Promise<GetFilterLogsReturnType<TAbiEvent, TAbi, TEventName>>
+    args: GetFilterLogsParameters<TAbi, TEventName>,
+  ) => Promise<GetFilterLogsReturnType<TAbi, TEventName>>
   /**
    * Returns the current price of gas (in wei).
    *

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -58,10 +58,10 @@ type GetTopics<
     ? TAbiEvent['name']
     : undefined,
   _AbiEvent extends AbiEvent | undefined = TAbi extends Abi
-  ? TEventName extends string
-    ? ExtractAbiEvent<TAbi, TEventName>
-    : undefined
-  : undefined,
+    ? TEventName extends string
+      ? ExtractAbiEvent<TAbi, TEventName>
+      : undefined
+    : undefined,
   _Args = _AbiEvent extends AbiEvent
     ? AbiEventParametersToPrimitiveTypes<_AbiEvent['inputs']>
     : never,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors inferred types on `Log`, `getLogs`, `getFilterLogs`, and `getFilterChanges`. Notable changes include:
- Importing `Address` from `abitype`
- Using `expectTypeOf` instead of `assertType`
- Removing `MaybeAbiEventName` from `types/contract.js`
- Changing `GetFilterChangesParameters` and `GetFilterLogsParameters` to use `Abi` instead of `AbiEvent`
- Adding `_AbiEvent` to `GetFilterLogsReturnType` and `GetFilterChangesReturnType`
- Changing `DecodedAbiEvent` to use `ExtractAbiEvent` and `ExtractAbiEventNames` from `abitype`

> The following files were skipped due to too many changes: `src/types/log.ts`, `src/actions/public/getFilterLogs.test-d.ts`, `src/actions/public/getFilterChanges.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->