### PR TITLE
chore: update noble & scure

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,9 +148,9 @@
   },
   "dependencies": {
     "@adraffy/ens-normalize": "1.9.0",
-    "@noble/curves": "0.9.0",
+    "@noble/curves": "1.0.0",
     "@noble/hashes": "1.3.0",
-    "@scure/bip32": "1.2.0",
+    "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0",
     "@wagmi/chains": "0.2.16",
     "abitype": "0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,14 +16,14 @@ importers:
         specifier: 1.9.0
         version: 1.9.0
       '@noble/curves':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 1.0.0
+        version: 1.0.0
       '@noble/hashes':
         specifier: 1.3.0
         version: 1.3.0
       '@scure/bip32':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.0
+        version: 1.3.0
       '@scure/bip39':
         specifier: 1.2.0
         version: 1.2.0
@@ -1887,14 +1887,8 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@noble/curves@0.8.3:
-    resolution: {integrity: sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==}
-    dependencies:
-      '@noble/hashes': 1.3.0
-    dev: false
-
-  /@noble/curves@0.9.0:
-    resolution: {integrity: sha512-OAdtHMXBp7Chl2lcTn/i7vnFX/q+hhTwDnek5NfYfZsY4LyaUuHCcoq2JlLY3BTFTLT+ZhYZalhF6ejlV7KnJQ==}
+  /@noble/curves@1.0.0:
+    resolution: {integrity: sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==}
     dependencies:
       '@noble/hashes': 1.3.0
     dev: false
@@ -2124,10 +2118,10 @@ packages:
     resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
     dev: false
 
-  /@scure/bip32@1.2.0:
-    resolution: {integrity: sha512-O+vT/hBVk+ag2i6j2CDemwd1E1MtGt+7O1KzrPNsaNvSsiEK55MyPIxJIMI2PS8Ijj464B2VbQlpRoQXxw1uHg==}
+  /@scure/bip32@1.3.0:
+    resolution: {integrity: sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==}
     dependencies:
-      '@noble/curves': 0.8.3
+      '@noble/curves': 1.0.0
       '@noble/hashes': 1.3.0
       '@scure/base': 1.1.1
     dev: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates several dependencies in the project, including `@noble/curves` and `@scure/bip32`, among others.

### Detailed summary
- Updated `@noble/curves` from `0.9.0` to `1.0.0`
- Updated `@scure/bip32` from `1.2.0` to `1.3.0`
- Updated `@scure/bip39` from `1.2.0` to `1.2.0`
- Updated `@wagmi/chains` from `0.2.16` to `0.2.16`
- Updated `pnpm-lock.yaml` version from `1.9.0` to `1.9.0`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->