### PR TITLE
[WIP] chore: exact optional property types

### DIFF
--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -47,17 +47,17 @@ export type HDAccount = LocalAccount<'hd'> & {
 export type HDOptions =
   | {
       /** The account index to use in the path (`"m/44'/60'/${accountIndex}'/0/0"`). */
-      accountIndex?: number
+      accountIndex?: number | undefined
       /** The address index to use in the path (`"m/44'/60'/0'/0/${addressIndex}"`). */
-      addressIndex?: number
+      addressIndex?: number | undefined
       /** The change index to use in the path (`"m/44'/60'/0'/${changeIndex}/0"`). */
-      changeIndex?: number
-      path?: never
+      changeIndex?: number | undefined
+      path?: never | undefined
     }
   | {
-      accountIndex?: never
-      addressIndex?: never
-      changeIndex?: never
+      accountIndex?: never | undefined
+      addressIndex?: never | undefined
+      changeIndex?: never | undefined
       /** The HD path. */
       path: `m/44'/60'/${string}`
     }

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -20,7 +20,7 @@ export type GetEnsAddressParameters = Prettify<
     /** Name to get the address for. */
     name: string
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -7,7 +7,7 @@ import type { GetEnsTextParameters } from './getEnsText.js'
 export type GetEnsAvatarParameters = Prettify<
   Omit<GetEnsTextParameters, 'key'> & {
     /** Gateway urls to resolve IPFS and/or Arweave assets. */
-    gatewayUrls?: AssetGatewayUrls
+    gatewayUrls?: AssetGatewayUrls | undefined
   }
 >
 

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -13,7 +13,7 @@ export type GetEnsNameParameters = Prettify<
     /** Address to get ENS name for. */
     address: Address
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -10,7 +10,7 @@ export type GetEnsResolverParameters = Prettify<
     /** Name to get the address for. */
     name: string
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -18,7 +18,7 @@ export type GetEnsTextParameters = Prettify<
     /** Text record to retrieve. */
     key: string
     /** Address of ENS Universal Resolver Contract. */
-    universalResolverAddress?: Address
+    universalResolverAddress?: Address | undefined
   }
 >
 

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -363,7 +363,7 @@ test('with and without wallet client `account`', () => {
   expectTypeOf(contractWithAccount.write.approve).parameters.toEqualTypeOf<
     [
       args: readonly [`0x${string}`, bigint],
-      options?: { account?: Account | Address },
+      options?: { account?: Account | Address | undefined },
     ]
   >()
   expectTypeOf(contractWithoutAccount.write.approve).parameters.toEqualTypeOf<
@@ -387,7 +387,10 @@ test('with and without wallet client `chain`', () => {
   })
 
   expectTypeOf(contractWithChain.write.approve).parameters.toEqualTypeOf<
-    [args: readonly [`0x${string}`, bigint], params?: { chain?: Chain | null }]
+    [
+      args: readonly [`0x${string}`, bigint],
+      params?: { chain?: Chain | null | undefined },
+    ]
   >()
   expectTypeOf(contractWithoutChain.write.approve).parameters.toEqualTypeOf<
     [

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -73,7 +73,7 @@ export type GetContractParameters<
    * - [`simulate`](https://viem.sh/docs/contract/simulateContract.html)
    * - [`watchEvent`](https://viem.sh/docs/contract/watchContractEvent.html)
    */
-  publicClient?: TPublicClient
+  publicClient?: TPublicClient | undefined
   /**
    * Wallet client
    *
@@ -81,7 +81,7 @@ export type GetContractParameters<
    *
    * - [`write`](https://viem.sh/docs/contract/writeContract.html)
    */
-  walletClient?: TWalletClient
+  walletClient?: TWalletClient | undefined
 }
 
 export type GetContractReturnType<

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -45,21 +45,21 @@ export type FormattedCall<
 export type CallParameters<
   TChain extends Chain | undefined = Chain | undefined,
 > = FormattedCall<TransactionRequestFormatter<TChain>> & {
-  account?: Account | Address
-  batch?: boolean
+  account?: Account | Address | undefined
+  batch?: boolean | undefined
 } & (
     | {
         /** The balance of the account at a block number. */
-        blockNumber?: bigint
-        blockTag?: never
+        blockNumber?: bigint | undefined
+        blockTag?: never | undefined
       }
     | {
-        blockNumber?: never
+        blockNumber?: never | undefined
         /**
          * The balance of the account at a block tag.
          * @default 'latest'
          */
-        blockTag?: BlockTag
+        blockTag?: BlockTag | undefined
       }
   )
 
@@ -201,7 +201,7 @@ type ScheduleMulticallParameters<TChain extends Chain | undefined> = Pick<
   'blockNumber' | 'blockTag'
 > & {
   data: Hex
-  multicallAddress?: Address
+  multicallAddress?: Address | undefined
   to: Address
 }
 
@@ -287,5 +287,5 @@ async function scheduleMulticall<TChain extends Chain | undefined>(
 
 export function getRevertErrorData(err: unknown) {
   if (!(err instanceof BaseError)) return undefined
-  return (err.walk() as { data?: Hex })?.data
+  return (err.walk() as { data?: Hex | undefined })?.data
 }

--- a/src/actions/public/createContractEventFilter.ts
+++ b/src/actions/public/createContractEventFilter.ts
@@ -21,24 +21,27 @@ export type CreateContractEventFilterParameters<
     | MaybeExtractEventArgsFromAbi<TAbi, TEventName>
     | undefined = undefined,
 > = {
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   abi: Narrow<TAbi>
-  eventName?: InferEventName<TAbi, TEventName>
-  fromBlock?: BlockNumber | BlockTag
-  toBlock?: BlockNumber | BlockTag
+  eventName?: InferEventName<TAbi, TEventName> | undefined
+  fromBlock?: BlockNumber | BlockTag | undefined
+  toBlock?: BlockNumber | BlockTag | undefined
 } & (undefined extends TEventName
   ? {
-      args?: never
+      args?: never | undefined
     }
   : MaybeExtractEventArgsFromAbi<
       TAbi,
       TEventName
     > extends infer TEventFilterArgs
   ? {
-      args?: TEventFilterArgs | (TArgs extends TEventFilterArgs ? TArgs : never)
+      args?:
+        | TEventFilterArgs
+        | (TArgs extends TEventFilterArgs ? TArgs : never)
+        | undefined
     }
   : {
-      args?: never
+      args?: never | undefined
     })
 
 export type CreateContractEventFilterReturnType<

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -24,9 +24,9 @@ export type CreateEventFilterParameters<
     | MaybeExtractEventArgsFromAbi<TAbi, TEventName>
     | undefined = undefined,
 > = {
-  address?: Address | Address[]
-  fromBlock?: BlockNumber | BlockTag
-  toBlock?: BlockNumber | BlockTag
+  address?: Address | Address[] | undefined
+  fromBlock?: BlockNumber | BlockTag | undefined
+  toBlock?: BlockNumber | BlockTag | undefined
 } & (MaybeExtractEventArgsFromAbi<
   TAbi,
   TEventName
@@ -39,16 +39,16 @@ export type CreateEventFilterParameters<
           event: Narrow<TAbiEvent>
         }
       | {
-          args?: never
-          event?: Narrow<TAbiEvent>
+          args?: never | undefined
+          event?: Narrow<TAbiEvent> | undefined
         }
       | {
-          args?: never
-          event?: never
+          args?: never | undefined
+          event?: never | undefined
         }
   : {
-      args?: never
-      event?: never
+      args?: never | undefined
+      event?: never | undefined
     })
 
 export type CreateEventFilterReturnType<

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -44,16 +44,16 @@ export type EstimateGasParameters<
   (
     | {
         /** The balance of the account at a block number. */
-        blockNumber?: bigint
-        blockTag?: never
+        blockNumber?: bigint | undefined
+        blockTag?: never | undefined
       }
     | {
-        blockNumber?: never
+        blockNumber?: never | undefined
         /**
          * The balance of the account at a block tag.
          * @default 'latest'
          */
-        blockTag?: BlockTag
+        blockTag?: BlockTag | undefined
       }
   )
 

--- a/src/actions/public/getBalance.ts
+++ b/src/actions/public/getBalance.ts
@@ -8,13 +8,13 @@ export type GetBalanceParameters = {
 } & (
   | {
       /** The balance of the account at a block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /** The balance of the account at a block tag. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -16,28 +16,28 @@ import { format, formatBlock, numberToHex } from '../../utils/index.js'
 
 export type GetBlockParameters = {
   /** Whether or not to include transaction data in the response. */
-  includeTransactions?: boolean
+  includeTransactions?: boolean | undefined
 } & (
   | {
       /** Hash of the block. */
-      blockHash?: Hash
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: Hash | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /**
        * The block tag.
        * @default 'latest'
        */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 

--- a/src/actions/public/getBlockNumber.ts
+++ b/src/actions/public/getBlockNumber.ts
@@ -4,7 +4,7 @@ import { getCache, withCache } from '../../utils/promise/index.js'
 
 export type GetBlockNumberParameters = {
   /** The maximum age (in ms) of the cached value. */
-  maxAge?: number
+  maxAge?: number | undefined
 }
 
 export type GetBlockNumberReturnType = bigint

--- a/src/actions/public/getBlockTransactionCount.ts
+++ b/src/actions/public/getBlockTransactionCount.ts
@@ -5,21 +5,21 @@ import { hexToNumber, numberToHex } from '../../utils/index.js'
 export type GetBlockTransactionCountParameters =
   | {
       /** Hash of the block. */
-      blockHash?: Hash
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: Hash | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /** The block tag. Defaults to 'latest'. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 
 export type GetBlockTransactionCountReturnType = number

--- a/src/actions/public/getBytecode.ts
+++ b/src/actions/public/getBytecode.ts
@@ -6,12 +6,12 @@ export type GetBytecodeParameters = {
   address: Address
 } & (
   | {
-      blockNumber?: never
-      blockTag?: BlockTag
+      blockNumber?: never | undefined
+      blockTag?: BlockTag | undefined
     }
   | {
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 

--- a/src/actions/public/getFeeHistory.ts
+++ b/src/actions/public/getFeeHistory.ts
@@ -14,17 +14,17 @@ export type GetFeeHistoryParameters = {
   rewardPercentiles: number[]
 } & (
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /**
        * Highest number block of the requested range.
        * @default 'latest'
        */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
   | {
       /** Highest number block of the requested range. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 export type GetFeeHistoryReturnType = FeeHistory

--- a/src/actions/public/getLogs.ts
+++ b/src/actions/public/getLogs.ts
@@ -26,30 +26,30 @@ export type GetLogsParameters<
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = {
   /** Address or list of addresses from which logs originated */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
 } & (
   | {
       event: Narrow<TAbiEvent>
-      args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName>
+      args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName> | undefined
     }
   | {
-      event?: never
-      args?: never
+      event?: never | undefined
+      args?: never | undefined
     }
 ) &
   (
     | {
         /** Block number or tag after which to include logs */
-        fromBlock?: BlockNumber<bigint> | BlockTag
+        fromBlock?: BlockNumber<bigint> | BlockTag | undefined
         /** Block number or tag before which to include logs */
-        toBlock?: BlockNumber<bigint> | BlockTag
-        blockHash?: never
+        toBlock?: BlockNumber<bigint> | BlockTag | undefined
+        blockHash?: never | undefined
       }
     | {
-        fromBlock?: never
-        toBlock?: never
+        fromBlock?: never | undefined
+        toBlock?: never | undefined
         /** Hash of block to include logs from */
-        blockHash?: Hash
+        blockHash?: Hash | undefined
       }
   )
 

--- a/src/actions/public/getStorageAt.ts
+++ b/src/actions/public/getStorageAt.ts
@@ -7,12 +7,12 @@ export type GetStorageAtParameters = {
   slot: Hex
 } & (
   | {
-      blockNumber?: never
-      blockTag?: BlockTag
+      blockNumber?: never | undefined
+      blockTag?: BlockTag | undefined
     }
   | {
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
 )
 

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -17,37 +17,37 @@ export type GetTransactionParameters =
   | {
       /** The block hash */
       blockHash: Hash
-      blockNumber?: never
-      blockTag?: never
-      hash?: never
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
+      blockHash?: never | undefined
       /** The block number */
       blockNumber: bigint
-      blockTag?: never
-      hash?: never
+      blockTag?: never | undefined
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
-      blockNumber?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
       /** The block tag. */
       blockTag: BlockTag
-      hash?: never
+      hash?: never | undefined
       /** The index of the transaction on the block. */
       index: number
     }
   | {
-      blockHash?: never
-      blockNumber?: never
-      blockTag?: never
+      blockHash?: never | undefined
+      blockNumber?: never | undefined
+      blockTag?: never | undefined
       /** The hash of the transaction. */
       hash: Hash
-      index?: number
+      index?: number | undefined
     }
 
 export type GetTransactionReturnType<TChain extends Chain | undefined = Chain> =

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -13,10 +13,10 @@ export type GetTransactionConfirmationsParameters<
   | {
       /** The transaction hash. */
       hash: Hash
-      transactionReceipt?: never
+      transactionReceipt?: never | undefined
     }
   | {
-      hash?: never
+      hash?: never | undefined
       /** The transaction receipt. */
       transactionReceipt: FormattedTransactionReceipt<
         TransactionReceiptFormatter<TChain>

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -12,13 +12,13 @@ export type GetTransactionCountParameters = {
 } & (
   | {
       /** The block number. */
-      blockNumber?: bigint
-      blockTag?: never
+      blockNumber?: bigint | undefined
+      blockTag?: never | undefined
     }
   | {
-      blockNumber?: never
+      blockNumber?: never | undefined
       /** The block tag. Defaults to 'latest'. */
-      blockTag?: BlockTag
+      blockTag?: BlockTag | undefined
     }
 )
 export type GetTransactionCountReturnType = number

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -29,11 +29,11 @@ export type MulticallParameters<
   TContracts extends ContractFunctionConfig[] = ContractFunctionConfig[],
   TAllowFailure extends boolean = true,
 > = Pick<CallParameters, 'blockNumber' | 'blockTag'> & {
-  allowFailure?: TAllowFailure
+  allowFailure?: TAllowFailure | undefined
   /** The maximum size (in bytes) for each calldata chunk. Set to `0` to disable the size limit. @default 1_024 */
-  batchSize?: number
+  batchSize?: number | undefined
   contracts: Narrow<readonly [...MulticallContracts<TContracts>]>
-  multicallAddress?: Address
+  multicallAddress?: Address | undefined
 }
 
 export type MulticallReturnType<

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -29,9 +29,9 @@ export type SimulateContractParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TChainOverride extends Chain | undefined = undefined,
 > = {
-  chain?: TChainOverride
+  chain?: TChainOverride | undefined
   /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
-  dataSuffix?: Hex
+  dataSuffix?: Hex | undefined
 } & ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
   Omit<
     CallParameters<TChainOverride extends Chain ? TChainOverride : TChain>,

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -34,18 +34,18 @@ export type WaitForTransactionReceiptParameters<
    * The number of confirmations (blocks that have passed) to wait before resolving.
    * @default 1
    */
-  confirmations?: number
+  confirmations?: number | undefined
   /** The hash of the transaction. */
   hash: Hash
   /** Optional callback to emit if the transaction has been replaced. */
-  onReplaced?: (response: ReplacementReturnType<TChain>) => void
+  onReplaced?: ((response: ReplacementReturnType<TChain>) => void) | undefined
   /**
    * Polling frequency (in ms). Defaults to the client's pollingInterval config.
    * @default client.pollingInterval
    */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
   /** Optional timeout (in milliseconds) to wait before stopping polling. */
-  timeout?: number
+  timeout?: number | undefined
 }
 
 /**

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -14,11 +14,11 @@ export type OnBlockNumberFn = (
 
 export type PollOptions = {
   /** Whether or not to emit the missed block numbers to the callback. */
-  emitMissed?: boolean
+  emitMissed?: boolean | undefined
   /** Whether or not to emit the latest block number to the callback when the subscription opens. */
-  emitOnBegin?: boolean
+  emitOnBegin?: boolean | undefined
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
 }
 
 export type WatchBlockNumberParameters<
@@ -27,18 +27,18 @@ export type WatchBlockNumberParameters<
   /** The callback to call when a new block number is received. */
   onBlockNumber: OnBlockNumberFn
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void | undefined
 } & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
   ?
       | {
-          emitMissed?: never
-          emitOnBegin?: never
+          emitMissed?: never | undefined
+          emitOnBegin?: never | undefined
           /** Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`. */
-          poll?: false
-          pollingInterval?: never
+          poll?: false | undefined
+          pollingInterval?: never | undefined
         }
       | (PollOptions & { poll: true })
-  : PollOptions & { poll?: true })
+  : PollOptions & { poll?: true | undefined })
 
 export type WatchBlockNumberReturnType = () => void
 

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -15,15 +15,15 @@ export type OnBlock<TChain extends Chain | undefined = Chain> = (
 
 type PollOptions = {
   /** The block tag. Defaults to "latest". */
-  blockTag?: BlockTag
+  blockTag?: BlockTag | undefined
   /** Whether or not to emit the missed blocks to the callback. */
-  emitMissed?: boolean
+  emitMissed?: boolean | undefined
   /** Whether or not to emit the block to the callback when the subscription opens. */
-  emitOnBegin?: boolean
+  emitOnBegin?: boolean | undefined
   /** Whether or not to include transaction data in the response. */
-  includeTransactions?: boolean
+  includeTransactions?: boolean | undefined
   /** Polling frequency (in ms). Defaults to the client's pollingInterval config. */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
 }
 
 export type WatchBlocksParameters<
@@ -33,20 +33,20 @@ export type WatchBlocksParameters<
   /** The callback to call when a new block is received. */
   onBlock: OnBlock<TChain>
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void | undefined
 } & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
   ?
       | {
-          blockTag?: never
-          emitMissed?: never
-          emitOnBegin?: never
-          includeTransactions?: never
+          blockTag?: never | undefined
+          emitMissed?: never | undefined
+          emitOnBegin?: never | undefined
+          includeTransactions?: never | undefined
           /** Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`. */
-          poll?: false
-          pollingInterval?: never
+          poll?: false | undefined
+          pollingInterval?: never | undefined
         }
-      | (PollOptions & { poll?: true })
-  : PollOptions & { poll?: true })
+      | (PollOptions & { poll?: true | undefined })
+  : PollOptions & { poll?: true | undefined })
 
 export type WatchBlocksReturnType = () => void
 

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -36,20 +36,20 @@ export type WatchContractEventParameters<
   TEventName extends string = string,
 > = {
   /** The address of the contract. */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   /** Contract ABI. */
   abi: Narrow<TAbi>
-  args?: GetEventArgs<TAbi, TEventName>
+  args?: GetEventArgs<TAbi, TEventName> | undefined
   /** Whether or not the event logs should be batched on each invocation. */
-  batch?: boolean
+  batch?: boolean | undefined
   /** Contract event. */
-  eventName?: InferEventName<TAbi, TEventName>
+  eventName?: InferEventName<TAbi, TEventName> | undefined
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void | undefined
   /** The callback to call when new event logs are received. */
   onLogs: OnLogsFn<TAbi, TEventName>
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
 }
 
 export type WatchContractEventReturnType = () => void

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -31,26 +31,26 @@ export type WatchEventParameters<
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = {
   /** The address of the contract. */
-  address?: Address | Address[]
+  address?: Address | Address[] | undefined
   /**
    * Whether or not the event logs should be batched on each invocation.
    * @default true
    */
-  batch?: boolean
+  batch?: boolean | undefined
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void | undefined
   /** The callback to call when new event logs are received. */
   onLogs: OnLogsFn<TAbiEvent, TEventName>
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
 } & (
   | {
       event: TAbiEvent
-      args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName>
+      args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName> | undefined
     }
   | {
-      event?: never
-      args?: never
+      event?: never | undefined
+      args?: never | undefined
     }
 )
 

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -19,41 +19,41 @@ type PollOptions = {
    * Whether or not the transaction hashes should be batched on each invocation.
    * @default true
    */
-  batch?: boolean
+  batch?: boolean | undefined
   /**
    * Polling frequency (in ms). Defaults to Client's pollingInterval config.
    * @default client.pollingInterval
    */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
 }
 
 export type WatchPendingTransactionsParameters<
   TTransport extends Transport = Transport,
 > = {
   /** The callback to call when an error occurred when trying to get for a new block. */
-  onError?: (error: Error) => void
+  onError?: (error: Error) => void | undefined
   /** The callback to call when new transactions are received. */
   onTransactions: OnTransactionsFn
 } & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
   ?
       | {
-          batch?: never
+          batch?: never | undefined
           /**
            * Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`.
            * @default false
            */
-          poll?: false
-          pollingInterval?: never
+          poll?: false | undefined
+          pollingInterval?: never | undefined
         }
       | (PollOptions & {
           /**
            * Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`.
            * @default true
            */
-          poll?: true
+          poll?: true | undefined
         })
   : PollOptions & {
-      poll?: true
+      poll?: true | undefined
     })
 
 export type WatchPendingTransactionsReturnType = () => void

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -10,7 +10,7 @@ export type MineParameters = {
   /** Number of blocks to mine. */
   blocks: number
   /** Interval between each block in seconds. */
-  interval?: number
+  interval?: number | undefined
 }
 
 /**

--- a/src/actions/test/reset.ts
+++ b/src/actions/test/reset.ts
@@ -7,9 +7,9 @@ import type { Chain } from '../../types/index.js'
 
 export type ResetParameters = {
   /** The block number to reset from. */
-  blockNumber?: bigint
+  blockNumber?: bigint | undefined
   /** The JSON RPC URL. */
-  jsonRpcUrl?: string
+  jsonRpcUrl?: string | undefined
 }
 
 /**

--- a/src/actions/wallet/addChain.test.ts
+++ b/src/actions/wallet/addChain.test.ts
@@ -11,6 +11,7 @@ test('default', async () => {
 
 test('no block explorer', async () => {
   await addChain(walletClient!, {
-    chain: { ...avalanche, blockExplorers: undefined },
+    // NOTE: Wagmi should type `blockExplorers` as optionally `undefined`.
+    chain: { ...avalanche, blockExplorers: undefined as any },
   })
 })

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -31,7 +31,7 @@ export type WriteContractParameters<
   GetChain<TChain, TChainOverride> &
   GetValue<TAbi, TFunctionName, SendTransactionParameters<TChain>['value']> & {
     /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
-    dataSuffix?: Hex
+    dataSuffix?: Hex | undefined
   }
 
 export type WriteContractReturnType = SendTransactionReturnType

--- a/src/adapters/ethers.ts
+++ b/src/adapters/ethers.ts
@@ -84,7 +84,7 @@ export const ethersWalletToAccount = (wallet: EthersWallet) =>
         ? wallet.signTypedData.bind(wallet)
         : wallet._signTypedData.bind(wallet)
       return (await signTypedData(
-        domain ?? {},
+        (domain ?? {}) as TypedDataDomain,
         types as Record<string, TypedDataField[]>,
         message,
       )) as Hash

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -11,20 +11,20 @@ export type ClientConfig<
   TChain extends Chain | undefined = Chain | undefined,
 > = {
   /** Chain for the client. */
-  chain?: TChain
+  chain?: TChain | undefined
   /** A key for the client. */
-  key?: string
+  key?: string | undefined
   /** A name for the client. */
-  name?: string
+  name?: string | undefined
   /**
    * Frequency (in ms) for polling enabled actions & events.
    * @default 4_000
    */
-  pollingInterval?: number
+  pollingInterval?: number | undefined
   /** The RPC transport */
   transport: TTransport
   /** The type of client. */
-  type?: string
+  type?: string | undefined
 }
 
 export type Client<

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -8,9 +8,9 @@ import type { Transport } from './transports/createTransport.js'
 
 export type MulticallBatchOptions = {
   /** The maximum size (in bytes) for each calldata chunk. @default 1_024 */
-  batchSize?: number
+  batchSize?: number | undefined
   /** The maximum number of milliseconds to wait before sending a batch. @default 16 */
-  wait?: number
+  wait?: number | undefined
 }
 
 export type PublicClientConfig<
@@ -21,10 +21,12 @@ export type PublicClientConfig<
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
 > & {
   /** Flags for batch settings. */
-  batch?: {
-    /** Toggle to enable `eth_call` multicall aggregation. */
-    multicall?: boolean | MulticallBatchOptions
-  }
+  batch?:
+    | {
+        /** Toggle to enable `eth_call` multicall aggregation. */
+        multicall?: boolean | MulticallBatchOptions
+      }
+    | undefined
 }
 
 export type PublicClient<

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -25,7 +25,7 @@ export type WalletClientConfig<
   'chain' | 'key' | 'name' | 'pollingInterval' | 'transport'
 > & {
   /** The Account to use for the Wallet Client. This will be used for Actions that require an account as an argument. */
-  account?: TAccountOrAddress
+  account?: TAccountOrAddress | undefined
 }
 
 export type WalletClient<

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -18,11 +18,11 @@ export type TransportConfig<
   /** The JSON-RPC request function that matches the EIP-1193 request spec. */
   request: TRequests
   /** The base delay (in ms) between retries. */
-  retryDelay?: number
+  retryDelay?: number | undefined
   /** The max number of times to retry. */
-  retryCount?: number
+  retryCount?: number | undefined
   /** The timeout (in ms) for requests. */
-  timeout?: number
+  timeout?: number | undefined
   /** The type of the transport. */
   type: TType
 }
@@ -34,14 +34,14 @@ export type Transport<
 > = <TChain extends Chain | undefined = Chain>({
   chain,
 }: {
-  chain?: TChain
-  pollingInterval?: ClientConfig['pollingInterval']
-  retryCount?: TransportConfig['retryCount']
-  timeout?: TransportConfig['timeout']
+  chain?: TChain | undefined
+  pollingInterval?: ClientConfig['pollingInterval'] | undefined
+  retryCount?: TransportConfig['retryCount'] | undefined
+  timeout?: TransportConfig['timeout'] | undefined
 }) => {
   config: TransportConfig<TType>
   request: TRequests
-  value?: TRpcAttributes
+  value?: TRpcAttributes | undefined
 }
 
 /**

--- a/src/clients/transports/custom.ts
+++ b/src/clients/transports/custom.ts
@@ -9,13 +9,13 @@ type EthereumProvider = { request: BaseRpcRequests['request'] }
 
 export type CustomTransportConfig = {
   /** The key of the transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
 }
 
 export type CustomTransport = Transport<'custom', EthereumProvider['request']>

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -12,13 +12,13 @@ export type OnResponseFn = (
     transport: ReturnType<Transport>
   } & (
     | {
-        error?: never
+        error?: never | undefined
         response: unknown
         status: 'success'
       }
     | {
         error: Error
-        response?: never
+        response?: never | undefined
         status: 'error'
       }
   ),
@@ -29,45 +29,47 @@ type RankOptions = {
    * The polling interval (in ms) at which the ranker should ping the RPC URL.
    * @default client.pollingInterval
    */
-  interval?: number
+  interval?: number | undefined
   /**
    * The number of previous samples to perform ranking on.
    * @default 10
    */
-  sampleCount?: number
+  sampleCount?: number | undefined
   /**
    * Timeout when sampling transports.
    * @default 1_000
    */
-  timeout?: number
+  timeout?: number | undefined
   /**
    * Weights to apply to the scores. Weight values are proportional.
    */
-  weights?: {
-    /**
-     * The weight to apply to the latency score.
-     * @default 0.3
-     */
-    latency?: number
-    /**
-     * The weight to apply to the stability score.
-     * @default 0.7
-     */
-    stability?: number
-  }
+  weights?:
+    | {
+        /**
+         * The weight to apply to the latency score.
+         * @default 0.3
+         */
+        latency?: number
+        /**
+         * The weight to apply to the stability score.
+         * @default 0.7
+         */
+        stability?: number
+      }
+    | undefined
 }
 
 export type FallbackTransportConfig = {
   /** The key of the Fallback transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the Fallback transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** Toggle to enable ranking, or rank options. */
-  rank?: boolean | RankOptions
+  rank?: boolean | RankOptions | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
 }
 
 export type FallbackTransport = Transport<
@@ -173,13 +175,13 @@ export function rankTransports({
   transports,
   weights = {},
 }: {
-  chain?: Chain
+  chain?: Chain | undefined
   interval: RankOptions['interval']
   onTransports: (transports: Transport[]) => void
-  sampleCount?: RankOptions['sampleCount']
-  timeout?: RankOptions['timeout']
+  sampleCount?: RankOptions['sampleCount'] | undefined
+  timeout?: RankOptions['timeout'] | undefined
   transports: Transport[]
-  weights?: RankOptions['weights']
+  weights?: RankOptions['weights'] | undefined
 }) {
   const { stability: stabilityWeight = 0.7, latency: latencyWeight = 0.3 } =
     weights

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -9,23 +9,23 @@ export type HttpTransportConfig = {
    * Request configuration to pass to `fetch`.
    * @link https://developer.mozilla.org/en-US/docs/Web/API/fetch
    */
-  fetchOptions?: HttpOptions['fetchOptions']
+  fetchOptions?: HttpOptions['fetchOptions'] | undefined
   /** The key of the HTTP transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the HTTP transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for the HTTP request. Default: 10_000 */
-  timeout?: TransportConfig['timeout']
+  timeout?: TransportConfig['timeout'] | undefined
 }
 
 export type HttpTransport = Transport<
   'http',
   {
-    url?: string
+    url?: string | undefined
   }
 >
 

--- a/src/clients/transports/webSocket.ts
+++ b/src/clients/transports/webSocket.ts
@@ -9,7 +9,7 @@ import { createTransport } from './createTransport.js'
 
 type WebSocketTransportSubscribeParameters = {
   onData: (data: RpcResponse) => void
-  onError?: (error: any) => void
+  onError?: ((error: any) => void) | undefined
 }
 
 type WebSocketTransportSubscribeReturnType = {
@@ -31,15 +31,15 @@ type WebSocketTransportSubscribe = {
 
 export type WebSocketTransportConfig = {
   /** The key of the WebSocket transport. */
-  key?: TransportConfig['key']
+  key?: TransportConfig['key'] | undefined
   /** The name of the WebSocket transport. */
-  name?: TransportConfig['name']
+  name?: TransportConfig['name'] | undefined
   /** The max number of times to retry. */
-  retryCount?: TransportConfig['retryCount']
+  retryCount?: TransportConfig['retryCount'] | undefined
   /** The base delay (in ms) between retries. */
-  retryDelay?: TransportConfig['retryDelay']
+  retryDelay?: TransportConfig['retryDelay'] | undefined
   /** The timeout (in ms) for async WebSocket requests. Default: 10_000 */
-  timeout?: TransportConfig['timeout']
+  timeout?: TransportConfig['timeout'] | undefined
 }
 
 export type WebSocketTransport = Transport<

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -146,7 +146,10 @@ export class AbiErrorInputsNotFoundError extends BaseError {
 
 export class AbiErrorNotFoundError extends BaseError {
   override name = 'AbiErrorNotFoundError'
-  constructor(errorName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    errorName?: string,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Error ${errorName ? `"${errorName}" ` : ''}not found on ABI.`,
@@ -202,7 +205,10 @@ export class AbiEventSignatureNotFoundError extends BaseError {
 
 export class AbiEventNotFoundError extends BaseError {
   override name = 'AbiEventNotFoundError'
-  constructor(eventName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    eventName?: string,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Event ${eventName ? `"${eventName}" ` : ''}not found on ABI.`,
@@ -217,7 +223,10 @@ export class AbiEventNotFoundError extends BaseError {
 
 export class AbiFunctionNotFoundError extends BaseError {
   override name = 'AbiFunctionNotFoundError'
-  constructor(functionName?: string, { docsPath }: { docsPath?: string } = {}) {
+  constructor(
+    functionName?: string,
+    { docsPath }: { docsPath?: string | undefined } = {},
+  ) {
     super(
       [
         `Function ${functionName ? `"${functionName}" ` : ''}not found on ABI.`,

--- a/src/errors/account.ts
+++ b/src/errors/account.ts
@@ -2,7 +2,7 @@ import { BaseError } from './base.js'
 
 export class AccountNotFoundError extends BaseError {
   override name = 'AccountNotFoundError'
-  constructor({ docsPath }: { docsPath?: string } = {}) {
+  constructor({ docsPath }: { docsPath?: string | undefined } = {}) {
     super(
       [
         'Could not find an Account to execute with this Action.',

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -1,24 +1,24 @@
 import { getVersion } from './utils.js'
 
 type BaseErrorParameters = {
-  docsPath?: string
-  docsSlug?: string
-  metaMessages?: string[]
+  docsPath?: string | undefined
+  docsSlug?: string | undefined
+  metaMessages?: string[] | undefined
 } & (
   | {
-      cause?: never
-      details?: string
+      cause?: never | undefined
+      details?: string | undefined
     }
   | {
       cause: BaseError | Error
-      details?: never
+      details?: never | undefined
     }
 )
 
 export class BaseError extends Error {
   details: string
-  docsPath?: string
-  metaMessages?: string[]
+  docsPath?: string | undefined
+  metaMessages?: string[] | undefined
   shortMessage: string
 
   override name = 'ViemError'

--- a/src/errors/block.ts
+++ b/src/errors/block.ts
@@ -7,8 +7,8 @@ export class BlockNotFoundError extends BaseError {
     blockHash,
     blockNumber,
   }: {
-    blockHash?: Hash
-    blockNumber?: bigint
+    blockHash?: Hash | undefined
+    blockNumber?: bigint | undefined
   }) {
     let identifier = 'Block'
     if (blockHash) identifier = `Block at hash "${blockHash}"`

--- a/src/errors/chain.ts
+++ b/src/errors/chain.ts
@@ -8,9 +8,9 @@ export class ChainDoesNotSupportContract extends BaseError {
     chain,
     contract,
   }: {
-    blockNumber?: bigint
+    blockNumber?: bigint | undefined
     chain: Chain
-    contract: { name: string; blockCreated?: number }
+    contract: { name: string; blockCreated?: number | undefined }
   }) {
     super(
       `Chain "${chain.name}" does not support contract "${contract.name}".`,

--- a/src/errors/contract.ts
+++ b/src/errors/contract.ts
@@ -36,7 +36,10 @@ export class CallExecutionError extends BaseError {
       nonce,
       to,
       value,
-    }: CallParameters & { chain?: Chain; docsPath?: string },
+    }: CallParameters & {
+      chain?: Chain | undefined
+      docsPath?: string | undefined
+    },
   ) {
     const account = account_ ? parseAccount(account_) : undefined
     const prettyArgs = prettyPrint({
@@ -73,12 +76,12 @@ export class CallExecutionError extends BaseError {
 
 export class ContractFunctionExecutionError extends BaseError {
   abi: Abi
-  args?: unknown[]
+  args?: unknown[] | undefined
   override cause: BaseError
-  contractAddress?: Address
-  formattedArgs?: string
+  contractAddress?: Address | undefined
+  formattedArgs?: string | undefined
   functionName: string
-  sender?: Address
+  sender?: Address | undefined
 
   override name = 'ContractFunctionExecutionError'
 
@@ -93,11 +96,11 @@ export class ContractFunctionExecutionError extends BaseError {
       sender,
     }: {
       abi: Abi
-      args?: any
-      contractAddress?: Address
-      docsPath?: string
+      args?: any | undefined
+      contractAddress?: Address | undefined
+      docsPath?: string | undefined
       functionName: string
-      sender?: Address
+      sender?: Address | undefined
     },
   ) {
     const abiItem = getAbiItem({ abi, args, name: functionName })
@@ -150,15 +153,20 @@ export class ContractFunctionExecutionError extends BaseError {
 export class ContractFunctionRevertedError extends BaseError {
   override name = 'ContractFunctionRevertedError'
 
-  data?: DecodeErrorResultReturnType
-  reason?: string
+  data?: DecodeErrorResultReturnType | undefined
+  reason?: string | undefined
 
   constructor({
     abi,
     data,
     functionName,
     message,
-  }: { abi: Abi; data?: Hex; functionName: string; message?: string }) {
+  }: {
+    abi: Abi
+    data?: Hex | undefined
+    functionName: string
+    message?: string | undefined
+  }) {
     let decodedData: DecodeErrorResultReturnType | undefined = undefined
     let metaMessages
     let reason
@@ -229,9 +237,12 @@ export class RawContractError extends BaseError {
   code = 3
   override name = 'RawContractError'
 
-  data?: Hex
+  data?: Hex | undefined
 
-  constructor({ data, message }: { data?: Hex; message?: string }) {
+  constructor({
+    data,
+    message,
+  }: { data?: Hex | undefined; message?: string | undefined }) {
     super(message || '')
     this.data = data
   }

--- a/src/errors/encoding.ts
+++ b/src/errors/encoding.ts
@@ -32,10 +32,10 @@ export class IntegerOutOfRangeError extends BaseError {
     size,
     value,
   }: {
-    max?: string
+    max?: string | undefined
     min: string
-    signed?: boolean
-    size?: number
+    signed?: boolean | undefined
+    size?: number | undefined
     value: string
   }) {
     super(

--- a/src/errors/estimateGas.ts
+++ b/src/errors/estimateGas.ts
@@ -24,9 +24,9 @@ export class EstimateGasExecutionError extends BaseError {
       to,
       value,
     }: Omit<EstimateGasParameters<any, any>, 'account'> & {
-      account?: Account
-      chain?: Chain
-      docsPath?: string
+      account?: Account | undefined
+      chain?: Chain | undefined
+      docsPath?: string | undefined
     },
   ) {
     const prettyArgs = prettyPrint({

--- a/src/errors/node.ts
+++ b/src/errors/node.ts
@@ -20,7 +20,7 @@ export class ExecutionRevertedError extends BaseError {
   constructor({
     cause,
     message,
-  }: { cause?: BaseError; message?: string } = {}) {
+  }: { cause?: BaseError | undefined; message?: string | undefined } = {}) {
     const reason = message
       ?.replace('execution reverted: ', '')
       ?.replace('execution reverted', '')
@@ -42,7 +42,10 @@ export class FeeCapTooHighError extends BaseError {
   constructor({
     cause,
     maxFeePerGas,
-  }: { cause?: BaseError; maxFeePerGas?: bigint } = {}) {
+  }: {
+    cause?: BaseError | undefined
+    maxFeePerGas?: bigint | undefined
+  } = {}) {
     super(
       `The fee cap (\`maxFeePerGas\`${
         maxFeePerGas ? ` = ${formatGwei(maxFeePerGas)} gwei` : ''
@@ -61,7 +64,10 @@ export class FeeCapTooLowError extends BaseError {
   constructor({
     cause,
     maxFeePerGas,
-  }: { cause?: BaseError; maxFeePerGas?: bigint } = {}) {
+  }: {
+    cause?: BaseError | undefined
+    maxFeePerGas?: bigint | undefined
+  } = {}) {
     super(
       `The fee cap (\`maxFeePerGas\`${
         maxFeePerGas ? ` = ${formatGwei(maxFeePerGas)}` : ''
@@ -76,7 +82,10 @@ export class FeeCapTooLowError extends BaseError {
 export class NonceTooHighError extends BaseError {
   static nodeMessage = /nonce too high/
   override name = 'NonceTooHighError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
@@ -89,7 +98,10 @@ export class NonceTooHighError extends BaseError {
 export class NonceTooLowError extends BaseError {
   static nodeMessage = /nonce too low|transaction already imported/
   override name = 'NonceTooLowError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       [
         `Nonce provided for the transaction ${
@@ -105,7 +117,10 @@ export class NonceTooLowError extends BaseError {
 export class NonceMaxValueError extends BaseError {
   static nodeMessage = /nonce has max value/
   override name = 'NonceMaxValueError'
-  constructor({ cause, nonce }: { cause?: BaseError; nonce?: number } = {}) {
+  constructor({
+    cause,
+    nonce,
+  }: { cause?: BaseError | undefined; nonce?: number | undefined } = {}) {
     super(
       `Nonce provided for the transaction ${
         nonce ? `(${nonce}) ` : ''
@@ -118,7 +133,7 @@ export class NonceMaxValueError extends BaseError {
 export class InsufficientFundsError extends BaseError {
   static nodeMessage = /insufficient funds/
   override name = 'InsufficientFundsError'
-  constructor({ cause }: { cause?: BaseError } = {}) {
+  constructor({ cause }: { cause?: BaseError | undefined } = {}) {
     super(
       [
         'The total cost (gas * gas fee + value) of executing this transaction exceeds the balance of the account.',
@@ -143,7 +158,10 @@ export class InsufficientFundsError extends BaseError {
 export class IntrinsicGasTooHighError extends BaseError {
   static nodeMessage = /intrinsic gas too high|gas limit reached/
   override name = 'IntrinsicGasTooHighError'
-  constructor({ cause, gas }: { cause?: BaseError; gas?: bigint } = {}) {
+  constructor({
+    cause,
+    gas,
+  }: { cause?: BaseError | undefined; gas?: bigint | undefined } = {}) {
     super(
       `The amount of gas ${
         gas ? `(${gas}) ` : ''
@@ -158,7 +176,10 @@ export class IntrinsicGasTooHighError extends BaseError {
 export class IntrinsicGasTooLowError extends BaseError {
   static nodeMessage = /intrinsic gas too low/
   override name = 'IntrinsicGasTooLowError'
-  constructor({ cause, gas }: { cause?: BaseError; gas?: bigint } = {}) {
+  constructor({
+    cause,
+    gas,
+  }: { cause?: BaseError | undefined; gas?: bigint | undefined } = {}) {
     super(
       `The amount of gas ${
         gas ? `(${gas}) ` : ''
@@ -173,7 +194,7 @@ export class IntrinsicGasTooLowError extends BaseError {
 export class TransactionTypeNotSupportedError extends BaseError {
   static nodeMessage = /transaction type not valid/
   override name = 'TransactionTypeNotSupportedError'
-  constructor({ cause }: { cause?: BaseError }) {
+  constructor({ cause }: { cause?: BaseError | undefined }) {
     super('The transaction type is not supported for this chain.', {
       cause,
     })
@@ -189,9 +210,9 @@ export class TipAboveFeeCapError extends BaseError {
     maxPriorityFeePerGas,
     maxFeePerGas,
   }: {
-    cause?: BaseError
-    maxPriorityFeePerGas?: bigint
-    maxFeePerGas?: bigint
+    cause?: BaseError | undefined
+    maxPriorityFeePerGas?: bigint | undefined
+    maxFeePerGas?: bigint | undefined
   } = {}) {
     super(
       [
@@ -213,7 +234,7 @@ export class TipAboveFeeCapError extends BaseError {
 export class UnknownNodeError extends BaseError {
   override name = 'UnknownNodeError'
 
-  constructor({ cause }: { cause?: BaseError }) {
+  constructor({ cause }: { cause?: BaseError | undefined }) {
     super(`An error occurred while executing: ${cause?.message}`, {
       cause,
     })

--- a/src/errors/request.ts
+++ b/src/errors/request.ts
@@ -5,9 +5,9 @@ import { getUrl } from './utils.js'
 export class HttpRequestError extends BaseError {
   override name = 'HttpRequestError'
 
-  body?: { [key: string]: unknown }
-  headers?: Headers
-  status?: number
+  body?: { [key: string]: unknown } | undefined
+  headers?: Headers | undefined
+  status?: number | undefined
   url: string
 
   constructor({
@@ -17,10 +17,10 @@ export class HttpRequestError extends BaseError {
     status,
     url,
   }: {
-    body?: { [key: string]: unknown }
-    details?: string
-    headers?: Headers
-    status?: number
+    body?: { [key: string]: unknown } | undefined
+    details?: string | undefined
+    headers?: Headers | undefined
+    status?: number | undefined
     url: string
   }) {
     super('HTTP request failed.', {

--- a/src/errors/rpc.ts
+++ b/src/errors/rpc.ts
@@ -4,9 +4,9 @@ import { RpcRequestError } from './request.js'
 const unknownErrorCode = -1
 
 type RpcErrorOptions = {
-  code?: number
-  docsPath?: string
-  metaMessages?: string[]
+  code?: number | undefined
+  docsPath?: string | undefined
+  metaMessages?: string[] | undefined
   shortMessage: string
 }
 
@@ -31,7 +31,8 @@ export class RpcError extends BaseError {
       cause,
       docsPath,
       metaMessages:
-        metaMessages || (cause as { metaMessages?: string[] })?.metaMessages,
+        metaMessages ||
+        (cause as { metaMessages?: string[] | undefined })?.metaMessages,
     })
     this.name = cause.name
     this.code = cause instanceof RpcRequestError ? cause.code : code
@@ -46,12 +47,12 @@ export class RpcError extends BaseError {
 export class ProviderRpcError<T = undefined> extends RpcError {
   override name = 'ProviderRpcError'
 
-  data?: T
+  data?: T | undefined
 
   constructor(
     cause: Error,
     options: RpcErrorOptions & {
-      data?: T
+      data?: T | undefined
     },
   ) {
     super(cause, options)

--- a/src/errors/transaction.ts
+++ b/src/errors/transaction.ts
@@ -141,8 +141,8 @@ export class TransactionExecutionError extends BaseError {
       value,
     }: Omit<SendTransactionParameters, 'account' | 'chain'> & {
       account: Account
-      chain?: Chain
-      docsPath?: string
+      chain?: Chain | undefined
+      docsPath?: string | undefined
     },
   ) {
     const prettyArgs = prettyPrint({
@@ -187,11 +187,11 @@ export class TransactionNotFoundError extends BaseError {
     hash,
     index,
   }: {
-    blockHash?: Hash
-    blockNumber?: bigint
-    blockTag?: BlockTag
-    hash?: Hash
-    index?: number
+    blockHash?: Hash | undefined
+    blockNumber?: bigint | undefined
+    blockTag?: BlockTag | undefined
+    hash?: Hash | undefined
+    index?: number | undefined
   }) {
     let identifier = 'Transaction'
     if (blockTag && index !== undefined)

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -19,7 +19,7 @@ export type GetAccountParameter<
   TAccount extends Account | undefined = Account | undefined,
 > = IsUndefined<TAccount> extends true
   ? { account: Account | Address }
-  : { account?: Account | Address }
+  : { account?: Account | Address | undefined }
 
 export type ParseAccount<TAccount extends Account | Address | undefined> =
   | (TAccount extends Account ? TAccount : never)

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -51,7 +51,7 @@ export type Block<TQuantity = bigint, TTransaction = Transaction> = {
 
 export type BlockIdentifier<TQuantity = bigint> = {
   /** Whether or not to throw an error if the block is not in the canonical chain as described below. Only allowed in conjunction with the blockHash tag. Defaults to false. */
-  requireCanonical?: boolean
+  requireCanonical?: boolean | undefined
 } & (
   | {
       /** The block in the canonical chain with this number */

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -5,12 +5,12 @@ import type { Formatters } from './formatter.js'
 import type { IsUndefined } from './utils.js'
 
 export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
-  formatters?: TFormatters
+  formatters?: TFormatters | undefined
 }
 
 export type ChainContract = {
   address: Address
-  blockCreated?: number
+  blockCreated?: number | undefined
 }
 
 export type GetChain<
@@ -18,4 +18,4 @@ export type GetChain<
   TChainOverride extends Chain | undefined = undefined,
 > = IsUndefined<TChain> extends true
   ? { chain: TChainOverride | null }
-  : { chain?: TChainOverride | null }
+  : { chain?: TChainOverride | null | undefined }

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -169,10 +169,10 @@ test('GetValue', () => {
 
   // other
   expectTypeOf<GetValue<typeof seaportAbi, 'getOrderStatus'>>().toEqualTypeOf<{
-    value?: never
+    value?: never | undefined
   }>()
   expectTypeOf<GetValue<typeof seaportAbi, 'cancel'>>().toEqualTypeOf<{
-    value?: never
+    value?: never | undefined
   }>()
 })
 
@@ -449,8 +449,8 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     }
   >
   expectTypeOf<Named_DisableUnion>().toEqualTypeOf<{
-    foo?: string
-    bar?: number
+    foo?: string | undefined
+    bar?: number | undefined
   }>()
 
   // unnamed parameters

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -68,7 +68,7 @@ export type GetValue<
   ? { value: NoUndefined<TValueType> }
   : TAbiFunction['payable'] extends true
   ? { value: NoUndefined<TValueType> }
-  : { value?: never }
+  : { value?: never | undefined }
 
 export type MaybeAbiEventName<TAbiEvent extends AbiEvent | undefined> =
   TAbiEvent extends AbiEvent ? TAbiEvent['name'] : undefined
@@ -154,10 +154,10 @@ export type GetFunctionArgs<
        *
        * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link abi} for type inference.
        */
-      args?: readonly unknown[]
+      args?: readonly unknown[] | undefined
     }
   : TArgs extends readonly []
-  ? { args?: never }
+  ? { args?: never | undefined }
   : {
       /** Arguments to pass contract method */ args: TArgs
     }
@@ -178,10 +178,10 @@ export type GetConstructorArgs<
        *
        * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link abi} for type inference.
        */
-      args?: readonly unknown[]
+      args?: readonly unknown[] | undefined
     }
   : TArgs extends readonly []
-  ? { args?: never }
+  ? { args?: never | undefined }
   : {
       /** Arguments to pass contract constructor */ args: TArgs
     }
@@ -203,10 +203,10 @@ export type GetErrorArgs<
        *
        * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link abi} for type inference.
        */
-      args?: readonly unknown[]
+      args?: readonly unknown[] | undefined
     }
   : TArgs extends readonly []
-  ? { args?: never }
+  ? { args?: never | undefined }
   : {
       /** Arguments to pass contract method */ args: TArgs
     }
@@ -239,17 +239,17 @@ export type GetEventArgsFromTopics<
   TArgs = AbiEventTopicsToPrimitiveTypes<TAbiEvent['inputs'], TTopics, TData>,
 > = TTopics extends readonly []
   ? TData extends undefined
-    ? { args?: never }
-    : { args?: TArgs }
+    ? { args?: never | undefined }
+    : { args?: TArgs | undefined }
   : { args: TArgs }
 
 //////////////////////////////////////////////////////////////////////
 // ABI event types
 
 type EventParameterOptions = {
-  EnableUnion?: boolean
-  IndexedOnly?: boolean
-  Required?: boolean
+  EnableUnion?: boolean | undefined
+  IndexedOnly?: boolean | undefined
+  Required?: boolean | undefined
 }
 type DefaultEventParameterOptions = {
   EnableUnion: true

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -84,14 +84,16 @@ export type Chain = {
   /** The chain name. */
   chainName: string
   /** Native currency for the chain. */
-  nativeCurrency?: {
-    name: string
-    symbol: string
-    decimals: number
-  }
+  nativeCurrency?:
+    | {
+        name: string
+        symbol: string
+        decimals: number
+      }
+    | undefined
   rpcUrls: readonly string[]
-  blockExplorerUrls?: string[]
-  iconUrls?: string[]
+  blockExplorerUrls?: string[] | undefined
+  iconUrls?: string[] | undefined
 }
 
 export type NetworkSync = {
@@ -127,7 +129,7 @@ export type WatchAssetParams = {
     /** The number of token decimals */
     decimals: number
     /** A string url of the token logo */
-    image?: string
+    image?: string | undefined
   }
 }
 
@@ -141,7 +143,7 @@ export type PublicRequests = {
      * // => 'MetaMask/v1.0.0'
      */
     method: 'web3_clientVersion'
-    params?: never
+    params?: never | undefined
   }): Promise<string>
   request(args: {
     /**
@@ -163,7 +165,7 @@ export type PublicRequests = {
      * // => true
      */
     method: 'net_listening'
-    params?: never
+    params?: never | undefined
   }): Promise<boolean>
   request(args: {
     /**
@@ -174,7 +176,7 @@ export type PublicRequests = {
      * // => '0x1'
      */
     method: 'net_peerCount'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -185,7 +187,7 @@ export type PublicRequests = {
      * // => '1'
      */
     method: 'net_version'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -196,7 +198,7 @@ export type PublicRequests = {
      * // => '0x1b4'
      * */
     method: 'eth_blockNumber'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -220,9 +222,12 @@ export type PublicRequests = {
      * // => '1'
      */
     method: 'eth_chainId'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
-  request(args: { method: 'eth_coinbase'; params?: never }): Promise<Address>
+  request(args: {
+    method: 'eth_coinbase'
+    params?: never | undefined
+  }): Promise<Address>
   request(args: {
     /**
      * @description Estimates the gas necessary to complete a transaction without submitting it to the network
@@ -272,7 +277,7 @@ export type PublicRequests = {
      * // => '0x09184e72a000'
      * */
     method: 'eth_gasPrice'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -393,18 +398,18 @@ export type PublicRequests = {
     method: 'eth_getLogs'
     params: [
       parameters: {
-        address?: Address | Address[]
-        topics?: LogTopic[]
+        address?: Address | Address[] | undefined
+        topics?: LogTopic[] | undefined
       } & (
         | {
-            fromBlock?: BlockNumber | BlockTag
-            toBlock?: BlockNumber | BlockTag
-            blockHash?: never
+            fromBlock?: BlockNumber | BlockTag | undefined
+            toBlock?: BlockNumber | BlockTag | undefined
+            blockHash?: never | undefined
           }
         | {
-            fromBlock?: never
-            toBlock?: never
-            blockHash?: Hash
+            fromBlock?: never | undefined
+            toBlock?: never | undefined
+            blockHash?: Hash | undefined
           }
       ),
     ]
@@ -532,7 +537,7 @@ export type PublicRequests = {
      * // => '0x1'
      * */
     method: 'eth_newBlockFilter'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -545,10 +550,10 @@ export type PublicRequests = {
     method: 'eth_newFilter'
     params: [
       filter: {
-        fromBlock?: BlockNumber | BlockTag
-        toBlock?: BlockNumber | BlockTag
-        address?: Address | Address[]
-        topics?: LogTopic[]
+        fromBlock?: BlockNumber | BlockTag | undefined
+        toBlock?: BlockNumber | BlockTag | undefined
+        address?: Address | Address[] | undefined
+        topics?: LogTopic[] | undefined
       },
     ]
   }): Promise<Quantity>
@@ -561,7 +566,7 @@ export type PublicRequests = {
      * // => '0x1'
      * */
     method: 'eth_newPendingTransactionFilter'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -572,7 +577,7 @@ export type PublicRequests = {
      * // => '54'
      * */
     method: 'eth_protocolVersion'
-    params?: never
+    params?: never | undefined
   }): Promise<string>
   request(args: {
     /**
@@ -623,7 +628,7 @@ export type TestRequests<Name extends string> = {
      * @description Turn on call traces for transactions that are returned to the user when they execute a transaction (instead of just txhash/receipt).
      */
     method: `${Name}_enableTraces`
-    params?: never
+    params?: never | undefined
   }): Promise<void>
   request(args: {
     /**
@@ -828,21 +833,21 @@ export type TestRequests<Name extends string> = {
      * @link https://hardhat.org/hardhat-network/docs/reference#evm_snapshot
      */
     method: 'evm_snapshot'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
      * @description Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to.
      */
     method: 'evm_revert'
-    params?: [id: Quantity]
+    params?: [id: Quantity] | undefined
   }): Promise<void>
   request(args: {
     /**
      * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-content
      */
     method: 'txpool_content'
-    params?: never
+    params?: never | undefined
   }): Promise<{
     pending: Record<Address, Record<string, Transaction>>
     queued: Record<Address, Record<string, Transaction>>
@@ -852,7 +857,7 @@ export type TestRequests<Name extends string> = {
      * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
      */
     method: 'txpool_inspect'
-    params?: never
+    params?: never | undefined
   }): Promise<{
     pending: Record<Address, Record<string, string>>
     queued: Record<Address, Record<string, string>>
@@ -862,7 +867,7 @@ export type TestRequests<Name extends string> = {
      * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
      */
     method: 'txpool_status'
-    params?: never
+    params?: never | undefined
   }): Promise<{
     pending: Quantity
     queued: Quantity
@@ -944,7 +949,7 @@ export type SignableRequests = {
      * // => { startingBlock: '0x...', currentBlock: '0x...', highestBlock: '0x...' }
      * */
     method: 'eth_syncing'
-    params?: never
+    params?: never | undefined
   }): Promise<NetworkSync | false>
   request(args: {
     /**
@@ -974,7 +979,7 @@ export type WalletRequests = {
      * // => ['0x0fB69...']
      * */
     method: 'eth_accounts'
-    params?: never
+    params?: never | undefined
   }): Promise<Address[]>
   request(args: {
     /**
@@ -984,7 +989,7 @@ export type WalletRequests = {
      * // => '1'
      */
     method: 'eth_chainId'
-    params?: never
+    params?: never | undefined
   }): Promise<Quantity>
   request(args: {
     /**
@@ -995,7 +1000,7 @@ export type WalletRequests = {
      * // => ['0x...', '0x...']
      * */
     method: 'eth_requestAccounts'
-    params?: never
+    params?: never | undefined
   }): Promise<Address[]>
   request(args: {
     /**
@@ -1017,7 +1022,7 @@ export type WalletRequests = {
      * // => { ... }
      * */
     method: 'wallet_getPermissions'
-    params?: never
+    params?: never | undefined
   }): Promise<WalletPermission[]>
   request(args: {
     /**

--- a/src/types/fee.ts
+++ b/src/types/fee.ts
@@ -9,18 +9,18 @@ export type FeeHistory<TQuantity = bigint> = {
   /** Lowest number block of the returned range. */
   oldestBlock: TQuantity
   /** An array of effective priority fees (in wei) per gas data points from a single block. All zeroes are returned if the block is empty. */
-  reward?: TQuantity[][]
+  reward?: TQuantity[][] | undefined
 }
 
 export type FeeValuesLegacy<TQuantity = bigint> = {
   /** Base fee per gas. */
   gasPrice: TQuantity
-  maxFeePerGas?: never
-  maxPriorityFeePerGas?: never
+  maxFeePerGas?: never | undefined
+  maxPriorityFeePerGas?: never | undefined
 }
 
 export type FeeValuesEIP1559<TQuantity = bigint> = {
-  gasPrice?: never
+  gasPrice?: never | undefined
   /** Total fee per gas in wei (gasPrice/baseFeePerGas + maxPriorityFeePerGas). */
   maxFeePerGas: TQuantity
   /** Max priority fee per gas (in wei). */

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -23,8 +23,8 @@ export type Filter<
     ? undefined extends TEventName
       ? {
           abi: TAbi
-          args?: never
-          eventName?: never
+          args?: never | undefined
+          eventName?: never | undefined
         }
       : TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName>
       ? {
@@ -34,12 +34,12 @@ export type Filter<
         }
       : {
           abi: TAbi
-          args?: never
+          args?: never | undefined
           eventName: TEventName
         }
     : {
-        abi?: never
-        args?: never
-        eventName?: never
+        abi?: never | undefined
+        args?: never | undefined
+        eventName?: never | undefined
       }
   : {})

--- a/src/types/formatter.ts
+++ b/src/types/formatter.ts
@@ -16,8 +16,12 @@ export type Formatter<TSource = any, TTarget = any> = (
 ) => TTarget
 
 export type Formatters = {
-  block?: Formatter<RpcBlock, Block>
-  transaction?: Formatter<RpcTransaction, Transaction>
-  transactionReceipt?: Formatter<RpcTransactionReceipt, TransactionReceipt>
-  transactionRequest?: Formatter<TransactionRequest, RpcTransactionRequest>
+  block?: Formatter<RpcBlock, Block> | undefined
+  transaction?: Formatter<RpcTransaction, Transaction> | undefined
+  transactionReceipt?:
+    | Formatter<RpcTransactionReceipt, TransactionReceipt>
+    | undefined
+  transactionRequest?:
+    | Formatter<TransactionRequest, RpcTransactionRequest>
+    | undefined
 }

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -82,7 +82,7 @@ export type TransactionLegacy<
   TType = 'legacy',
 > = TransactionBase<TQuantity, TIndex> &
   FeeValuesLegacy<TQuantity> & {
-    accessList?: never
+    accessList?: never | undefined
     type: TType
   }
 export type TransactionEIP2930<
@@ -110,38 +110,38 @@ export type Transaction<TQuantity = bigint, TIndex = number> =
 
 export type TransactionRequestBase<TQuantity = bigint, TIndex = number> = {
   /** Contract code or a hashed method call with encoded args */
-  data?: Hex
+  data?: Hex | undefined
   /** Transaction sender */
   from: Address
   /** Gas provided for transaction execution */
-  gas?: TQuantity
+  gas?: TQuantity | undefined
   /** Unique number identifying this transaction */
-  nonce?: TIndex
+  nonce?: TIndex | undefined
   /** Transaction recipient */
-  to?: Address
+  to?: Address | undefined
   /** Value in wei sent with this transaction */
-  value?: TQuantity
+  value?: TQuantity | undefined
 }
 export type TransactionRequestLegacy<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: never
+    accessList?: never | undefined
   }
 export type TransactionRequestEIP2930<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: AccessList
+    accessList?: AccessList | undefined
   }
 export type TransactionRequestEIP1559<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
+    accessList?: AccessList | undefined
   }
 export type TransactionRequest<TQuantity = bigint, TIndex = number> =
   | TransactionRequestLegacy<TQuantity, TIndex>
@@ -165,29 +165,29 @@ export type TransactionSerializableLegacy<
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: never
-    chainId?: number
-    type?: 'legacy'
+    accessList?: never | undefined
+    chainId?: number | undefined
+    type?: 'legacy' | undefined
   }
 export type TransactionSerializableEIP2930<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
-    accessList?: AccessList
+    accessList?: AccessList | undefined
     chainId: number
-    type?: 'eip2930'
-    yParity?: number
+    type?: 'eip2930' | undefined
+    yParity?: number | undefined
   }
 export type TransactionSerializableEIP1559<
   TQuantity = bigint,
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> &
   Partial<FeeValuesEIP1559<TQuantity>> & {
-    accessList?: AccessList
+    accessList?: AccessList | undefined
     chainId: number
-    type?: 'eip1559'
-    yParity?: number
+    type?: 'eip1559' | undefined
+    yParity?: number | undefined
   }
 export type TransactionSerializable<TQuantity = bigint, TIndex = number> =
   | TransactionSerializableLegacy<TQuantity, TIndex>

--- a/src/types/typedData.ts
+++ b/src/types/typedData.ts
@@ -28,7 +28,7 @@ export type GetTypedDataDomain<
       domain: TDomain
     }
   : {
-      domain?: TDomain
+      domain?: TDomain | undefined
     }
 
 export type GetTypedDataMessage<
@@ -74,7 +74,7 @@ export type GetTypedDataTypes<
   TPrimaryType extends string = string,
 > = TPrimaryType extends 'EIP712Domain'
   ? {
-      types?: Narrow<TTypedData>
+      types?: Narrow<TTypedData> | undefined
     }
   : {
       types: Narrow<TTypedData>

--- a/src/types/utils.test-d.ts
+++ b/src/types/utils.test-d.ts
@@ -1,13 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 
-import type {
-  Filter,
-  IsNarrowable,
-  IsNever,
-  IsUndefined,
-  Or,
-  RequiredBy,
-} from './utils.js'
+import type { Filter, IsNarrowable, IsNever, IsUndefined, Or } from './utils.js'
 
 test('Filter', () => {
   expectTypeOf<Filter<[1, 'foo', false, 'baz'], 1 | boolean>>().toEqualTypeOf<
@@ -49,13 +42,4 @@ test('IsUndefined', () => {
 test('Or', () => {
   expectTypeOf<Or<[true, false, true]>>().toEqualTypeOf<true>()
   expectTypeOf<Or<[false, false, false]>>().toEqualTypeOf<false>()
-})
-
-test('RequiredBy', () => {
-  expectTypeOf<
-    RequiredBy<
-      { a?: number | undefined; b?: string | undefined; c: boolean },
-      'a' | 'c'
-    >
-  >().toEqualTypeOf<{ a: number; b?: string | undefined; c: boolean }>()
 })

--- a/src/types/utils.test-d.ts
+++ b/src/types/utils.test-d.ts
@@ -53,6 +53,9 @@ test('Or', () => {
 
 test('RequiredBy', () => {
   expectTypeOf<
-    RequiredBy<{ a?: number; b?: string; c: boolean }, 'a' | 'c'>
-  >().toEqualTypeOf<{ a: number; b?: string; c: boolean }>()
+    RequiredBy<
+      { a?: number | undefined; b?: string | undefined; c: boolean },
+      'a' | 'c'
+    >
+  >().toEqualTypeOf<{ a: number; b?: string | undefined; c: boolean }>()
 })

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -173,15 +173,6 @@ type TrimRight<T, Chars extends string = ' '> = T extends `${infer R}${Chars}`
   : T
 
 /**
- * @description Creates a type with required keys K from T.
- *
- * @example
- * type Result = RequiredBy<{ a?: string, b?: number, c: number }, 'a' | 'c'>
- * //   ^? { a: string, b?: number, c: number }
- */
-export type RequiredBy<T, K extends keyof T> = Omit<T, K> & Required<Pick<T, K>>
-
-/**
  * @description Trims empty space from type T.
  *
  * @example

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -2,6 +2,6 @@ import type { EIP1193Provider } from './eip1193.js'
 
 declare global {
   interface Window {
-    ethereum?: EIP1193Provider
+    ethereum?: EIP1193Provider | undefined
   }
 }

--- a/src/utils/abi/decodeErrorResult.ts
+++ b/src/utils/abi/decodeErrorResult.ts
@@ -18,7 +18,7 @@ import { formatAbiItem } from './formatAbiItem.js'
 
 export type DecodeErrorResultParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
-> = { abi?: Narrow<TAbi>; data: Hex }
+> = { abi?: Narrow<TAbi> | undefined; data: Hex }
 
 export type DecodeErrorResultReturnType<
   TAbi extends Abi | readonly unknown[] = Abi,

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -25,8 +25,8 @@ export type DecodeEventLogParameters<
   TData extends Hex | undefined = undefined,
 > = {
   abi: Narrow<TAbi>
-  data?: TData
-  eventName?: InferEventName<TAbi, TEventName>
+  data?: TData | undefined
+  eventName?: InferEventName<TAbi, TEventName> | undefined
   topics: [signature: Hex, ...args: TTopics] | []
 }
 

--- a/src/utils/abi/decodeFunctionResult.ts
+++ b/src/utils/abi/decodeFunctionResult.ts
@@ -22,7 +22,7 @@ export type DecodeFunctionResultParameters<
   TFunctionName extends string | undefined = string,
   _FunctionName = InferFunctionName<TAbi, TFunctionName>,
 > = {
-  functionName?: _FunctionName
+  functionName?: _FunctionName | undefined
   data: Hex
 } & (TFunctionName extends string
   ? { abi: Narrow<TAbi> } & Partial<GetFunctionArgs<TAbi, TFunctionName>>

--- a/src/utils/abi/encodeErrorResult.ts
+++ b/src/utils/abi/encodeErrorResult.ts
@@ -24,7 +24,7 @@ export type EncodeErrorResultParameters<
   TErrorName extends string | undefined = string,
   _ErrorName = InferErrorName<TAbi, TErrorName>,
 > = {
-  errorName?: _ErrorName
+  errorName?: _ErrorName | undefined
 } & (TErrorName extends string
   ? { abi: Narrow<TAbi> } & GetErrorArgs<TAbi, TErrorName>
   : _ErrorName extends string

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -28,11 +28,14 @@ export type EncodeEventTopicsParameters<
   TEventName extends string | undefined = string,
   _EventName = InferEventName<TAbi, TEventName>,
 > = {
-  eventName?: _EventName
+  eventName?: _EventName | undefined
 } & (TEventName extends string
-  ? { abi: Narrow<TAbi>; args?: GetEventArgs<TAbi, TEventName> }
+  ? { abi: Narrow<TAbi>; args?: GetEventArgs<TAbi, TEventName> | undefined }
   : _EventName extends string
-  ? { abi: [Narrow<TAbi[number]>]; args?: GetEventArgs<TAbi, _EventName> }
+  ? {
+      abi: [Narrow<TAbi[number]>]
+      args?: GetEventArgs<TAbi, _EventName> | undefined
+    }
   : never)
 
 export function encodeEventTopics<

--- a/src/utils/abi/encodeFunctionData.ts
+++ b/src/utils/abi/encodeFunctionData.ts
@@ -18,7 +18,7 @@ export type EncodeFunctionDataParameters<
   TFunctionName extends string | undefined = string,
   _FunctionName = InferFunctionName<TAbi, TFunctionName>,
 > = {
-  functionName?: _FunctionName
+  functionName?: _FunctionName | undefined
 } & (TFunctionName extends string
   ? { abi: Narrow<TAbi> } & GetFunctionArgs<TAbi, TFunctionName>
   : _FunctionName extends string

--- a/src/utils/abi/encodeFunctionResult.ts
+++ b/src/utils/abi/encodeFunctionResult.ts
@@ -19,13 +19,16 @@ export type EncodeFunctionResultParameters<
   TFunctionName extends string | undefined = string,
   _FunctionName = InferFunctionName<TAbi, TFunctionName>,
 > = {
-  functionName?: _FunctionName
+  functionName?: _FunctionName | undefined
 } & (TFunctionName extends string
-  ? { abi: Narrow<TAbi>; result?: ContractFunctionResult<TAbi, TFunctionName> }
+  ? {
+      abi: Narrow<TAbi>
+      result?: ContractFunctionResult<TAbi, TFunctionName> | undefined
+    }
   : _FunctionName extends string
   ? {
       abi: [Narrow<TAbi[number]>]
-      result?: ContractFunctionResult<TAbi, _FunctionName>
+      result?: ContractFunctionResult<TAbi, _FunctionName> | undefined
     }
   : never)
 

--- a/src/utils/abi/formatAbiItem.ts
+++ b/src/utils/abi/formatAbiItem.ts
@@ -5,7 +5,7 @@ import type { AbiItem } from '../../types/index.js'
 
 export function formatAbiItem(
   abiItem: AbiItem,
-  { includeName = false }: { includeName?: boolean } = {},
+  { includeName = false }: { includeName?: boolean | undefined } = {},
 ) {
   if (
     abiItem.type !== 'function' &&
@@ -19,7 +19,7 @@ export function formatAbiItem(
 
 export function formatAbiParams(
   params: readonly AbiParameter[] | undefined,
-  { includeName = false }: { includeName?: boolean } = {},
+  { includeName = false }: { includeName?: boolean | undefined } = {},
 ): string {
   if (!params) return ''
   return params

--- a/src/utils/abi/formatAbiItemWithArgs.ts
+++ b/src/utils/abi/formatAbiItemWithArgs.ts
@@ -11,8 +11,8 @@ export function formatAbiItemWithArgs({
 }: {
   abiItem: AbiItem
   args: readonly unknown[]
-  includeFunctionName?: boolean
-  includeName?: boolean
+  includeFunctionName?: boolean | undefined
+  includeName?: boolean | undefined
 }) {
   if (!('name' in abiItem)) return
   if (!('inputs' in abiItem)) return

--- a/src/utils/address/getContractAddress.ts
+++ b/src/utils/address/getContractAddress.ts
@@ -17,7 +17,7 @@ export type GetCreate2AddressOptions = {
 
 export type GetContractAddressOptions =
   | ({
-      opcode?: 'CREATE'
+      opcode?: 'CREATE' | undefined
     } & GetCreateAddressOptions)
   | ({ opcode: 'CREATE2' } & GetCreate2AddressOptions)
 

--- a/src/utils/buildRequest.ts
+++ b/src/utils/buildRequest.ts
@@ -56,9 +56,9 @@ export function buildRequest<TRequest extends (args: any) => Promise<any>>(
     retryCount = 3,
   }: {
     // The base delay (in ms) between retries.
-    retryDelay?: number
+    retryDelay?: number | undefined
     // The max number of times to retry.
-    retryCount?: number
+    retryCount?: number | undefined
   } = {},
 ) {
   return (async (args: any) =>

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -13,7 +13,7 @@ export function getChainContractAddress({
   chain,
   contract: name,
 }: {
-  blockNumber?: bigint
+  blockNumber?: bigint | undefined
   chain: Chain
   contract: string
 }) {

--- a/src/utils/data/pad.ts
+++ b/src/utils/data/pad.ts
@@ -2,8 +2,8 @@ import { SizeExceedsPaddingSizeError } from '../../errors/index.js'
 import type { ByteArray, Hex } from '../../types/index.js'
 
 type PadOptions = {
-  dir?: 'left' | 'right'
-  size?: number | null
+  dir?: 'left' | 'right' | undefined
+  size?: number | null | undefined
 }
 export type PadReturnType<TValue extends ByteArray | Hex> = TValue extends Hex
   ? Hex

--- a/src/utils/data/trim.ts
+++ b/src/utils/data/trim.ts
@@ -1,7 +1,7 @@
 import type { ByteArray, Hex } from '../../types/index.js'
 
 type TrimOptions = {
-  dir?: 'left' | 'right'
+  dir?: 'left' | 'right' | undefined
 }
 export type TrimReturnType<TValue extends ByteArray | Hex> = TValue extends Hex
   ? Hex

--- a/src/utils/encoding/fromBytes.ts
+++ b/src/utils/encoding/fromBytes.ts
@@ -10,7 +10,7 @@ export type FromBytesParameters<
   | TTo
   | {
       /** Size of the bytes. */
-      size?: number
+      size?: number | undefined
       /** Type to convert to. */
       to: TTo
     }
@@ -72,9 +72,9 @@ export function fromBytes<
 
 export type BytesToBigIntOpts = {
   /** Whether or not the number of a signed representation. */
-  signed?: boolean
+  signed?: boolean | undefined
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -102,7 +102,7 @@ export function bytesToBigint(
 
 export type BytesToBoolOpts = {
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -162,7 +162,7 @@ export function bytesToNumber(
 
 export type BytesToStringOpts = {
   /** Size of the bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -24,7 +24,7 @@ export type FromHexParameters<
   | TTo
   | {
       /** Size (in bytes) of the hex value. */
-      size?: number
+      size?: number | undefined
       /** Type to convert to. */
       to: TTo
     }
@@ -84,9 +84,9 @@ export function fromHex<
 
 export type HexToBigIntOpts = {
   /** Whether or not the number of a signed representation. */
-  signed?: boolean
+  signed?: boolean | undefined
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -125,7 +125,7 @@ export function hexToBigInt(hex: Hex, opts: HexToBigIntOpts = {}): bigint {
 
 export type HexToBoolOpts = {
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -185,7 +185,7 @@ export function hexToNumber(hex: Hex, opts: HexToNumberOpts = {}): number {
 
 export type HexToStringOpts = {
   /** Size (in bytes) of the hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**

--- a/src/utils/encoding/toBytes.ts
+++ b/src/utils/encoding/toBytes.ts
@@ -10,7 +10,7 @@ const encoder = new TextEncoder()
 
 export type ToBytesParameters = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -51,7 +51,7 @@ export function toBytes(
 
 export type BoolToHexOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -85,7 +85,7 @@ export function boolToBytes(value: boolean, opts: BoolToHexOpts = {}) {
 
 export type HexToBytesOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -157,7 +157,7 @@ export function numberToBytes(value: bigint | number, opts?: NumberToHexOpts) {
 
 export type StringToBytesOpts = {
   /** Size of the output bytes. */
-  size?: number
+  size?: number | undefined
 }
 
 /**

--- a/src/utils/encoding/toHex.ts
+++ b/src/utils/encoding/toHex.ts
@@ -9,7 +9,7 @@ const hexes = Array.from({ length: 256 }, (_v, i) =>
 
 export type ToHexParameters = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -52,7 +52,7 @@ export function toHex(
 
 export type BoolToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -90,7 +90,7 @@ export function boolToHex(value: boolean, opts: BoolToHexOpts = {}): Hex {
 
 export type BytesToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 /**
@@ -129,14 +129,14 @@ export function bytesToHex(value: ByteArray, opts: BytesToHexOpts = {}): Hex {
 export type NumberToHexOpts =
   | {
       /** Whether or not the number of a signed representation. */
-      signed?: boolean
+      signed?: boolean | undefined
       /** The size (in bytes) of the output hex value. */
       size: number
     }
   | {
-      signed?: never
+      signed?: never | undefined
       /** The size (in bytes) of the output hex value. */
-      size?: number
+      size?: number | undefined
     }
 
 /**
@@ -197,7 +197,7 @@ export function numberToHex(
 
 export type StringToHexOpts = {
   /** The size (in bytes) of the output hex value. */
-  size?: number
+  size?: number | undefined
 }
 
 const encoder = new TextEncoder()

--- a/src/utils/ens/avatar/parseAvatarRecord.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.ts
@@ -15,7 +15,7 @@ export async function parseAvatarRecord<TChain extends Chain | undefined>(
     gatewayUrls,
     record,
   }: {
-    gatewayUrls?: AssetGatewayUrls
+    gatewayUrls?: AssetGatewayUrls | undefined
     record: string
   },
 ): Promise<string> {
@@ -30,7 +30,7 @@ async function parseNftAvatarUri<TChain extends Chain | undefined>(
     gatewayUrls,
     record,
   }: {
-    gatewayUrls?: AssetGatewayUrls
+    gatewayUrls?: AssetGatewayUrls | undefined
     record: string
   },
 ): Promise<string> {

--- a/src/utils/errors/getCallError.ts
+++ b/src/utils/errors/getCallError.ts
@@ -10,8 +10,8 @@ export function getCallError(
     docsPath,
     ...args
   }: CallParameters & {
-    chain?: Chain
-    docsPath?: string
+    chain?: Chain | undefined
+    docsPath?: string | undefined
   },
 ) {
   let cause = err

--- a/src/utils/errors/getContractError.ts
+++ b/src/utils/errors/getContractError.ts
@@ -26,10 +26,10 @@ export function getContractError(
   }: {
     abi: Abi
     args: any
-    address?: Address
-    docsPath?: string
+    address?: Address | undefined
+    docsPath?: string | undefined
     functionName: string
-    sender?: Address
+    sender?: Address | undefined
   },
 ) {
   const { code, data, message, shortMessage } = (

--- a/src/utils/errors/getEstimateGasError.ts
+++ b/src/utils/errors/getEstimateGasError.ts
@@ -10,9 +10,9 @@ export function getEstimateGasError(
     docsPath,
     ...args
   }: Omit<EstimateGasParameters, 'account'> & {
-    account?: Account
-    chain?: Chain
-    docsPath?: string
+    account?: Account | undefined
+    chain?: Chain | undefined
+    docsPath?: string | undefined
   },
 ) {
   let cause = err

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -25,6 +25,7 @@ export function containsNodeError(err: BaseError) {
   )
 }
 
+// @jxom / @tmm: Can one of you guys look into these types? Not sure what's going on here. (see getTransactionError.ts and getEstimateGasError.ts)
 export function getNodeError(
   err: BaseError,
   args: Partial<SendTransactionParameters<any>>,

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -1,4 +1,5 @@
 import type { SendTransactionParameters } from '../../actions/index.js'
+import type { Chain } from '../../chains.js'
 import { type BaseError, RpcRequestError } from '../../errors/index.js'
 import {
   ExecutionRevertedError,
@@ -16,6 +17,7 @@ import {
   TransactionTypeNotSupportedError,
   UnknownNodeError,
 } from '../../errors/index.js'
+import type { Account } from '../../index.js'
 
 export function containsNodeError(err: BaseError) {
   return (
@@ -28,7 +30,7 @@ export function containsNodeError(err: BaseError) {
 // @jxom / @tmm: Can one of you guys look into these types? Not sure what's going on here. (see getTransactionError.ts and getEstimateGasError.ts)
 export function getNodeError(
   err: BaseError,
-  args: Partial<SendTransactionParameters<any>>,
+  args: Partial<SendTransactionParameters<Chain, Account>>,
 ) {
   const message = err.details.toLowerCase()
   if (FeeCapTooHighError.nodeMessage.test(message))

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -16,8 +16,7 @@ export function getTransactionError(
   },
 ) {
   let cause = err
-  if (containsNodeError(err))
-    cause = getNodeError<Chain | undefined, Account>(err, args)
+  if (containsNodeError(err)) cause = getNodeError(err, args)
   return new TransactionExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -11,12 +11,13 @@ export function getTransactionError(
     ...args
   }: Omit<SendTransactionParameters, 'account' | 'chain'> & {
     account: Account
-    chain?: Chain
-    docsPath?: string
+    chain?: Chain | undefined
+    docsPath?: string | undefined
   },
 ) {
   let cause = err
-  if (containsNodeError(err)) cause = getNodeError(err, args)
+  if (containsNodeError(err))
+    cause = getNodeError<Chain | undefined, Account>(err, args)
   return new TransactionExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/formatters/block.test.ts
+++ b/src/utils/formatters/block.test.ts
@@ -74,17 +74,17 @@ test('nullish values', () => {
   expect(
     formatBlock({
       ...block,
-      difficulty: undefined,
+      // difficulty: undefined,
       number: null,
-      baseFeePerGas: undefined,
-      gasLimit: undefined,
-      gasUsed: undefined,
-      hash: undefined,
-      logsBloom: undefined,
-      nonce: undefined,
-      size: undefined,
-      timestamp: undefined,
-      totalDifficulty: undefined,
+      baseFeePerGas: null,
+      // gasLimit: undefined,
+      // gasUsed: undefined,
+      hash: null,
+      logsBloom: null,
+      nonce: null,
+      // size: undefined,
+      // timestamp: undefined,
+      totalDifficulty: null,
     }),
   ).toMatchInlineSnapshot(`
     {

--- a/src/utils/formatters/extract.ts
+++ b/src/utils/formatters/extract.ts
@@ -5,7 +5,7 @@ import type { Formatter } from '../../types/index.js'
  */
 export function extract(
   value: Record<string, unknown>,
-  { formatter }: { formatter?: Formatter },
+  { formatter }: { formatter?: Formatter | undefined },
 ) {
   if (!formatter) return {}
   const keys = Object.keys(formatter({}))

--- a/src/utils/formatters/format.ts
+++ b/src/utils/formatters/format.ts
@@ -76,8 +76,8 @@ export function defineFormatter<
       exclude,
       format: formatOverride,
     }: {
-      exclude?: TExclude
-      format?: TFormat
+      exclude?: TExclude | undefined
+      format?: TFormat | undefined
     }) =>
     (data: TSource & { [key: string]: unknown }) => {
       const formatted = format(data)

--- a/src/utils/formatters/log.test.ts
+++ b/src/utils/formatters/log.test.ts
@@ -44,18 +44,18 @@ test('nullish values', () => {
   expect(
     formatLog({
       address: '0x15d4c048f83bd7e37d49ea4c83a07267ec4203da',
-      blockHash: undefined,
-      blockNumber: undefined,
+      blockHash: null,
+      blockNumber: null,
       data: '0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0',
-      logIndex: undefined,
+      logIndex: null,
       removed: false,
       topics: [
         '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
         '0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0',
         '0x000000000000000000000000f16e9b0d03470827a95cdfd0cb8a8a3b46969b91',
       ],
-      transactionHash: undefined,
-      transactionIndex: undefined,
+      transactionHash: null,
+      transactionIndex: null,
     }),
   ).toMatchInlineSnapshot(`
     {

--- a/src/utils/formatters/log.ts
+++ b/src/utils/formatters/log.ts
@@ -2,7 +2,10 @@ import type { Log, RpcLog } from '../../types/index.js'
 
 export function formatLog(
   log: Partial<RpcLog>,
-  { args, eventName }: { args?: unknown; eventName?: string } = {},
+  {
+    args,
+    eventName,
+  }: { args?: unknown | undefined; eventName?: string | undefined } = {},
 ) {
   return {
     ...log,

--- a/src/utils/formatters/transactionRequest.test.ts
+++ b/src/utils/formatters/transactionRequest.test.ts
@@ -7,6 +7,7 @@ import type {
   TransactionRequestLegacy,
 } from '../../types/index.js'
 
+import type { TransactionRequestBase } from '../../types/transaction.js'
 import { formatTransactionRequest } from './transactionRequest.js'
 
 const base: TransactionRequest = {
@@ -136,7 +137,7 @@ test('nullish gasPrice', () => {
     formatTransactionRequest({
       ...base,
       gasPrice: undefined,
-    }),
+    } as TransactionRequestEIP1559),
   ).toMatchInlineSnapshot(`
     {
       "data": "0x1",
@@ -157,7 +158,7 @@ test('nullish maxFeePerGas', () => {
     formatTransactionRequest({
       ...base,
       maxFeePerGas: undefined,
-    }),
+    } as TransactionRequestLegacy),
   ).toMatchInlineSnapshot(`
     {
       "data": "0x1",
@@ -178,7 +179,7 @@ test('nullish maxPriorityFeePerGas', () => {
     formatTransactionRequest({
       ...base,
       maxPriorityFeePerGas: undefined,
-    }),
+    } as TransactionRequestLegacy),
   ).toMatchInlineSnapshot(`
     {
       "data": "0x1",

--- a/src/utils/formatters/transactionRequest.test.ts
+++ b/src/utils/formatters/transactionRequest.test.ts
@@ -7,7 +7,6 @@ import type {
   TransactionRequestLegacy,
 } from '../../types/index.js'
 
-import type { TransactionRequestBase } from '../../types/transaction.js'
 import { formatTransactionRequest } from './transactionRequest.js'
 
 const base: TransactionRequest = {

--- a/src/utils/poll.ts
+++ b/src/utils/poll.ts
@@ -2,9 +2,9 @@ import { wait } from './wait.js'
 
 type PollOptions<TData> = {
   // Whether or not to emit when the polling starts.
-  emitOnBegin?: boolean
+  emitOnBegin?: boolean | undefined
   // The initial wait time (in ms) before polling.
-  initialWaitTime?: (data: TData | void) => Promise<number>
+  initialWaitTime?: (data: TData | void) => Promise<number> | undefined
   // The interval (in ms).
   interval: number
 }

--- a/src/utils/promise/createBatchScheduler.ts
+++ b/src/utils/promise/createBatchScheduler.ts
@@ -4,8 +4,8 @@ type Resolved<TReturnType extends readonly unknown[] = any> = [
 ]
 
 type PendingPromise<TReturnType extends readonly unknown[] = any> = {
-  resolve?: (data: Resolved<TReturnType>) => void
-  reject?: (reason?: unknown) => void
+  resolve?: (data: Resolved<TReturnType>) => void | undefined
+  reject?: (reason?: unknown) => void | undefined
 }
 
 type SchedulerItem = { args: unknown; pendingPromise: PendingPromise }
@@ -23,8 +23,8 @@ export function createBatchScheduler<
 }: {
   fn: (args: TParameters[]) => Promise<TReturnType>
   id: number | string
-  shouldSplitBatch?: (args: TParameters[]) => boolean
-  wait?: number
+  shouldSplitBatch?: (args: TParameters[]) => boolean | undefined
+  wait?: number | undefined
 }) {
   const exec = async () => {
     const scheduler = getScheduler()

--- a/src/utils/promise/withCache.ts
+++ b/src/utils/promise/withCache.ts
@@ -28,7 +28,7 @@ export type WithCacheParameters = {
   /** The key to cache the data against. */
   cacheKey: string
   /** The maximum age (in ms) of the cached value. Default: Infinity (no expiry) */
-  maxAge?: number
+  maxAge?: number | undefined
 }
 
 /**

--- a/src/utils/promise/withRetry.ts
+++ b/src/utils/promise/withRetry.ts
@@ -8,9 +8,12 @@ export function withRetry<TData>(
     shouldRetry = () => true,
   }: {
     // The delay (in ms) between retries.
-    delay?: ((config: { count: number; error: Error }) => number) | number
+    delay?:
+      | ((config: { count: number; error: Error }) => number)
+      | number
+      | undefined
     // The max number of times to retry.
-    retryCount?: number
+    retryCount?: number | undefined
     // Whether or not to retry when an error is thrown.
     shouldRetry?: ({
       count,
@@ -18,7 +21,7 @@ export function withRetry<TData>(
     }: {
       count: number
       error: Error
-    }) => Promise<boolean> | boolean
+    }) => Promise<boolean> | boolean | undefined
   } = {},
 ) {
   return new Promise<TData>((resolve, reject) => {

--- a/src/utils/promise/withTimeout.test.ts
+++ b/src/utils/promise/withTimeout.test.ts
@@ -23,7 +23,7 @@ test('times out correctly w/ signal', async () => {
   await expect(() =>
     withTimeout(
       async ({ signal }) => {
-        await fetch(server.url, { signal })
+        await fetch(server.url, { signal: signal ?? null })
       },
       {
         errorInstance: new Error('timed out'),

--- a/src/utils/promise/withTimeout.ts
+++ b/src/utils/promise/withTimeout.ts
@@ -1,5 +1,7 @@
 export function withTimeout<TData>(
-  fn: ({ signal }: { signal?: AbortController['signal'] }) => Promise<TData>,
+  fn: ({
+    signal,
+  }: { signal?: AbortController['signal'] | undefined }) => Promise<TData>,
   {
     errorInstance,
     timeout,
@@ -10,7 +12,7 @@ export function withTimeout<TData>(
     // The timeout (in ms).
     timeout: number
     // Whether or not the timeout should use an abort signal.
-    signal?: boolean
+    signal?: boolean | undefined
   },
 ): Promise<TData> {
   return new Promise((resolve, reject) => {

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -12,34 +12,34 @@ import { stringify } from './stringify.js'
 let id = 0
 
 type SuccessResult<T> = {
-  method?: never
+  method?: never | undefined
   result: T
-  error?: never
+  error?: never | undefined
 }
 type ErrorResult<T> = {
-  method?: never
-  result?: never
+  method?: never | undefined
+  result?: never | undefined
   error: T
 }
 type Subscription<TResult, TError> = {
   method: 'eth_subscription'
-  error?: never
-  result?: never
+  error?: never | undefined
+  result?: never | undefined
   params: {
     subscription: string
   } & (
     | {
         result: TResult
-        error?: never
+        error?: never | undefined
       }
     | {
-        result?: never
+        result?: never | undefined
         error: TError
       }
   )
 }
 
-type RpcRequest = { method: string; params?: any }
+type RpcRequest = { method: string; params?: any | undefined }
 
 export type RpcResponse<TResult = any, TError = any> = {
   jsonrpc: `${number}`
@@ -57,9 +57,9 @@ export type HttpOptions = {
   // The RPC request body.
   body: RpcRequest
   // Request configuration to pass to `fetch`.
-  fetchOptions?: Omit<RequestInit, 'body'>
+  fetchOptions?: Omit<RequestInit, 'body'> | undefined
   // The timeout (in ms) for the request.
-  timeout?: number
+  timeout?: number | undefined
 }
 
 async function http(
@@ -78,7 +78,7 @@ async function http(
             'Content-Type': 'application/json',
           },
           method: method || 'POST',
-          signal: signal_ || (timeout > 0 ? signal : undefined),
+          signal: (signal_ || (timeout > 0 ? signal : null)) ?? null,
         })
         return response
       },
@@ -150,7 +150,7 @@ export async function getSocket(url_: string) {
   // https://github.com/vitejs/vite/issues/9703
   // TODO: Remove when issue is resolved.
   if (
-    (WebSocket as unknown as { default?: typeof WebSocket }).default
+    (WebSocket as unknown as { default?: typeof WebSocket | undefined }).default
       ?.constructor
   )
     WebSocket = (WebSocket as unknown as { default: typeof WebSocket }).default
@@ -212,9 +212,9 @@ function webSocket(
     // The RPC request body.
     body: RpcRequest
     // The callback to invoke when the request is successful.
-    onData?: (message: RpcResponse) => void
+    onData?: ((message: RpcResponse) => void) | undefined
     // The callback to invoke if the request errors.
-    onError?: (message: RpcResponse['error']) => void
+    onError?: (message: RpcResponse['error']) => void | undefined
   },
 ) {
   if (
@@ -269,7 +269,7 @@ async function webSocketAsync(
     // The RPC request body.
     body: RpcRequest
     // The timeout (in ms) for the request.
-    timeout?: number
+    timeout?: number | undefined
   },
 ) {
   return withTimeout(

--- a/src/utils/transaction/assertRequest.ts
+++ b/src/utils/transaction/assertRequest.ts
@@ -5,11 +5,11 @@ import {
   TipAboveFeeCapError,
 } from '../../errors/index.js'
 import { FeeConflictError } from '../../errors/transaction.js'
-import type { Chain } from '../../types/index.js'
+import type { Account, Chain } from '../../types/index.js'
 import { parseAccount } from '../accounts.js'
 import { isAddress } from '../address/index.js'
 
-export function assertRequest(args: Partial<SendTransactionParameters<Chain>>) {
+export function assertRequest(args: SendTransactionParameters<Chain, Account>) {
   const {
     account: account_,
     gasPrice,

--- a/src/utils/transaction/parseTransaction.ts
+++ b/src/utils/transaction/parseTransaction.ts
@@ -193,7 +193,7 @@ function parseTransactionEIP2930(
 function parseTransactionLegacy(
   serializedTransaction: Hex,
 ): Omit<TransactionRequestLegacy, 'from'> &
-  ({ chainId?: number } | ({ chainId: number } & Signature)) {
+  ({ chainId?: number | undefined } | ({ chainId: number } & Signature)) {
   const transactionArray = fromRlp(serializedTransaction, 'hex')
 
   const [nonce, gasPrice, gas, to, value, data, chainIdOrV_, r, s] =

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -27,11 +27,13 @@ import { assertRequest } from './assertRequest.js'
 export type PrepareRequestParameters<
   TAccount extends Account | undefined = undefined,
 > = GetAccountParameter<TAccount> & {
-  gas?: SendTransactionParameters['gas']
-  gasPrice?: SendTransactionParameters['gasPrice']
-  maxFeePerGas?: SendTransactionParameters['maxFeePerGas']
-  maxPriorityFeePerGas?: SendTransactionParameters['maxPriorityFeePerGas']
-  nonce?: SendTransactionParameters['nonce']
+  gas?: SendTransactionParameters['gas'] | undefined
+  gasPrice?: SendTransactionParameters['gasPrice'] | undefined
+  maxFeePerGas?: SendTransactionParameters['maxFeePerGas'] | undefined
+  maxPriorityFeePerGas?:
+    | SendTransactionParameters['maxPriorityFeePerGas']
+    | undefined
+  nonce?: SendTransactionParameters['nonce'] | undefined
 }
 
 export type PrepareRequestReturnType<
@@ -40,9 +42,11 @@ export type PrepareRequestReturnType<
 > = TParameters & {
   from: Address
   gas: SendTransactionParameters['gas']
-  gasPrice?: SendTransactionParameters['gasPrice']
-  maxFeePerGas?: SendTransactionParameters['maxFeePerGas']
-  maxPriorityFeePerGas?: SendTransactionParameters['maxPriorityFeePerGas']
+  gasPrice?: SendTransactionParameters['gasPrice'] | undefined
+  maxFeePerGas?: SendTransactionParameters['maxFeePerGas'] | undefined
+  maxPriorityFeePerGas?:
+    | SendTransactionParameters['maxPriorityFeePerGas']
+    | undefined
   nonce: SendTransactionParameters['nonce']
 }
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,15 +8,14 @@
 
     // Type checking
     "strict": true,
-    "useDefineForClassFields": true, // Not enabled by default in `strict` mode unless we bump `target` to ES2022.
-    "noFallthroughCasesInSwitch": true, // Not enabled by default in `strict` mode.
-    "noImplicitReturns": true, // Not enabled by default in `strict` mode.
-    "useUnknownInCatchVariables": true, // TODO: This would normally be enabled in `strict` mode but would require some adjustments to the codebase.
-    "noImplicitOverride": true, // Not enabled by default in `strict` mode.
-    "noUnusedLocals": true, // Not enabled by default in `strict` mode.
-    "noUnusedParameters": true, // Not enabled by default in `strict` mode.
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
     // TODO: The following options are also not enabled by default in `strict` mode and would be nice to have but would require some adjustments to the codebase.
-    // "exactOptionalPropertyTypes": true,
     // "noUncheckedIndexedAccess": true,
 
     // JavaScript support


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds the `| undefined` type to various optional parameters. 

### Detailed summary
- Adds `| undefined` type to optional parameters in various files, including `src/types/window.ts`, `src/utils/chain.ts`, `src/actions/test/mine.ts`, `src/utils/errors/getCallError.ts`, `src/actions/ens/getEnsText.ts`, `src/actions/ens/getEnsAddress.ts`, `src/actions/ens/getEnsName.ts`, `src/actions/ens/getEnsResolver.ts`, `src/utils/promise/withCache.ts`, `src/adapters/ethers.ts`, `src/errors/encoding.ts`, `src/actions/public/getBlockNumber.ts`, `src/errors/block.ts`, `src/utils/errors/getTransactionError.ts`, `src/actions/test/reset.ts`, `src/utils/data/pad.ts`, `src/utils/formatters/format.ts`, `src/utils/abi/decodeEventLog.ts`, `src/utils/formatters/extract.ts`, `src/utils/address/getContractAddress.ts`, `src/utils/errors/getEstimateGasError.ts`, `src/utils/buildRequest.ts`, `src/utils/formatters/log.ts`, `src/utils/abi/encodeErrorResult.ts`, `src/utils/abi/encodeFunctionData.ts`, `src/actions/wallet/addChain.test.ts`, `src/errors/account.ts`, `src/actions/public/getTransactionConfirmations.ts`, `src/types/typedData.ts`, `src/actions/public/getBalance.ts`, `src/utils/poll.ts`, `src/types/block.ts`.

> The following files were skipped due to too many changes: `src/types/block.ts`, `src/utils/transaction/parseTransaction.ts`, `src/actions/public/estimateGas.ts`, `src/actions/public/getTransactionCount.ts`, `src/utils/ens/avatar/parseAvatarRecord.ts`, `src/actions/wallet/writeContract.ts`, `src/actions/getContract.ts`, `src/actions/public/getFeeHistory.ts`, `src/types/filter.ts`, `src/utils/promise/withTimeout.ts`, `src/types/contract.test-d.ts`, `src/actions/public/multicall.ts`, `src/clients/createClient.ts`, `src/utils/transaction/assertRequest.ts`, `src/utils/formatters/block.test.ts`, `src/actions/public/simulateContract.ts`, `src/types/chain.ts`, `src/utils/abi/formatAbiItem.ts`, `src/utils/abi/encodeEventTopics.ts`, `src/utils/abi/encodeFunctionResult.ts`, `src/utils/formatters/transactionRequest.test.ts`, `src/types/formatter.ts`, `src/errors/base.ts`, `src/errors/request.ts`, `src/utils/promise/withRetry.ts`, `src/errors/transaction.ts`, `src/types/utils.test-d.ts`, `src/clients/transports/custom.ts`, `src/actions/getContract.test-d.ts`, `src/actions/public/getBlockTransactionCount.ts`, `src/utils/formatters/log.test.ts`, `src/actions/public/waitForTransactionReceipt.ts`, `src/accounts/types.ts`, `src/types/fee.ts`, `src/utils/encoding/toBytes.ts`, `src/utils/encoding/fromBytes.ts`, `src/utils/promise/createBatchScheduler.ts`, `src/actions/public/createEventFilter.ts`, `src/actions/public/getBlock.ts`, `src/clients/createPublicClient.ts`, `src/utils/encoding/fromHex.ts`, `src/errors/rpc.ts`, `src/actions/public/createContractEventFilter.ts`, `src/utils/errors/getNodeError.ts`, `src/actions/public/watchEvent.ts`, `src/clients/transports/http.ts`, `src/clients/transports/createTransport.ts`, `src/actions/public/getLogs.ts`, `src/actions/public/watchContractEvent.ts`, `src/clients/transports/webSocket.ts`, `src/actions/public/getTransaction.ts`, `src/actions/public/call.ts`, `tsconfig.base.json`, `src/errors/abi.ts`, `src/utils/encoding/toHex.ts`, `src/actions/public/watchPendingTransactions.ts`, `src/utils/transaction/prepareRequest.ts`, `src/actions/public/watchBlockNumber.ts`, `src/actions/public/watchBlocks.ts`, `src/errors/contract.ts`, `src/types/contract.ts`, `src/utils/rpc.ts`, `src/clients/transports/fallback.ts`, `src/types/transaction.ts`, `src/errors/node.ts`, `src/types/eip1193.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->