### PR TITLE
chore: add script to generate entrypoint exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "rome": "^12.0.0",
     "simple-git-hooks": "^2.8.1",
     "size-limit": "^8.2.4",
+    "ts-morph": "^18.0.0",
     "typescript": "^5.0.3",
     "vite": "^4.1.4",
     "vitest": "~0.30.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       size-limit:
         specifier: ^8.2.4
         version: 8.2.4
+      ts-morph:
+        specifier: ^18.0.0
+        version: 18.0.0
       typescript:
         specifier: ^5.0.3
         version: 5.0.3
@@ -2204,6 +2207,15 @@ packages:
       - webpack-cli
     dev: true
 
+  /@ts-morph/common@0.19.0:
+    resolution: {integrity: sha512-Unz/WHmd4pGax91rdIKWi51wnVUW11QttMEPpBiBgIewnc9UQIX7UDLxr5vRlqeByXCwhkF6VabSsI0raWcyAQ==}
+    dependencies:
+      fast-glob: 3.2.12
+      minimatch: 7.4.6
+      mkdirp: 2.1.6
+      path-browserify: 1.0.1
+    dev: true
+
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
@@ -3078,6 +3090,12 @@ packages:
       concat-map: 0.0.1
     dev: true
 
+  /brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+    dependencies:
+      balanced-match: 1.0.2
+    dev: true
+
   /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
@@ -3350,6 +3368,10 @@ packages:
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+    dev: true
+
+  /code-block-writer@12.0.0:
+    resolution: {integrity: sha512-q4dMFMlXtKR3XNBHyMHt/3pwYNA69EDk00lloMOaaUMKPUXBw6lpXtbu3MMVG6/uOihGnRDOlkyqsONEUj60+w==}
     dev: true
 
   /color-convert@1.9.3:
@@ -5137,6 +5159,13 @@ packages:
       brace-expansion: 1.1.11
     dev: true
 
+  /minimatch@7.4.6:
+    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist-options@4.1.0:
     resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
     engines: {node: '>= 6'}
@@ -5157,6 +5186,12 @@ packages:
 
   /mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+    dev: true
+
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
     dev: true
 
   /mlly@1.2.0:
@@ -5417,6 +5452,10 @@ packages:
     dependencies:
       no-case: 3.0.4
       tslib: 2.5.0
+    dev: true
+
+  /path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
     dev: true
 
   /path-case@3.0.4:
@@ -6397,6 +6436,13 @@ packages:
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /ts-morph@18.0.0:
+    resolution: {integrity: sha512-Kg5u0mk19PIIe4islUI/HWRvm9bC1lHejK4S0oh1zaZ77TMZAEmQC0sHQYiu2RgCQFZKXz1fMVi/7nOOeirznA==}
+    dependencies:
+      '@ts-morph/common': 0.19.0
+      code-block-writer: 12.0.0
     dev: true
 
   /tslib@2.4.0:

--- a/scripts/generateEntrypoints.ts
+++ b/scripts/generateEntrypoints.ts
@@ -1,0 +1,198 @@
+import {
+  ExportDeclaration,
+  ExportDeclarationStructure,
+  ModuleResolutionKind,
+  Node,
+  OptionalKind,
+  SourceFile,
+  Structures,
+  Symbol as MorphSymbol,
+  SyntaxKind,
+} from 'ts-morph'
+import { Project } from 'ts-morph'
+
+const project = new Project({
+  tsConfigFilePath: './tsconfig.build.json',
+})
+
+const entrypoints = [
+  'src/index.ts',
+  'src/abi.ts',
+  'src/chains.ts',
+  'src/contract.ts',
+  'src/ens.ts',
+  'src/ethers.ts',
+  'src/public.ts',
+  'src/test.ts',
+  'src/wallet.ts',
+  'src/window.ts',
+  'src/utils/index.ts',
+  'src/accounts/index.ts',
+] as const
+
+type Entrypoint = typeof entrypoints[number]
+
+// TODO: Add the other entrypoints here.
+const exports: Partial<Record<Entrypoint, string[]>> = {
+  'src/index.ts': ['src/**/*.ts', ...excludePaths(entrypoints)],
+}
+
+for (const entrypoint of entrypoints) {
+  const patterns = exports[entrypoint]
+  if (patterns !== undefined) {
+    generateEntrypoint(project, entrypoint, patterns)
+  }
+}
+
+function generateEntrypoint(
+  tsProject: Project,
+  filePath: string,
+  globPatterns: string[],
+) {
+  const compilerOptions = tsProject.getCompilerOptions()
+  const moduleResolution = compilerOptions.moduleResolution
+
+  const entryPointFile = tsProject.createSourceFile(filePath, undefined, {
+    overwrite: true,
+  })
+
+  const entryPointFullPath = entryPointFile.getFilePath()
+  const sourceFiles = tsProject
+    .getSourceFiles(globPatterns)
+    .filter((sourceFile) => sourceFile.getFilePath() !== entryPointFullPath)
+
+  const collectedExports = new Set<OptionalKind<ExportDeclarationStructure>>()
+  for (const sourceFile of sourceFiles) {
+    if (isIgnored(sourceFile)) {
+      continue
+    }
+
+    const exportsForFile: [type: boolean, name: string][] = []
+    for (const exportedSymbol of Array.from(sourceFile.getExportSymbols())) {
+      const resolvedExport = getExport(exportedSymbol)
+
+      if (resolvedExport !== undefined) {
+        exportsForFile.push(resolvedExport)
+      }
+    }
+
+    if (exportsForFile.length !== 0) {
+      const moduleSpecifier = getModuleSpecifer(entryPointFile, sourceFile)
+      const isTypeOnly = exportsForFile.every(([type]) => type)
+
+      collectedExports.add({
+        moduleSpecifier,
+        isTypeOnly,
+        namedExports: exportsForFile.map(([type, name]) => ({
+          isTypeOnly: type && !isTypeOnly,
+          name,
+        })),
+        leadingTrivia: `// ${moduleSpecifier}`,
+        trailingTrivia: '\n',
+      })
+    }
+  }
+
+  const exportDeclarations = Array.from(collectedExports.values())
+  entryPointFile.addExportDeclarations(exportDeclarations)
+  entryPointFile.saveSync()
+
+  function getModuleSpecifer(from: SourceFile, to: SourceFile) {
+    const moduleSpecifier = from.getRelativePathAsModuleSpecifierTo(to)
+    if (moduleResolution === ModuleResolutionKind.NodeNext) {
+      if (!moduleSpecifier.endsWith('.js')) {
+        return `${moduleSpecifier}.js`
+      }
+    }
+
+    return moduleSpecifier
+  }
+}
+
+function excludePaths(paths: readonly string[]) {
+  return paths.map((path) => `!${path}`)
+}
+
+function getLeadingCommentStatements(node: SourceFile) {
+  const comments: string[] = []
+  for (const statement of node.getStatementsWithComments()) {
+    if (Node.isCommentStatement(statement)) {
+      comments.push(statement.getText())
+    } else {
+      break
+    }
+  }
+
+  return comments
+}
+
+function getExport(
+  symbol: MorphSymbol,
+): [type: boolean, name: string] | undefined {
+  const [node] = symbol.getDeclarations() ?? []
+
+  if (node === undefined || isIgnored(node) || isDefaultExport(node)) {
+    return undefined
+  }
+
+  const parent = node.getParentOrThrow()
+  if (parent.isKind(SyntaxKind.NamedExports)) {
+    const declaration = parent.getParent()
+    const match = getNamedExportForSymbol(declaration, symbol)
+    if (match === undefined) {
+      return undefined
+    }
+
+    if (declaration.isTypeOnly() || match.isTypeOnly()) {
+      return [true, symbol.getName()]
+    }
+
+    return [false, symbol.getName()]
+  }
+
+  if (node.isKind(SyntaxKind.TypeAliasDeclaration)) {
+    return [true, symbol.getName()]
+  } else if (node.isKind(SyntaxKind.InterfaceDeclaration)) {
+    return [true, symbol.getName()]
+  } else if (node.isKind(SyntaxKind.ExportDeclaration)) {
+    console.log(true)
+  }
+
+  return [false, symbol.getName()]
+}
+
+function getNamedExportForSymbol(node: ExportDeclaration, symbol: MorphSymbol) {
+  const name = symbol.getAliasedSymbol()?.getName() ?? symbol.getName()
+  return node.getNamedExports().find((item) => item.getName() === name)
+}
+
+function isIgnored(item: Node | Structures | string) {
+  if (Node.isNode(item)) {
+    if (Node.isSourceFile(item)) {
+      const comments = getLeadingCommentStatements(item)
+      if (comments.some((item) => item.includes('entrypoint:ignore'))) {
+        return true
+      }
+
+      return false
+    }
+
+    return item.getLeadingCommentRanges().some((comment) => {
+      return comment.getText().includes('entrypoint:ignore')
+    })
+  }
+
+  if (typeof item === 'string') {
+    return item.includes('entrypoint:ignore')
+  }
+
+  if (typeof item.leadingTrivia === 'string') {
+    return item.leadingTrivia.includes('entrypoint:ignore')
+  }
+
+  return false
+}
+
+function isDefaultExport(node: Node) {
+  return Node.isExportGetable(node) && node.hasDefaultKeyword()
+}


### PR DESCRIPTION
This script can generate all exports for our entrypoints by re-exporting any exports from any included files that:

- Are in scope of the `tsconfig.build.json`
- Match the glob (micromatch) patterns specified in `generateEntrypoint.ts`

It can also ignore files or individual export declarations or even individual named exports of export declarations by putting a simple ignore comment on top:

```ts
// entrypoint:ignore
```

This script should significantly simplify the maintenance burden of ensuring that all relevant exports are exposed to the consumer. We'd just need to set it up correctly ;-). 

TODO:

- [ ] Configure all existing entrypoints with the correct glob pattern and exclude undesirable exports with the aforementioned comment.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `ts-morph` to the project dependencies and introduces a new script to generate entrypoints. 

### Detailed summary
- Added `ts-morph` to project dependencies
- Introduced a new script to generate entrypoints
- Updated `pnpm-lock.yaml` to include `ts-morph`
- Minor updates to other dependencies in `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->