### PR TITLE
test: add failing test for formatting plain Solidity errors in error messages

### DIFF
--- a/contracts/src/ErrorsExample.sol
+++ b/contracts/src/ErrorsExample.sol
@@ -7,6 +7,7 @@ contract ErrorsExample {
         uint256 bar;
     }
 
+    error PlainError();
     error SimpleError(string message);
     error ComplexError(Foo foo, string message, uint256 number);
 

--- a/src/errors/contract.test.ts
+++ b/src/errors/contract.test.ts
@@ -378,6 +378,20 @@ describe('ContractFunctionRevertedError', () => {
 
       Version: viem@1.0.2]
     `)
+
+    expect(
+      new ContractFunctionRevertedError({
+        abi: errorsExampleABI,
+        data: '0x253eb71d',
+        functionName: 'customPlainError',
+      }),
+    ).toMatchInlineSnapshot(`
+      [ContractFunctionRevertedError: The contract function "customPlainError" reverted.
+
+      Error: PlainError()
+
+      Version: viem@1.0.2]
+    `)
   })
 
   test('data: zero data', () => {


### PR DESCRIPTION
Reverting with a plain custom error in Solidity (e.g. `revert PlainError()`) doesn't surface in error messages.

<!-- start pr-codex -->

## PR-Codex overview
This PR adds new error types to the `ErrorsExample` contract and includes a test for a custom plain error function. 

### Detailed summary:
- Added `PlainError()`, `SimpleError(string message)`, and `ComplexError(Foo foo, string message, uint256 number)` error types to `ErrorsExample` contract
- Included a test for a custom plain error function in `src/errors/contract.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->