### PR TITLE
fix: add `retries` to `waitForTransactionReceipt`

### DIFF
--- a/.changeset/eleven-foxes-reply.md
+++ b/.changeset/eleven-foxes-reply.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed issue where `waitForTransactionReceipt` would throw immediately for RPC Providers which may be slow to sync mined transactions.

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -115,6 +115,7 @@ export async function waitForTransactionReceipt<
   let transaction: GetTransactionReturnType<TChain> | undefined
   let replacedTransaction: GetTransactionReturnType<TChain> | undefined
   let receipt: GetTransactionReceiptReturnType<TChain>
+  let retries = 0
 
   return new Promise((resolve, reject) => {
     if (timeout)
@@ -219,7 +220,8 @@ export async function waitForTransactionReceipt<
                   emit.resolve(receipt)
                 })
               } else {
-                done(() => emit.reject(err))
+                if (retries > 2) done(() => emit.reject(err))
+                retries++
               }
             }
           },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes an issue with `waitForTransactionReceipt` throwing immediately for slow RPC Providers. It adds a retry mechanism to the function.

### Detailed summary
- Added a `retries` variable to keep track of the number of retries.
- If `waitForTransactionReceipt` fails, it will retry up to 2 times before rejecting the promise.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->