### PR TITLE
refactor: add & export `assertCurrentChain`

### DIFF
--- a/.changeset/unlucky-tigers-fold.md
+++ b/.changeset/unlucky-tigers-fold.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `assertCurrentChain` util.

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -642,6 +642,36 @@ describe('local account', () => {
     expect(transaction.chainId).toBe(1)
   })
 
+  test('args: chain (nullish)', async () => {
+    await setup()
+
+    expect(
+      await getBalance(publicClient, { address: targetAccount.address }),
+    ).toMatchInlineSnapshot('10000000000000000000000n')
+    expect(
+      await getBalance(publicClient, { address: sourceAccount.address }),
+    ).toMatchInlineSnapshot('10000000000000000000000n')
+
+    const hash = await sendTransaction(walletClient, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      chain: null,
+      to: targetAccount.address,
+      value: parseEther('1'),
+    })
+
+    await mine(testClient, { blocks: 1 })
+
+    expect(
+      await getBalance(publicClient, { address: targetAccount.address }),
+    ).toMatchInlineSnapshot('10001000000000000000000n')
+    expect(
+      await getBalance(publicClient, { address: sourceAccount.address }),
+    ).toBeLessThan(sourceAccount.balance)
+
+    const transaction = await getTransaction(publicClient, { hash })
+    expect(transaction.chainId).toBe(1)
+  })
+
   describe('args: maxFeePerGas', () => {
     test('sends transaction', async () => {
       await setup()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -89,6 +89,7 @@ test('exports actions', () => {
       "UserRejectedRequestError": [Function],
       "WaitForTransactionReceiptTimeoutError": [Function],
       "WebSocketRequestError": [Function],
+      "assertCurrentChain": [Function],
       "assertRequest": [Function],
       "assertTransactionEIP1559": [Function],
       "assertTransactionEIP2930": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -630,7 +630,7 @@ export {
   offchainLookupSignature,
 } from './utils/ccip.js'
 export { concat, concatBytes, concatHex } from './utils/data/concat.js'
-export { defineChain } from './utils/chain.js'
+export { assertCurrentChain, defineChain } from './utils/chain.js'
 export { encodePacked } from './utils/abi/encodePacked.js'
 export { formatEther } from './utils/unit/formatEther.js'
 export { formatGwei } from './utils/unit/formatGwei.js'

--- a/src/utils/chain.test.ts
+++ b/src/utils/chain.test.ts
@@ -2,7 +2,60 @@ import { describe, expect, test } from 'vitest'
 
 import { mainnet, optimism, polygon } from '../chains.js'
 
-import { defineChain, getChainContractAddress } from './chain.js'
+import {
+  assertCurrentChain,
+  defineChain,
+  getChainContractAddress,
+} from './chain.js'
+
+describe('assertCurrentChain', () => {
+  test('matching chains', () => {
+    assertCurrentChain({ currentChainId: mainnet.id, chain: mainnet })
+    assertCurrentChain({ currentChainId: optimism.id, chain: optimism })
+  })
+
+  test('chain mismatch', () => {
+    expect(() =>
+      assertCurrentChain({ currentChainId: mainnet.id, chain: optimism }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "The current chain of the wallet (id: 1) does not match the target chain for the transaction (id: 10 – Optimism).
+
+      Current Chain ID:  1
+      Expected Chain ID: 10 – Optimism
+
+      Version: viem@1.0.2"
+    `)
+    expect(() =>
+      assertCurrentChain({ currentChainId: optimism.id, chain: mainnet }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "The current chain of the wallet (id: 10) does not match the target chain for the transaction (id: 1 – Ethereum).
+
+      Current Chain ID:  10
+      Expected Chain ID: 1 – Ethereum
+
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('no chain', () => {
+    expect(() =>
+      assertCurrentChain({ currentChainId: mainnet.id }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+    "No chain was provided to the request.
+    Please provide a chain with the \`chain\` argument on the Action, or by supplying a \`chain\` to WalletClient.
+
+    Version: viem@1.0.2"
+  `)
+    expect(() =>
+      assertCurrentChain({ currentChainId: optimism.id }),
+    ).toThrowErrorMatchingInlineSnapshot(`
+    "No chain was provided to the request.
+    Please provide a chain with the \`chain\` argument on the Action, or by supplying a \`chain\` to WalletClient.
+
+    Version: viem@1.0.2"
+  `)
+  })
+})
 
 describe('defineChain', () => {
   test('default', () => {

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,6 +1,24 @@
-import { ChainDoesNotSupportContract } from '../errors/chain.js'
+import {
+  ChainDoesNotSupportContract,
+  ChainMismatchError,
+  ChainNotFoundError,
+} from '../errors/chain.js'
 import type { Chain, ChainContract } from '../types/chain.js'
 import type { Formatters } from '../types/formatter.js'
+
+export type AssertCurrentChainParameters = {
+  chain?: Chain
+  currentChainId: number
+}
+
+export function assertCurrentChain({
+  chain,
+  currentChainId,
+}: AssertCurrentChainParameters): void {
+  if (!chain) throw new ChainNotFoundError()
+  if (currentChainId !== chain.id)
+    throw new ChainMismatchError({ chain, currentChainId })
+}
 
 export function defineChain<
   TFormatters extends Formatters = Formatters,

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -6,6 +6,7 @@ test('exports utils', () => {
   expect(utils).toMatchInlineSnapshot(`
     {
       "arrayRegex": /\\^\\(\\.\\*\\)\\\\\\[\\(\\[0-9\\]\\*\\)\\\\\\]\\$/,
+      "assertCurrentChain": [Function],
       "assertRequest": [Function],
       "assertTransactionEIP1559": [Function],
       "assertTransactionEIP2930": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,12 @@ export {
   offchainLookupSignature,
 } from './ccip.js'
 
-export { defineChain, getChainContractAddress } from './chain.js'
+export {
+  type AssertCurrentChainParameters,
+  assertCurrentChain,
+  defineChain,
+  getChainContractAddress,
+} from './chain.js'
 export { arrayRegex, bytesRegex, integerRegex } from './regex.js'
 
 export {


### PR DESCRIPTION
Might be good to compose & export a `assertCurrentChain` util that we can use upstream in wagmi.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an `assertCurrentChain` utility function and exports it, along with other functions, from various modules.

### Detailed summary
- Added `assertCurrentChain` utility function to `src/utils/chain.ts`
- Exported `assertCurrentChain` from `src/utils/index.ts` and `src/index.ts`
- Added `assertCurrentChain` to `src/index.test.ts`
- Added tests for `assertCurrentChain` to `src/utils/chain.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->