### PR TITLE
fix: `hashMessage` bytes conversion

### DIFF
--- a/.changeset/polite-carrots-vanish.md
+++ b/.changeset/polite-carrots-vanish.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed \`hashMessage\` string conversion for messages that have same format as hex bytes.

--- a/src/actions/public/verifyHash.test.ts
+++ b/src/actions/public/verifyHash.test.ts
@@ -21,21 +21,9 @@ describe('verifyHash', async () => {
       expectedResult: true,
     },
     {
-      _name: 'deployed, supports ERC1271, valid signature, hex message',
-      address: smartAccountConfig.address,
-      hash: hashMessage(
-        '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
-      ),
-      signature:
-        '0xefd5fb29a274ea6682673d8b3caa9263e936d48d486e5df68893003e0a76496439594d12245008c6fba1c8e3ef28241cffe1bef27ff6bca487b167f261f329251c',
-      expectedResult: true,
-    },
-    {
       _name: 'deployed, supports ERC1271, invalid signature',
       address: smartAccountConfig.address,
-      hash: hashMessage(
-        '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
-      ),
+      hash: hashMessage('This is a test message for viem!'),
       signature: '0xdead',
       expectedResult: false,
     },
@@ -91,9 +79,7 @@ describe('verifyHash', async () => {
     expect(
       await verifyHash(publicClient, {
         address: smartAccountConfig.address,
-        hash: hashMessage(
-          '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
-        ),
+        hash: hashMessage('This is a test message for viem!'),
         signature: toBytes(
           '0xefd5fb29a274ea6682673d8b3caa9263e936d48d486e5df68893003e0a76496439594d12245008c6fba1c8e3ef28241cffe1bef27ff6bca487b167f261f329251c',
         ),

--- a/src/actions/public/verifyMessage.test.ts
+++ b/src/actions/public/verifyMessage.test.ts
@@ -10,8 +10,7 @@ describe('verifyMessage', async () => {
     expect(
       await verifyMessage(publicClientMainnet, {
         address: smartAccountConfig.address,
-        message:
-          '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
+        message: 'This is a test message for viem!',
         signature:
           '0xefd5fb29a274ea6682673d8b3caa9263e936d48d486e5df68893003e0a76496439594d12245008c6fba1c8e3ef28241cffe1bef27ff6bca487b167f261f329251c',
       }),
@@ -22,8 +21,7 @@ describe('verifyMessage', async () => {
     expect(
       await verifyMessage(publicClientMainnet, {
         address: smartAccountConfig.address,
-        message:
-          '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
+        message: 'This is a test message for viem!',
         signature: '0xdead',
       }),
     ).toBe(false)
@@ -33,8 +31,7 @@ describe('verifyMessage', async () => {
     expect(
       await verifyMessage(publicClientMainnet, {
         address: address.notDeployed,
-        message:
-          '0x5468697320697320612074657374206d65737361676520666f72207669656d21',
+        message: 'This is a test message for viem!',
         signature:
           '0xefd5fb29a274ea6682673d8b3caa9263e936d48d486e5df68893003e0a76496439594d12245008c6fba1c8e3ef28241cffe1bef27ff6bca487b167f261f329251c',
       }),

--- a/src/utils/signature/hashMessage.test.ts
+++ b/src/utils/signature/hashMessage.test.ts
@@ -9,6 +9,9 @@ test('to hex', () => {
   expect(hashMessage('🤗')).toMatchInlineSnapshot(
     '"0x716ce69c5d2d629c168bc02e24a961456bdc5a362d366119305aea73978a0332"',
   )
+  expect(hashMessage('0xdeadbeef')).toMatchInlineSnapshot(
+    '"0xefedd0a9a0294228c3977d7fbb68c7d40279f8b408cf3e24ef1823b179709e58"',
+  )
 })
 
 test('to bytes', () => {
@@ -85,6 +88,44 @@ test('to bytes', () => {
       138,
       3,
       50,
+    ]
+  `,
+  )
+  expect(hashMessage('0xdeadbeef', 'bytes')).toMatchInlineSnapshot(
+    `
+    Uint8Array [
+      239,
+      237,
+      208,
+      169,
+      160,
+      41,
+      66,
+      40,
+      195,
+      151,
+      125,
+      127,
+      187,
+      104,
+      199,
+      212,
+      2,
+      121,
+      248,
+      180,
+      8,
+      207,
+      62,
+      36,
+      239,
+      24,
+      35,
+      177,
+      121,
+      112,
+      158,
+      88,
     ]
   `,
   )

--- a/src/utils/signature/hashMessage.ts
+++ b/src/utils/signature/hashMessage.ts
@@ -1,6 +1,6 @@
 import type { ByteArray, Hex } from '../../types/misc.js'
 import { concat } from '../data/concat.js'
-import { toBytes } from '../encoding/toBytes.js'
+import { stringToBytes } from '../encoding/toBytes.js'
 import { keccak256 } from '../hash/keccak256.js'
 
 type To = 'hex' | 'bytes'
@@ -13,8 +13,8 @@ export function hashMessage<TTo extends To = 'hex'>(
   message: string,
   to_?: TTo,
 ): HashMessage<TTo> {
-  const messageBytes = toBytes(message)
-  const prefixBytes = toBytes(
+  const messageBytes = stringToBytes(message)
+  const prefixBytes = stringToBytes(
     `\x19Ethereum Signed Message:\n${messageBytes.length}`,
   )
   return keccak256(concat([prefixBytes, messageBytes]), to_)


### PR DESCRIPTION
Fixes #473. Use explicit `stringToBytes` instead of `toBytes`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a bug in the `hashMessage` function related to string conversion. It also adds a new parameter to the function allowing for different output formats.

### Detailed summary
- Fixed `hashMessage` string conversion for messages that have same format as hex bytes.
- Added new parameter to `hashMessage` function allowing for different output formats.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->