### PR TITLE
feat: change return value of getByteCode

### DIFF
--- a/.changeset/empty-needles-cheer.md
+++ b/.changeset/empty-needles-cheer.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Removed undefined from return value of getByteCode. Now it always return a hex string

--- a/src/actions/public/getBytecode.ts
+++ b/src/actions/public/getBytecode.ts
@@ -20,7 +20,7 @@ export type GetBytecodeParameters = {
     }
 )
 
-export type GetBytecodeReturnType = Hex | undefined
+export type GetBytecodeReturnType = Hex
 
 /**
  * Retrieves the bytecode at an address.
@@ -55,6 +55,6 @@ export async function getBytecode<TChain extends Chain | undefined>(
     method: 'eth_getCode',
     params: [address, blockNumberHex || blockTag],
   })
-  if (hex === '0x') return undefined
+
   return hex
 }


### PR DESCRIPTION
Dicussion here: [https://github.com/wagmi-dev/viem/discussions/477](https://github.com/wagmi-dev/viem/discussions/477)


<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the possibility of `undefined` being returned by `getBytecode` function in `getBytecode.ts` and now it always returns a hex string.

### Detailed summary
- `GetBytecodeReturnType` type is modified to only allow `Hex` type
- `getBytecode` function is modified to remove the possibility of returning `undefined`
- `getBytecode` function now always returns a hex string

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->