### PR TITLE
fix: encodeEventTopics for leading non-indexed args

### DIFF
--- a/.changeset/serious-melons-beg.md
+++ b/.changeset/serious-melons-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix encodeEventTopics for leading non-indexed args

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -292,6 +292,38 @@ test('Foo((uint,string))', () => {
   `)
 })
 
+test('leading non-indexed args: Bar(string,string)', () => {
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: false,
+              name: 'title',
+              type: 'string',
+            },
+            {
+              indexed: true,
+              name: 'message',
+              type: 'string',
+            },
+          ],
+          name: 'Bar',
+          type: 'event',
+        },
+      ],
+      eventName: 'Bar',
+      args: {
+        message: 'hello',
+      },
+    }),
+  ).toEqual([
+    '0xc4a51b4017224dc1cc4aff8acc6d8da6475dfcb9743bb821dc45c91454526cbd',
+    '0x1c8aff950685c2ed4bc3174f3472287b56d9517b9c948127319a09a7a36deac8',
+  ])
+})
+
 test('inferred eventName', () => {
   expect(
     encodeEventTopics({

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -61,21 +61,22 @@ export function encodeEventTopics<
 
   let topics: Hex[] = []
   if (args && 'inputs' in abiItem) {
+    const indexedAbiItemInputs = abiItem.inputs?.filter(
+      (param) => 'indexed' in param && param.indexed,
+    )
     const args_ = Array.isArray(args)
       ? args
-      : abiItem.inputs?.map((x: any) => (args as any)[x.name]) ?? []
+      : indexedAbiItemInputs?.map((x: any) => (args as any)[x.name]) ?? []
     topics =
-      abiItem.inputs
-        ?.filter((param) => 'indexed' in param && param.indexed)
-        .map((param, i) =>
-          Array.isArray(args_[i])
-            ? args_[i].map((_: any, j: number) =>
-                encodeArg({ param, value: args_[i][j] }),
-              )
-            : args_[i]
-            ? encodeArg({ param, value: args_[i] })
-            : null,
-        ) ?? []
+      indexedAbiItemInputs?.map((param, i) =>
+        Array.isArray(args_[i])
+          ? args_[i].map((_: any, j: number) =>
+              encodeArg({ param, value: args_[i][j] }),
+            )
+          : args_[i]
+          ? encodeArg({ param, value: args_[i] })
+          : null,
+      ) ?? []
   }
   return [signature, ...topics]
 }

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -61,14 +61,14 @@ export function encodeEventTopics<
 
   let topics: Hex[] = []
   if (args && 'inputs' in abiItem) {
-    const indexedAbiItemInputs = abiItem.inputs?.filter(
+    const indexedInputs = abiItem.inputs?.filter(
       (param) => 'indexed' in param && param.indexed,
     )
     const args_ = Array.isArray(args)
       ? args
-      : indexedAbiItemInputs?.map((x: any) => (args as any)[x.name]) ?? []
+      : indexedInputs?.map((x: any) => (args as any)[x.name]) ?? []
     topics =
-      indexedAbiItemInputs?.map((param, i) =>
+      indexedInputs?.map((param, i) =>
         Array.isArray(args_[i])
           ? args_[i].map((_: any, j: number) =>
               encodeArg({ param, value: args_[i][j] }),


### PR DESCRIPTION
Fixes #485

For more details, check out the issue.

In first commit, I've added a test for an event that has 2 arguments, and only second one is indexed. The test was failing. Then, small change was made to `encodeEventTopics` and now the test is passing.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the `encodeEventTopics` function to properly handle leading non-indexed arguments in event topics. 

### Detailed summary
- Added a new test case for `Bar(string,string)` with leading non-indexed arguments
- Modified the `encodeEventTopics` function to handle leading non-indexed arguments properly by filtering out non-indexed parameters and mapping indexed ones to their corresponding values in `args`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->