### PR TITLE
chore: use rome for json & js formatting too

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,15 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.rome": true
   },
+  "[json]": {
+    "editor.defaultFormatter": "rome.rome"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "rome.rome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "rome.rome"
+  },
   "[typescript]": {
     "editor.defaultFormatter": "rome.rome"
   },


### PR DESCRIPTION
No idea why, but the default `defaultFormatter` setting doesn't apply to `json` otherwise.

<!-- start pr-codex -->

## PR-Codex overview
This PR adds Rome as the default formatter for JSON, JavaScript, and TypeScript files in the VS Code settings.

### Detailed summary
- Sets `editor.defaultFormatter` to `rome.rome` for JSON, JavaScript, and TypeScript files in VS Code settings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->