### PR TITLE
refactor: lax log types

### DIFF
--- a/.changeset/wild-seals-melt.md
+++ b/.changeset/wild-seals-melt.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+refactor: lax log types

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -63,11 +63,11 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -114,11 +114,11 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -224,21 +224,21 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
         }
     >()
   })
@@ -257,11 +257,11 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -310,11 +310,11 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -576,9 +576,9 @@ describe('events', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      from: Address
-      to: Address
-      value: bigint
+      from?: Address
+      to?: Address
+      value?: bigint
     }>()
 
     expect(logs.length).toBe(2)

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -63,11 +63,11 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -114,11 +114,11 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -224,21 +224,21 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
         }
     >()
   })
@@ -257,11 +257,11 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 
@@ -310,11 +310,11 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      owner: Address
-      spender: Address
-      foo: Address
-      value: bigint
-      bar: bigint
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
     }>()
   })
 

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -160,14 +160,14 @@ describe('contract events', () => {
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
     >()
 

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -46,11 +46,11 @@ test('event: const assertion', async () => {
     [`0x${string}`, `0x${string}`, `0x${string}`]
   >()
   expectTypeOf(logs[0]['args']).toEqualTypeOf<{
-    from: `0x${string}`
-    to: `0x${string}`
-    value: bigint
-    foo: string
-    bar: string
+    from?: `0x${string}`
+    to?: `0x${string}`
+    value?: bigint
+    foo?: string
+    bar?: string
   }>()
 })
 
@@ -93,11 +93,11 @@ test('event: defined inline', async () => {
     [`0x${string}`, `0x${string}`, `0x${string}`]
   >()
   expectTypeOf(logs[0]['args']).toEqualTypeOf<{
-    from: `0x${string}`
-    to: `0x${string}`
-    value: bigint
-    foo: string
-    bar: string
+    from?: `0x${string}`
+    to?: `0x${string}`
+    value?: bigint
+    foo?: string
+    bar?: string
   }>()
 })
 

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -166,9 +166,9 @@ describe('events', () => {
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
-      from: Address
-      to: Address
-      value: bigint
+      from?: Address
+      to?: Address
+      value?: bigint
     }>()
 
     expect(logs.length).toBe(2)

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -421,22 +421,6 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     bar?: number | number[] | null | undefined
     baz?: `0x${string}` | `0x${string}`[] | null | undefined
   }>()
-  type Named_Required = AbiEventParametersToPrimitiveTypes<
-    [
-      { name: 'foo'; type: 'string'; indexed: true },
-      { name: 'bar'; type: 'uint8'; indexed: true },
-      { name: 'baz'; type: 'address'; indexed: false },
-    ],
-    {
-      EnableUnion: true
-      IndexedOnly: true
-      Required: true
-    }
-  >
-  expectTypeOf<Named_Required>().toEqualTypeOf<{
-    foo: string | string[] | null
-    bar: number | number[] | null
-  }>()
   type Named_DisableUnion = AbiEventParametersToPrimitiveTypes<
     [
       { name: 'foo'; type: 'string'; indexed: true },
@@ -494,21 +478,7 @@ test('AbiEventParametersToPrimitiveTypes', () => {
         `0x${string}` | `0x${string}`[] | null,
       ]
   >()
-  type Unnamed_Required = AbiEventParametersToPrimitiveTypes<
-    [
-      { type: 'string'; indexed: true },
-      { type: 'uint8'; indexed: true },
-      { type: 'address'; indexed: false },
-    ],
-    {
-      EnableUnion: true
-      IndexedOnly: true
-      Required: true
-    }
-  >
-  expectTypeOf<Unnamed_Required>().toEqualTypeOf<
-    readonly [string | string[] | null, number | number[] | null]
-  >()
+
   type Unnamed_DisableUnion = AbiEventParametersToPrimitiveTypes<
     [
       { type: 'string'; indexed: true },

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -149,8 +149,9 @@ test('GetEventArgsFromTopics', () => {
   >
   expectTypeOf<Result>().toEqualTypeOf<{
     args: {
-      from: `0x${string}`
-      to: `0x${string}`
+      from?: `0x${string}`
+      to?: `0x${string}`
+      tokenId?: bigint
     }
   }>()
 })
@@ -538,5 +539,3 @@ test('AbiEventParametersToPrimitiveTypes', () => {
     | readonly [string | string[] | null, number | number[] | null]
   >()
 })
-
-test.todo('AbiEventTopicsToPrimitiveTypes')

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -20,7 +20,7 @@ import type {
 
 import type { Hex, LogTopic } from './misc.js'
 import type { TransactionRequest } from './transaction.js'
-import type { Filter, MaybeRequired, NoUndefined } from './utils.js'
+import type { Filter, NoUndefined } from './utils.js'
 
 export type AbiItem = Abi[number]
 
@@ -238,7 +238,7 @@ export type GetEventArgsFromTopics<
     : AbiEvent & { type: 'event' },
   TArgs = AbiEventParametersToPrimitiveTypes<
     TAbiEvent['inputs'],
-    { EnableUnion: false; IndexedOnly: false; Required: false }
+    { EnableUnion: false; IndexedOnly: false }
   >,
 > = TTopics extends readonly []
   ? TData extends undefined
@@ -252,12 +252,10 @@ export type GetEventArgsFromTopics<
 type EventParameterOptions = {
   EnableUnion?: boolean
   IndexedOnly?: boolean
-  Required?: boolean
 }
 type DefaultEventParameterOptions = {
   EnableUnion: true
   IndexedOnly: true
-  Required: false
 }
 
 type HashedEventTypes = 'bytes' | 'string' | 'tuple' | `${string}[${string}]`
@@ -329,13 +327,11 @@ export type AbiEventParametersToPrimitiveTypes<
               >
             },
           ]
-        | (Options['Required'] extends true
-            ? never
-            : // Distribute over tuple to represent optional parameters
-            Filtered extends readonly [
-                ...infer Head extends readonly AbiParameter[],
-                infer _,
-              ]
+        // Distribute over tuple to represent optional parameters
+        | (Filtered extends readonly [
+            ...infer Head extends readonly AbiParameter[],
+            infer _,
+          ]
             ? AbiEventParametersToPrimitiveTypes<
                 readonly [...{ [K in keyof Head]: Omit<Head[K], 'name'> }],
                 Options
@@ -350,9 +346,6 @@ export type AbiEventParametersToPrimitiveTypes<
             ? Name
             : never]?: AbiEventParameterToPrimitiveType<Parameter, Options>
       } extends infer Mapped
-    ? MaybeRequired<
-        Mapped,
-        Options['Required'] extends boolean ? Options['Required'] : false
-      >
+    ? Mapped
     : never
   : never

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -93,7 +93,7 @@ type GetInferredLogValues<
         args: GetEventArgs<
           TAbi,
           TEventName,
-          { EnableUnion: false; IndexedOnly: false; Required: true }
+          { EnableUnion: false; IndexedOnly: false; Required: false }
         >
         /** The event name decoded from `topics`. */
         eventName: TEventName
@@ -105,7 +105,7 @@ type GetInferredLogValues<
           args: GetEventArgs<
             TAbi,
             string,
-            { EnableUnion: false; IndexedOnly: false; Required: true }
+            { EnableUnion: false; IndexedOnly: false; Required: false }
           >
           /** The event name decoded from `topics`. */
           eventName: TName

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -93,7 +93,7 @@ type GetInferredLogValues<
         args: GetEventArgs<
           TAbi,
           TEventName,
-          { EnableUnion: false; IndexedOnly: false; Required: false }
+          { EnableUnion: false; IndexedOnly: false }
         >
         /** The event name decoded from `topics`. */
         eventName: TEventName
@@ -105,7 +105,7 @@ type GetInferredLogValues<
           args: GetEventArgs<
             TAbi,
             string,
-            { EnableUnion: false; IndexedOnly: false; Required: false }
+            { EnableUnion: false; IndexedOnly: false }
           >
           /** The event name decoded from `topics`. */
           eventName: TName

--- a/src/utils/abi/decodeEventLog.test-d.ts
+++ b/src/utils/abi/decodeEventLog.test-d.ts
@@ -60,9 +60,9 @@ test('named', async () => {
 
   expectTypeOf(event).toEqualTypeOf<{
     args: {
-      from: Address
-      to: Address
-      tokenId: bigint
+      from?: Address
+      to?: Address
+      tokenId?: bigint
     }
     eventName: 'Transfer'
   }>()
@@ -100,7 +100,11 @@ test('unnamed', async () => {
   })
 
   expectTypeOf(event).toEqualTypeOf<{
-    args: [Address, Address, bigint]
+    args:
+      | readonly []
+      | readonly [`0x${string}`]
+      | readonly [`0x${string}`, `0x${string}`]
+      | readonly [`0x${string}`, `0x${string}`, bigint]
     eventName: 'Transfer'
   }>()
 })
@@ -162,17 +166,17 @@ test('unknown eventName', async () => {
   expectTypeOf(event).toEqualTypeOf<
     | {
         args: {
-          from: Address
-          to: Address
-          tokenId: bigint
+          from?: Address
+          to?: Address
+          tokenId?: bigint
         }
         eventName: 'Transfer'
       }
     | {
         args: {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
         eventName: 'Foo'
       }

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -63,11 +63,12 @@ test('named args: Transfer(address,address,uint256)', () => {
       '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
       '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
       '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
     ],
   })
   assertType<typeof event>({
     eventName: 'Transfer',
-    args: { from: '0x', to: '0x' },
+    args: { from: '0x', to: '0x', tokenId: 1n },
   })
   expect(event).toEqual({
     eventName: 'Transfer',
@@ -104,9 +105,13 @@ test('unnamed args: Transfer(address,address,uint256)', () => {
       '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
       '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
       '0x000000000000000000000000a5cc3c03994db5b0d9a5eedd10cabab0813678ac',
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
     ],
   })
-  assertType<typeof event>({ eventName: 'Transfer', args: ['0x', '0x'] })
+  assertType<typeof event>({
+    eventName: 'Transfer',
+    args: ['0x', '0x', 1n],
+  })
   expect(event).toEqual({
     args: [
       '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -93,8 +93,8 @@ export function decodeEventLog<
   let args: any = isUnnamed ? [] : {}
 
   // Decode topics (indexed args).
+  const indexedInputs = inputs.filter((x) => 'indexed' in x && x.indexed)
   if (argTopics.length > 0) {
-    const indexedInputs = inputs.filter((x) => 'indexed' in x && x.indexed)
     for (let i = 0; i < indexedInputs.length; i++) {
       const param = indexedInputs[i]
       const topic = argTopics[i]
@@ -108,15 +108,15 @@ export function decodeEventLog<
   }
 
   // Decode data (non-indexed args).
+  const nonIndexedInputs = inputs.filter((x) => !('indexed' in x && x.indexed))
   if (data && data !== '0x') {
-    const params = inputs.filter((x) => !('indexed' in x && x.indexed))
     try {
-      const decodedData = decodeAbiParameters(params, data)
+      const decodedData = decodeAbiParameters(nonIndexedInputs, data)
       if (decodedData) {
         if (isUnnamed) args = [...args, ...decodedData]
         else {
-          for (let i = 0; i < params.length; i++) {
-            args[params[i].name!] = decodedData[i]
+          for (let i = 0; i < nonIndexedInputs.length; i++) {
+            args[nonIndexedInputs[i].name!] = decodedData[i]
           }
         }
       }


### PR DESCRIPTION
Most of the time, the length of the data/topics passed to `decodeEventLog` will be non-deterministic. Even if we do know the event (and thus, the expected length of topics/data), the topics/data length is still not guarenteed as the event 4-byte selector is not aware of indexed/non-indexed args. Because of this, there is a chance that there could be a mismatch between indexed/non-indexed arguments with their corresponding topics/data, so it's not guarenteed that we can fully decode every argument. 

This PR aims to change the attributes within the `args` type to be optional to represent this, and as a result, we can just use the `AbiEventParametersToPrimitiveTypes` type instead.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `args` object in several files to make some properties optional. It also adds a new `AbiEventParametersToPrimitiveTypes` type to convert ABI event parameters to primitive types.

### Detailed summary
- Make some properties optional in `args` object in several files
- Add `AbiEventParametersToPrimitiveTypes` type to convert ABI event parameters to primitive types

> The following files were skipped due to too many changes: `src/types/contract.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->