### PR TITLE
feat: support loose abi decode

### DIFF
--- a/.changeset/witty-pianos-lick.md
+++ b/.changeset/witty-pianos-lick.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added loose abi decode to decodeAbiParameters

--- a/site/docs/abi/decodeAbiParameters.md
+++ b/site/docs/abi/decodeAbiParameters.md
@@ -93,6 +93,19 @@ const values = decodeAbiParameters(
 )
 ```
 
+### loose (optional)
+
+- **Type:** `boolean`
+
+ignore extra data at the end of the encoded data or not, defaults to `false
+
+```ts
+const values = decodeAbiParameters(
+  [{ name: 'x', type: 'uint32' }],
+  '0x0000000000000000000000000000000000000000000000000000000000010f2cdeadcode', // [!code focus]
+)
+```
+
 ## More Examples
 
 ### Simple struct

--- a/site/docs/contract/decodeFunctionData.md
+++ b/site/docs/contract/decodeFunctionData.md
@@ -152,7 +152,7 @@ const { functionName } = decodeFunctionData({
 
 - **Type:** [`Hex`](/docs/glossary/types#hex)
 
-The encoded calldata.
+The encoded calldata. If data parameters size is not aligned to 32 bytes, it will be truncated to the nearest 32 bytes.
 
 ```ts
 const { functionName } = decodeFunctionData({

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -1947,27 +1947,24 @@ describe('multicall3', () => {
       ]
     `)
   })
-
-  test('loose data size', () => {
-    expect(
-      decodeAbiParameters(
-        [
-          {
-            name: 'purchase',
-            type: 'function',
-            stateMutability: 'nonpayable',
-            inputs: [{ type: 'uint256', name: 'quantity' }],
-            outputs: [{ type: 'uint256' }],
-          },
-        ],
-        '0xefef39a100000000000000000000000000000000000000000000000000000000000000010021fb3f',
-        true,
-      ),
-    )
-  })
 })
 
-test('invalid size', () => {
+test('turn on loose data size', () => {
+  const result = decodeAbiParameters(
+    [
+      {
+        name: 'xIn',
+        type: 'uint256',
+      },
+    ],
+    '0x0000000000000000000000000000000000000000000000000000000000010f2c00000dead',
+    true,
+  )
+  assertType<[bigint]>(result)
+  expect(result).toEqual([69420n])
+})
+
+test('turn off loose data size | invalid size', () => {
   expect(() =>
     decodeAbiParameters(
       [

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -1947,6 +1947,24 @@ describe('multicall3', () => {
       ]
     `)
   })
+
+  test('loose data size', () => {
+    expect(
+      decodeAbiParameters(
+        [
+          {
+            name: 'purchase',
+            type: 'function',
+            stateMutability: 'nonpayable',
+            inputs: [{ type: 'uint256', name: 'quantity' }],
+            outputs: [{ type: 'uint256' }],
+          },
+        ],
+        '0xefef39a100000000000000000000000000000000000000000000000000000000000000010021fb3f',
+        true,
+      ),
+    )
+  })
 })
 
 test('invalid size', () => {

--- a/src/utils/abi/decodeAbiParameters.ts
+++ b/src/utils/abi/decodeAbiParameters.ts
@@ -32,13 +32,19 @@ export type DecodeAbiParametersReturnType<
 
 export function decodeAbiParameters<
   TParams extends readonly AbiParameter[] | readonly unknown[],
->(params: Narrow<TParams>, data: Hex): DecodeAbiParametersReturnType<TParams> {
+>(
+  params: Narrow<TParams>,
+  data: Hex,
+  loose?: boolean,
+): DecodeAbiParametersReturnType<TParams> {
   if (data === '0x' && (params as unknown[]).length > 0)
     throw new AbiDecodingZeroDataError()
-  if (size(data) % 32 !== 0)
+  if ((!loose && size(data) % 32 !== 0) || (loose && size(data) < 32))
     throw new AbiDecodingDataSizeInvalidError({ data, size: size(data) })
+  const location = size(data) - (size(data) % 32)
+  const slicedData = loose ? slice(data, 0, location) : data
   return decodeParams({
-    data,
+    data: slicedData,
     params: params as readonly AbiParameter[],
   }) as unknown as DecodeAbiParametersReturnType<TParams>
 }

--- a/src/utils/abi/decodeFunctionData.ts
+++ b/src/utils/abi/decodeFunctionData.ts
@@ -47,7 +47,7 @@ export function decodeFunctionData<TAbi extends Abi | readonly unknown[]>({
     args: ('inputs' in description &&
     description.inputs &&
     description.inputs.length > 0
-      ? decodeAbiParameters(description.inputs, slice(data, 4))
+      ? decodeAbiParameters(description.inputs, slice(data, 4), true)
       : undefined) as readonly unknown[] | undefined,
   } as DecodeFunctionDataReturnType<TAbi>
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new optional parameter to `decodeAbiParameters` that allows ignoring extra data at the end of the encoded data. It also updates the documentation to reflect this change.

### Detailed summary
- Added a new optional `loose` parameter to `decodeAbiParameters`
- Updated `decodeFunctionData` to include a note about truncating data if it's not aligned to 32 bytes
- Updated documentation for `decodeFunctionData` and `decodeAbiParameters` to reflect the new `loose` parameter

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->