### PR TITLE
feat: support suffixed data in `decodeAbiParameters`.

### DIFF
--- a/.changeset/wet-jokes-drum.md
+++ b/.changeset/wet-jokes-drum.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support suffixed data in `decodeAbiParameters`.

--- a/site/docs/utilities/slice.md
+++ b/site/docs/utilities/slice.md
@@ -90,10 +90,10 @@ slice(
 Whether or not the end offset should be inclusive of the bounds of the data.
 
 ```ts
-sliceHex('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678', 0, 20, { strict: true })
+slice('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678', 0, 20, { strict: true })
 // [SliceOffsetOutOfBoundsError] Slice ending at offset "20" is out-of-bounds (size: 19).
 
-sliceHex('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 0, 20, { strict: true })
+slice('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 0, 20, { strict: true })
 // 0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC
 ```
 

--- a/site/docs/utilities/slice.md
+++ b/site/docs/utilities/slice.md
@@ -27,7 +27,7 @@ import { slice } from 'viem'
 ```ts
 import { slice } from 'viem'
 
-sliceHex('0x0123456789', 1, 4)
+slice('0x0123456789', 1, 4)
 // 0x234567
 
 slice(new Uint8Array([1, 122, 51, 123]), 1, 3)
@@ -49,7 +49,7 @@ The section of the sliced value.
 The hex or byte array to slice.
 
 ```ts
-sliceHex(
+slice(
   '0x0123456789', // [!code focus]
   1,
   4
@@ -63,7 +63,7 @@ sliceHex(
 The start offset (in bytes).
 
 ```ts
-sliceHex(
+slice(
   '0x0123456789', 
   1 // [!code focus]
 )
@@ -76,10 +76,24 @@ sliceHex(
 The end offset (in bytes).
 
 ```ts
-sliceHex(
+slice(
   '0x0123456789', 
   1,
   4 // [!code focus]
 )
+```
+
+#### options.strict (optional)
+
+- **Type:** `boolean`
+
+Whether or not the end offset should be inclusive of the bounds of the data.
+
+```ts
+sliceHex('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678', 0, 20, { strict: true })
+// [SliceOffsetOutOfBoundsError] Slice ending at offset "20" is out-of-bounds (size: 19).
+
+sliceHex('0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC', 0, 20, { strict: true })
+// 0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC
 ```
 

--- a/src/errors/abi.test.ts
+++ b/src/errors/abi.test.ts
@@ -113,8 +113,6 @@ test('DecodeLogDataMismatch', () => {
   ).toMatchInlineSnapshot(`
     [DecodeLogDataMismatch: Data size of 2 bytes is too small for non-indexed event parameters.
 
-    This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.
-
     Params: (uint256 a, uint256 b)
     Data:   0x1234 (2 bytes)
 

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -293,8 +293,6 @@ export class DecodeLogDataMismatch extends BaseError {
       ].join('\n'),
       {
         metaMessages: [
-          'This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.',
-          '',
           `Params: (${formatAbiParams(params, { includeName: true })})`,
           `Data:   ${data} (${size} bytes)`,
         ],

--- a/src/errors/data.ts
+++ b/src/errors/data.ts
@@ -2,9 +2,15 @@ import { BaseError } from './base.js'
 
 export class SliceOffsetOutOfBoundsError extends BaseError {
   override name = 'SliceOffsetOutOfBoundsError'
-  constructor({ offset, size }: { offset: number; size: number }) {
+  constructor({
+    offset,
+    position,
+    size,
+  }: { offset: number; position: 'start' | 'end'; size: number }) {
     super(
-      `Slice starting at offset "${offset}" is out-of-bounds (size: ${size}).`,
+      `Slice ${
+        position === 'start' ? 'starting' : 'ending'
+      } at offset "${offset}" is out-of-bounds (size: ${size}).`,
     )
   }
 }

--- a/src/utils/abi/decodeAbiParameters.test.ts
+++ b/src/utils/abi/decodeAbiParameters.test.ts
@@ -1,4 +1,4 @@
-import type { Address } from 'abitype'
+import { type Address } from 'abitype'
 import { assertType, describe, expect, test } from 'vitest'
 
 import { seaportContractConfig } from '../../_test/abis.js'
@@ -1950,8 +1950,8 @@ describe('multicall3', () => {
   })
 })
 
-test('invalid size', () => {
-  expect(() =>
+test('data suffix', () => {
+  expect(
     decodeAbiParameters(
       [
         {
@@ -1959,19 +1959,26 @@ test('invalid size', () => {
           type: 'uint256',
         },
       ],
-      '0x0000000000000000000000000000000000000000000000000000000000010fabababab',
+      '0x0000000000000000000000000000000000000000000000000000000000010f2cdeadbeef',
     ),
-  ).toThrowErrorMatchingInlineSnapshot(`
-    "Data size of 35 bytes is invalid.
-    Size must be in increments of 32 bytes (size % 32 === 0).
-
-    Data: 0x0000000000000000000000000000000000000000000000000000000000010fabababab (35 bytes)
-
-    Version: viem@1.0.2"
-  `)
+  ).toEqual([69420n])
 })
 
 test('data size too small', () => {
+  expect(() =>
+    decodeAbiParameters(
+      [{ type: 'uint256' }],
+      '0x0000000000000000000000000000000000000000000000000000000000010f',
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Data size of 31 bytes is too small for given parameters.
+
+    Params: (uint256)
+    Data:   0x0000000000000000000000000000000000000000000000000000000000010f (31 bytes)
+
+    Version: viem@1.0.2"
+  `)
+
   expect(() =>
     decodeAbiParameters(
       [{ type: 'uint256' }, { type: 'uint256' }],

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -1,5 +1,6 @@
 import { assertType, describe, expect, test } from 'vitest'
 
+import { getEventSelector } from '../../utils/hash/getEventSelector.js'
 import { getAddress } from '../address/getAddress.js'
 
 import { decodeEventLog } from './decodeEventLog.js'
@@ -534,8 +535,6 @@ describe('GitHub repros', () => {
       ).toThrowErrorMatchingInlineSnapshot(`
         "Data size of 32 bytes is too small for non-indexed event parameters.
 
-        This error is usually caused if the ABI event has too many non-indexed event parameters for the emitted log.
-
         Params: (address to, uint256 id)
         Data:   0x0000000000000000000000000000000000000000000000000000000023c34600 (32 bytes)
 
@@ -637,10 +636,51 @@ test('errors: invalid data size', () => {
       ],
     }),
   ).toThrowErrorMatchingInlineSnapshot(`
-    "Data size of 1 bytes is invalid.
-    Size must be in increments of 32 bytes (size % 32 === 0).
+    "Data size of 1 bytes is too small for non-indexed event parameters.
 
-    Data: 0x1 (1 bytes)
+    Params: (uint256 tokenId)
+    Data:   0x1 (1 bytes)
+
+    Version: viem@1.0.2"
+  `)
+})
+
+test('errors: invalid bool', () => {
+  expect(() =>
+    decodeEventLog({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'sender',
+              type: 'bool',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      data: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      eventName: 'Transfer',
+      topics: [
+        getEventSelector('Transfer(address,address,bool)'),
+        '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      ],
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Hex value \\"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef\\" is not a valid boolean. The hex value must be \\"0x0\\" (false) or \\"0x1\\" (true).
 
     Version: viem@1.0.2"
   `)

--- a/src/utils/data/slice.test.ts
+++ b/src/utils/data/slice.test.ts
@@ -37,6 +37,25 @@ test('hex', () => {
     Version: viem@1.0.2"
   `,
   )
+
+  expect(() =>
+    sliceHex('0x0123456789', 0, 6, { strict: true }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Slice ending at offset \\"6\\" is out-of-bounds (size: 5).
+
+    Version: viem@1.0.2"
+  `,
+  )
+  expect(() =>
+    sliceHex('0x0123456789', 0, 10, { strict: true }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Slice ending at offset \\"10\\" is out-of-bounds (size: 5).
+
+    Version: viem@1.0.2"
+  `,
+  )
 })
 
 test('bytes', () => {
@@ -204,6 +223,29 @@ test('bytes', () => {
   ).toThrowErrorMatchingInlineSnapshot(
     `
     "Slice starting at offset \\"10\\" is out-of-bounds (size: 10).
+
+    Version: viem@1.0.2"
+  `,
+  )
+
+  expect(() =>
+    sliceBytes(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 0, 11, {
+      strict: true,
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Slice ending at offset \\"11\\" is out-of-bounds (size: 10).
+
+    Version: viem@1.0.2"
+  `,
+  )
+  expect(() =>
+    sliceBytes(new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 5, 15, {
+      strict: true,
+    }),
+  ).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Slice ending at offset \\"15\\" is out-of-bounds (size: 5).
 
     Version: viem@1.0.2"
   `,

--- a/src/utils/data/slice.ts
+++ b/src/utils/data/slice.ts
@@ -19,15 +19,38 @@ export function slice<TValue extends ByteArray | Hex>(
   value: TValue,
   start?: number,
   end?: number,
+  { strict }: { strict?: boolean } = {},
 ): SliceReturnType<TValue> {
   if (isHex(value))
-    return sliceHex(value as Hex, start, end) as SliceReturnType<TValue>
-  return sliceBytes(value as ByteArray, start, end) as SliceReturnType<TValue>
+    return sliceHex(value as Hex, start, end, {
+      strict,
+    }) as SliceReturnType<TValue>
+  return sliceBytes(value as ByteArray, start, end, {
+    strict,
+  }) as SliceReturnType<TValue>
 }
 
 function assertStartOffset(value: Hex | ByteArray, start?: number) {
   if (typeof start === 'number' && start > 0 && start > size(value) - 1)
-    throw new SliceOffsetOutOfBoundsError({ offset: start, size: size(value) })
+    throw new SliceOffsetOutOfBoundsError({
+      offset: start,
+      position: 'start',
+      size: size(value),
+    })
+}
+
+function assertEndOffset(value: Hex | ByteArray, start?: number, end?: number) {
+  if (
+    typeof start === 'number' &&
+    typeof end === 'number' &&
+    size(value) !== end - start
+  ) {
+    throw new SliceOffsetOutOfBoundsError({
+      offset: end,
+      position: 'end',
+      size: size(value),
+    })
+  }
 }
 
 /**
@@ -38,12 +61,15 @@ function assertStartOffset(value: Hex | ByteArray, start?: number) {
  * @param end The end offset (in bytes).
  */
 export function sliceBytes(
-  value: ByteArray,
+  value_: ByteArray,
   start?: number,
   end?: number,
+  { strict }: { strict?: boolean } = {},
 ): ByteArray {
-  assertStartOffset(value, start)
-  return value.slice(start, end)
+  assertStartOffset(value_, start)
+  const value = value_.slice(start, end)
+  if (strict) assertEndOffset(value, start, end)
+  return value
 }
 
 /**
@@ -53,10 +79,16 @@ export function sliceBytes(
  * @param start The start offset (in bytes).
  * @param end The end offset (in bytes).
  */
-export function sliceHex(value_: Hex, start?: number, end?: number): Hex {
+export function sliceHex(
+  value_: Hex,
+  start?: number,
+  end?: number,
+  { strict }: { strict?: boolean } = {},
+): Hex {
   assertStartOffset(value_, start)
-  const value = value_
+  const value = `0x${value_
     .replace('0x', '')
-    .slice((start ?? 0) * 2, (end ?? value_.length) * 2)
-  return `0x${value}`
+    .slice((start ?? 0) * 2, (end ?? value_.length) * 2)}` as const
+  if (strict) assertEndOffset(value, start, end)
+  return value
 }


### PR DESCRIPTION
Fixes #505

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for suffixed data in `decodeAbiParameters` and adds an option to enable strict mode in `sliceHex` and `sliceBytes`. It also improves error messages for `SliceOffsetOutOfBoundsError` and `AbiDecodingDataSizeTooSmallError`. 

### Detailed summary
- Support suffixed data in `decodeAbiParameters`.
- Add an option to enable strict mode in `sliceHex` and `sliceBytes`.
- Improve error messages for `SliceOffsetOutOfBoundsError` and `AbiDecodingDataSizeTooSmallError`.

> The following files were skipped due to too many changes: `src/utils/abi/decodeAbiParameters.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->