### PR TITLE
fix docs for getEnsAddress

### DIFF
--- a/site/docs/ens/actions/getEnsAddress.md
+++ b/site/docs/ens/actions/getEnsAddress.md
@@ -54,7 +54,7 @@ Since ENS names prohibit certain forbidden characters (e.g. underscore) and have
 
 The address that resolves to provided ENS name.
 
-Returns `0x0000000000000000000000000000000000000000` if ENS name does not resolve to address.
+Returns `null` if ENS name does not resolve to address.
 
 ## Parameters
 


### PR DESCRIPTION
Fixes the docs for `getEnsAddress` to denote `null` will be returned if no address can be resolved.

This fix was implemented in https://github.com/wagmi-dev/viem/pull/293

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `getEnsAddress` function in the `site/docs/ens/actions/getEnsAddress.md` file to return `null` instead of `0x0000000000000000000000000000000000000000` when an ENS name does not resolve to an address. It also fixes a formatting issue in the same file.

### Detailed summary
- `getEnsAddress` now returns `null` instead of `0x0000000000000000000000000000000000000000` when an ENS name does not resolve to an address. 
- A formatting issue in the `getEnsAddress.md` file has been fixed.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->