### PR TITLE
refactor: optimize `waitForTransactionReceipt`

### DIFF
--- a/.changeset/soft-carrots-jam.md
+++ b/.changeset/soft-carrots-jam.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Optimized \`getTransaction\` strategy in \`waitForTransactionReceipt\`.

--- a/.changeset/soft-carrots-jam.md
+++ b/.changeset/soft-carrots-jam.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Optimized \`getTransaction\` strategy in \`waitForTransactionReceipt\`.
+Optimized `getTransaction` strategy in `waitForTransactionReceipt`.

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -9,6 +9,7 @@ import type { Chain } from '../../types/chain.js'
 import type { Hash } from '../../types/misc.js'
 import type { Transaction } from '../../types/transaction.js'
 import { observe } from '../../utils/observe.js'
+import { withRetry } from '../../utils/promise/withRetry.js'
 
 import { getBlock } from './getBlock.js'
 import {
@@ -115,7 +116,6 @@ export async function waitForTransactionReceipt<
   let transaction: GetTransactionReturnType<TChain> | undefined
   let replacedTransaction: GetTransactionReturnType<TChain> | undefined
   let receipt: GetTransactionReceiptReturnType<TChain>
-  let retries = 0
 
   return new Promise((resolve, reject) => {
     if (timeout)
@@ -133,7 +133,9 @@ export async function waitForTransactionReceipt<
           emitOnBegin: true,
           poll: true,
           pollingInterval,
-          async onBlockNumber(blockNumber) {
+          async onBlockNumber(blockNumber_) {
+            let blockNumber = blockNumber_
+
             const done = async (fn: () => void) => {
               unwatch()
               fn()
@@ -152,13 +154,30 @@ export async function waitForTransactionReceipt<
               }
 
               // Get the transaction to check if it's been replaced.
-              transaction = await getTransaction(client, { hash })
+              // We need to retry as some RPC Providers may be slow to sync
+              // up mined transactions.
+              await withRetry(
+                async () => {
+                  transaction = await getTransaction(client, { hash })
+                  if (transaction.blockNumber)
+                    blockNumber = transaction.blockNumber
+                },
+                {
+                  // exponential backoff
+                  delay: ({ count }) => ~~(1 << count) * 100,
+                  retryCount: 3,
+                },
+              )
 
               // Get the receipt to check if it's been processed.
               receipt = await getTransactionReceipt(client, { hash })
 
               // Check if we have enough confirmations. If not, continue polling.
-              if (blockNumber - receipt.blockNumber + 1n < confirmations) return
+              if (
+                confirmations > 0 &&
+                blockNumber - receipt.blockNumber + 1n < confirmations
+              )
+                return
 
               done(() => emit.resolve(receipt))
             } catch (err) {
@@ -220,8 +239,7 @@ export async function waitForTransactionReceipt<
                   emit.resolve(receipt)
                 })
               } else {
-                if (retries > 2) done(() => emit.reject(err))
-                retries++
+                done(() => emit.reject(err))
               }
             }
           },


### PR DESCRIPTION
Fixes #513.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR optimizes the `getTransaction` strategy in `waitForTransactionReceipt` by adding retries and exponential backoff.

### Detailed summary
- Adds `withRetry` utility function to retry slow RPC Providers
- Uses exponential backoff to wait for mined transactions
- Improves `getTransaction` strategy to optimize polling

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->