### PR TITLE
feat: add `strict` option to `isHex`.

### DIFF
--- a/.changeset/short-rivers-burn.md
+++ b/.changeset/short-rivers-burn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `strict` option to `isHex` & optimized data utilities.

--- a/site/docs/utilities/isHex.md
+++ b/site/docs/utilities/isHex.md
@@ -40,3 +40,37 @@ isHex('foo')
 `boolean`
 
 Returns truthy is the value is a hex value.
+
+## Parameters
+
+### value
+
+- **Type:** `unknown`
+
+The value to check.
+
+```ts
+isHex(
+  '0x1a4' // [!code focus]
+)
+// true
+```
+
+### options.strict
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+When enabled, checks if the value strictly consists of only hex characters (`"0x[0-9a-fA-F]*"`).
+When disabled, checks if the value loosely matches hex format (`value.startsWith('0x')`).
+
+```ts
+isHex('0xlol', { strict: false })
+// true
+
+isHex('0xlol', { strict: true })
+// false
+
+isHex('lol', { strict: false })
+// false
+```

--- a/src/utils/data/isHex.test.ts
+++ b/src/utils/data/isHex.test.ts
@@ -8,6 +8,7 @@ test('is hex', () => {
   expect(isHex('0x0123456789abcdef')).toBeTruthy()
   expect(isHex('0x0123456789abcdefABCDEF')).toBeTruthy()
   expect(isHex('0x0123456789abcdefg')).toBeFalsy()
+  expect(isHex('0x0123456789abcdefg', { strict: false })).toBeTruthy()
   expect(isHex({ foo: 'bar' })).toBeFalsy()
   expect(isHex(undefined)).toBeFalsy()
 })

--- a/src/utils/data/isHex.ts
+++ b/src/utils/data/isHex.ts
@@ -1,7 +1,10 @@
 import type { Hex } from '../../types/misc.js'
 
-export function isHex(value: unknown): value is Hex {
+export function isHex(
+  value: unknown,
+  { strict = true }: { strict?: boolean } = {},
+): value is Hex {
   if (!value) return false
   if (typeof value !== 'string') return false
-  return /^0x[0-9a-fA-F]*$/.test(value)
+  return strict ? /^0x[0-9a-fA-F]*$/.test(value) : value.startsWith('0x')
 }

--- a/src/utils/data/size.ts
+++ b/src/utils/data/size.ts
@@ -9,6 +9,6 @@ import { isHex } from './isHex.js'
  * @returns The size of the value (in bytes).
  */
 export function size(value: Hex | ByteArray) {
-  if (isHex(value)) return Math.ceil((value.length - 2) / 2)
+  if (isHex(value, { strict: false })) return Math.ceil((value.length - 2) / 2)
   return value.length
 }

--- a/src/utils/data/slice.ts
+++ b/src/utils/data/slice.ts
@@ -21,7 +21,7 @@ export function slice<TValue extends ByteArray | Hex>(
   end?: number,
   { strict }: { strict?: boolean } = {},
 ): SliceReturnType<TValue> {
-  if (isHex(value))
+  if (isHex(value, { strict: false }))
     return sliceHex(value as Hex, start, end, {
       strict,
     }) as SliceReturnType<TValue>

--- a/src/utils/hash/keccak256.ts
+++ b/src/utils/hash/keccak256.ts
@@ -16,7 +16,9 @@ export function keccak256<TTo extends To = 'hex'>(
   to_?: TTo,
 ): Keccak256Hash<TTo> {
   const to = to_ || 'hex'
-  const bytes = keccak_256(isHex(value) ? toBytes(value) : value)
+  const bytes = keccak_256(
+    isHex(value, { strict: false }) ? toBytes(value) : value,
+  )
   if (to === 'bytes') return bytes as Keccak256Hash<TTo>
   return toHex(bytes) as Keccak256Hash<TTo>
 }


### PR DESCRIPTION
There are cases where we don't really care if values are strictly hex (ie. data utils). Regex checks have quite a large cost, so removing the regex speeds up our algorithms like ABI encoding/decoding significantly.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `strict` option to the `isHex` function and optimizes data utilities.

### Detailed summary
- Added `strict` option to `isHex` function
- Optimized `slice` function in `src/utils/data/slice.ts`
- Optimized `size` function in `src/utils/data/size.ts`
- Added tests for `isHex` function in `src/utils/data/isHex.test.ts`
- Optimized `keccak256` function in `src/utils/hash/keccak256.ts`
- Updated documentation for `isHex` function in `site/docs/utilities/isHex.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->