### PR TITLE
fix: remove trailing zero byte data from `trim`

### DIFF
--- a/.changeset/fuzzy-fishes-reply.md
+++ b/.changeset/fuzzy-fishes-reply.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `trim` to trim trailing zero byte data instead of all trailing zeros.

--- a/site/docs/utilities/trim.md
+++ b/site/docs/utilities/trim.md
@@ -5,16 +5,16 @@ head:
       content: trim
   - - meta
     - name: description
-      content: Trims the leading or trailing zeros from a hex value or byte array.
+      content: Trims the leading or trailing zero byte data from a hex value or byte array.
   - - meta
     - property: og:description
-      content: Trims the leading or trailing zeros from a hex value or byte array.
+      content: Trims the leading or trailing zero byte data from a hex value or byte array.
 
 ---
 
 # trim
 
-Trims the leading or trailing zeros from a hex value or byte array.
+Trims the leading or trailing zero byte data from a hex value or byte array.
 
 ## Install
 
@@ -24,13 +24,13 @@ import { trim } from 'viem'
 
 ## Usage
 
-By default, `trim` will trim the leading zeros from a hex value or byte array.
+By default, `trim` will trim the leading zero byte data from a hex value or byte array.
 
 ```ts
 import { trim } from 'viem'
 
-trim('0x00000000000000000000000000000000000000000000000000000000a4e12a45')
-// 0xa4e12a45
+trim('0x00000000000000000000000000000000000000000000000000000001a4e12a45')
+// 0x01a4e12a45
 
 trim(new Uint8Array([0, 0, 0, 0, 0, 0, 1, 122, 51, 123]))
 // Uint8Array [1,122,51,123]
@@ -49,12 +49,12 @@ The trimmed value.
 - **Type:** `"left" | "right"`
 - **Default:** `"left"`
 
-The direction in which to trim the zeros – either leading (left), or trailing (right).
+The direction in which to trim the zero byte data – either leading (left), or trailing (right).
 
 ```ts
-trim('0xa4e12a4500000000000000000000000000000000000000000000000000000000', {
+trim('0xa4e12a4510000000000000000000000000000000000000000000000000000000', {
   dir: 'right'
 })
-// 0xa4e12a45
+// 0xa4e12a4510
 ```
 

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -106,5 +106,5 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
     data: res[0],
   })
 
-  return trim(address) === '0x0' ? null : address
+  return trim(address) === '0x00' ? null : address
 }

--- a/src/utils/data/trim.test.ts
+++ b/src/utils/data/trim.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest'
 import { trim } from './trim.js'
 
 test('default', () => {
-  expect(trim('0x000000')).toMatchInlineSnapshot('"0x0"')
+  expect(trim('0x000000')).toMatchInlineSnapshot('"0x00"')
   expect(trim(new Uint8Array([0, 0, 0, 0, 0]))).toMatchInlineSnapshot(
     `
     Uint8Array [
@@ -37,11 +37,22 @@ test('default', () => {
 
 describe('hex', () => {
   test('default', () => {
+    expect(trim('0x1')).toMatchInlineSnapshot('"0x01"')
+    expect(trim('0x01')).toMatchInlineSnapshot('"0x01"')
+    expect(trim('0x001')).toMatchInlineSnapshot('"0x01"')
+    expect(trim('0x0001')).toMatchInlineSnapshot('"0x01"')
+
     expect(
       trim(
         '0x0000000000000000000000000000000000000000000000000000000000000001',
       ),
-    ).toMatchInlineSnapshot('"0x1"')
+    ).toMatchInlineSnapshot('"0x01"')
+
+    expect(
+      trim(
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      ),
+    ).toMatchInlineSnapshot('"0x01"')
 
     expect(
       trim(
@@ -53,7 +64,10 @@ describe('hex', () => {
       trim(
         '0x00000000000000000000000000000000000000000000000000000001a4e12a45',
       ),
-    ).toMatchInlineSnapshot('"0x1a4e12a45"')
+    ).toMatchInlineSnapshot('"0x01a4e12a45"')
+
+    expect(trim('0x00012340')).toMatchInlineSnapshot('"0x012340"')
+    expect(trim('0x00102340')).toMatchInlineSnapshot('"0x102340"')
   })
 
   test('args: dir', () => {
@@ -76,7 +90,7 @@ describe('hex', () => {
         '0x1a4e12a450000000000000000000000000000000000000000000000000000000',
         { dir: 'right' },
       ),
-    ).toMatchInlineSnapshot('"0x1a4e12a45"')
+    ).toMatchInlineSnapshot('"0x01a4e12a45"')
   })
 })
 

--- a/src/utils/data/trim.ts
+++ b/src/utils/data/trim.ts
@@ -27,7 +27,9 @@ export function trim<TValue extends ByteArray | Hex>(
 
   if (typeof hexOrBytes === 'string') {
     if (data.length === 1 && dir === 'right') data = `${data}0`
-    return `0x${data}` as TrimReturnType<TValue>
+    return `0x${
+      data.length % 2 === 1 ? `0${data}` : data
+    }` as TrimReturnType<TValue>
   }
   return data as TrimReturnType<TValue>
 }

--- a/src/utils/encoding/fromHex.ts
+++ b/src/utils/encoding/fromHex.ts
@@ -140,7 +140,7 @@ export type HexToBoolOpts = {
  *
  * @example
  * import { hexToBool } from 'viem'
- * const data = hexToBool('0x1')
+ * const data = hexToBool('0x01')
  * // true
  *
  * @example
@@ -154,8 +154,8 @@ export function hexToBool(hex_: Hex, opts: HexToBoolOpts = {}): boolean {
     assertSize(hex, { size: opts.size })
     hex = trim(hex)
   }
-  if (trim(hex) === '0x0') return false
-  if (trim(hex) === '0x1') return true
+  if (trim(hex) === '0x00') return false
+  if (trim(hex) === '0x01') return true
   throw new InvalidHexBooleanError(hex)
 }
 

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../types/transaction.js'
 import { isAddress } from '../address/isAddress.js'
 import { concatHex } from '../data/concat.js'
+import { trim } from '../data/trim.js'
 import { toHex } from '../encoding/toHex.js'
 import { type RecursiveArray, toRlp } from '../encoding/toRlp.js'
 
@@ -97,8 +98,8 @@ function serializeTransactionEIP1559(
   if (signature)
     serializedTransaction.push(
       signature.v === 27n ? '0x' : toHex(1), // yParity
-      signature.r,
-      signature.s,
+      trim(signature.r),
+      trim(signature.s),
     )
 
   return concatHex([


### PR DESCRIPTION
Fixes #524.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `trim` function in `viem` to trim trailing zero byte data instead of all trailing zeros. It also updates related code to use the new behavior. 

### Detailed summary
- `trim` function now trims trailing zero byte data instead of all trailing zeros
- `getEnsAddress` and `hexToBool` functions updated to use new `trim` behavior
- `serializeTransactionEIP1559` function imports `trim` from `data/trim.js`
- `trim` function test cases updated to reflect new behavior
- Documentation for `trim` function updated to reflect new behavior

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->