### PR TITLE
docs: fix getTransactionReceipt TransactionReceipt Type link

### DIFF
--- a/site/docs/actions/public/getTransactionReceipt.md
+++ b/site/docs/actions/public/getTransactionReceipt.md
@@ -14,7 +14,7 @@ head:
 
 # getTransactionReceipt
 
-Returns the [Transaction Receipt](/docs/glossary/terms#transaction-receipt) given a [Transaction](/docs/glossary/terms#transaction) hash.
+Returns the [Transaction Receipt](/docs/glossary/terms#transactionreceipt) given a [Transaction](/docs/glossary/terms#transaction) hash.
 
 ## Usage
 


### PR DESCRIPTION
the correct url is https://viem.sh/docs/glossary/types.html#transactionreceipt, without the dash