### PR TITLE
feat: proxy packages

### DIFF
--- a/.changeset/slow-ears-attack.md
+++ b/.changeset/slow-ears-attack.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added proxy packages to support bundlers that are not compatible with `package.json#exports`.

--- a/scripts/prepublishOnly.ts
+++ b/scripts/prepublishOnly.ts
@@ -1,5 +1,9 @@
-import { readJsonSync, writeJsonSync } from 'fs-extra'
+import { outputFileSync, readJsonSync, writeJsonSync } from 'fs-extra'
 import path from 'path'
+
+type Exports = {
+  [key: string]: string | { types?: string; import: string; default: string }
+}
 
 generatePackageJson()
 
@@ -31,6 +35,34 @@ function generatePackageJson() {
     authors,
     keywords,
   } = tmpPackageJson
+
+  // Generate proxy packages for each export.
+  const files_ = [...files]
+  for (const [key, value] of Object.entries(exports_ as Exports)) {
+    if (typeof value === 'string') continue
+    if (key === '.') continue
+    if (!value.default || !value.import)
+      throw new Error('`default` and `import` are required.')
+
+    outputFileSync(
+      `${key}/package.json`,
+      `{
+  ${Object.entries(value)
+    .map(([k, v]) => {
+      const key = (() => {
+        if (k === 'import') return 'module'
+        if (k === 'default') return 'main'
+        if (k === 'types') return 'types'
+        throw new Error('Invalid key')
+      })()
+      return `"${key}": "${v.replace('./', '../')}"`
+    })
+    .join(',\n  ')}
+}`,
+    )
+    files_.push(key.replace('./', ''))
+  }
+
   writeJsonSync(
     packageJsonPath,
     {
@@ -39,7 +71,7 @@ function generatePackageJson() {
       dependencies,
       peerDependencies,
       version,
-      files,
+      files: files_,
       exports: exports_,
       // type,
       main,


### PR DESCRIPTION
Some bundlers (Parcel, Metro, Webpack 4, etc) do not support `package.json#exports`. Would be nice to be compatible with them if folks do not want to migrate to a different bundler, or migration effort is too much.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds proxy packages to support bundlers that do not work with `package.json#exports`.

### Detailed summary
- Added proxy packages for each export
- Generates a package.json with only necessary fields
- Replaces `files` with `files_` to include proxy packages
- Supports bundlers not compatible with `package.json#exports`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->