### PR TITLE
fix: allow recovery id as v when recovering public key

### DIFF
--- a/src/utils/signature/recoverPublicKey.test.ts
+++ b/src/utils/signature/recoverPublicKey.test.ts
@@ -48,4 +48,20 @@ test('default', async () => {
       ),
     }),
   ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
+
+  expect(
+    await recoverPublicKey({
+      hash: hashMessage('hello world'),
+      signature:
+        '0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b00',
+    }),
+  ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
+
+  expect(
+    await recoverPublicKey({
+      hash: '0x9a74cb859ad30835ffb2da406423233c212cf6dd78e6c2c98b0c9289568954ae',
+      signature:
+        '0xc4d8bcda762d35ea79d9542b23200f46c2c1899db15bf929bbacaf609581db0831538374a01206517edd934e474212a0f1e2d62e9a01cd64f1cf94ea2e09884901',
+    }),
+  ).toEqual(privateKeyToAccount(accounts[0].privateKey).publicKey)
 })

--- a/src/utils/signature/recoverPublicKey.ts
+++ b/src/utils/signature/recoverPublicKey.ts
@@ -18,7 +18,8 @@ export async function recoverPublicKey({
 
   // Derive v = recoveryId + 27 from end of the signature (27 is added when signing the message)
   // The recoveryId represents the y-coordinate on the secp256k1 elliptic curve and can have a value [0, 1].
-  const v = hexToNumber(`0x${signatureHex.slice(130)}`)
+  let v = hexToNumber(`0x${signatureHex.slice(130)}`)
+  if (v === 0 || v === 1) v += 27
 
   const { secp256k1 } = await import('@noble/curves/secp256k1')
   const publicKey = secp256k1.Signature.fromCompact(


### PR DESCRIPTION
Fixes #537

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a check to ensure the recoveryId is within a valid range, and updates the `recoverPublicKey` function to accept a hash instead of a message. 

### Detailed summary
- Added a check to ensure the recoveryId is within a valid range
- Updated `recoverPublicKey` function to accept a hash instead of a message

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->