### PR TITLE
Use static value for constant gwei default tip

### DIFF
--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -17,7 +17,6 @@ import { AccountNotFoundError } from '../../errors/account.js'
 import { BaseError } from '../../errors/base.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type { Chain } from '../../types/chain.js'
-import { parseGwei } from '../unit/parseGwei.js'
 
 import { assertRequest } from './assertRequest.js'
 
@@ -43,7 +42,7 @@ export type PrepareRequestReturnType<
   nonce: SendTransactionParameters['nonce']
 }
 
-export const defaultTip = parseGwei('1.5')
+export const defaultTip = 1500000000n // 1.5 gwei
 
 export async function prepareRequest<
   TChain extends Chain | undefined,

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -42,7 +42,7 @@ export type PrepareRequestReturnType<
   nonce: SendTransactionParameters['nonce']
 }
 
-export const defaultTip = 1500000000n // 1.5 gwei
+export const defaultTip = 1_500_000_000n // 1.5 gwei
 
 export async function prepareRequest<
   TChain extends Chain | undefined,


### PR DESCRIPTION
This pre-compiles 1.5 gwei into a bigint so `parseGwei` isn't called on every startup

<!-- start pr-codex -->

---

## PR-Codex overview
This PR replaces the `parseGwei` function with a hard-coded value in `prepareRequest.ts` for efficiency.

### Detailed summary
- Replaced `parseGwei` function with hard-coded value for `defaultTip`
- Improves efficiency of `prepareRequest` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->