### PR TITLE
refactor: eip1193 request types

### DIFF
--- a/.changeset/wild-toys-kiss.md
+++ b/.changeset/wild-toys-kiss.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Refactored EIP1193 request fn types.

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -208,7 +208,7 @@ async function scheduleMulticall<TChain extends Chain | undefined>(
   args: ScheduleMulticallParameters<TChain>,
 ) {
   const { batchSize = 1024, wait = 0 } =
-    typeof client.batch?.multicall === 'object' ? client.batch?.multicall : {}
+    typeof client.batch?.multicall === 'object' ? client.batch.multicall : {}
   const {
     blockNumber,
     blockTag = 'latest',

--- a/src/actions/public/createContractEventFilter.test.ts
+++ b/src/actions/public/createContractEventFilter.test.ts
@@ -6,11 +6,10 @@ import { createHttpServer, publicClient } from '../../_test/utils.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { fallback } from '../../clients/transports/fallback.js'
 import { http } from '../../clients/transports/http.js'
-import type { Requests } from '../../types/eip1193.js'
-
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import { createContractEventFilter } from './createContractEventFilter.js'
 
-const request = (() => {}) as unknown as Requests['request']
+const request = (() => {}) as unknown as EIP1193RequestFn
 
 test('default', async () => {
   const filter = await createContractEventFilter(publicClient, {

--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -5,8 +5,7 @@ import { createHttpServer, publicClient } from '../../_test/utils.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { fallback } from '../../clients/transports/fallback.js'
 import { http } from '../../clients/transports/http.js'
-import type { Requests } from '../../types/eip1193.js'
-
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import { createEventFilter } from './createEventFilter.js'
 
 const event = {
@@ -51,7 +50,7 @@ const event = {
   },
 } as const
 
-const request = (() => {}) as unknown as Requests['request']
+const request = (() => {}) as unknown as EIP1193RequestFn
 
 describe('default', () => {
   test('no args', async () => {

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -135,7 +135,7 @@ export async function estimateGas<
       },
     )
 
-    const balance = await client.request({
+    const balance = await (client as PublicClient).request({
       method: 'eth_estimateGas',
       params: block ? [request, block] : [request],
     })

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -89,12 +89,12 @@ export async function getBlock<
 
   let block: RpcBlock | null = null
   if (blockHash) {
-    block = await client.request({
+    block = await (client as PublicClient).request({
       method: 'eth_getBlockByHash',
       params: [blockHash, includeTransactions],
     })
   } else {
-    block = await client.request({
+    block = await (client as PublicClient).request({
       method: 'eth_getBlockByNumber',
       params: [blockNumberHex || blockTag, includeTransactions],
     })

--- a/src/actions/public/getBlockTransactionCount.ts
+++ b/src/actions/public/getBlockTransactionCount.ts
@@ -65,7 +65,7 @@ export async function getBlockTransactionCount<
   const blockNumberHex =
     blockNumber !== undefined ? numberToHex(blockNumber) : undefined
 
-  let count: Quantity | null = null
+  let count: Quantity
   if (blockHash) {
     count = await client.request({
       method: 'eth_getBlockTransactionCountByHash',

--- a/src/actions/public/getChainId.ts
+++ b/src/actions/public/getChainId.ts
@@ -36,6 +36,8 @@ export async function getChainId<
     | PublicClient<Transport, TChain>
     | WalletClient<Transport, TChain, TAccount>,
 ): Promise<GetChainIdReturnType> {
-  const chainIdHex = await client.request({ method: 'eth_chainId' })
+  const chainIdHex = await (client as PublicClient).request({
+    method: 'eth_chainId',
+  })
   return hexToNumber(chainIdHex)
 }

--- a/src/actions/public/getGasPrice.ts
+++ b/src/actions/public/getGasPrice.ts
@@ -34,7 +34,7 @@ export async function getGasPrice<
     | PublicClient<Transport, TChain>
     | WalletClient<Transport, TChain, TAccount>,
 ): Promise<GetGasPriceReturnType> {
-  const gasPrice = await client.request({
+  const gasPrice = await (client as PublicClient).request({
     method: 'eth_gasPrice',
   })
   return BigInt(gasPrice)

--- a/src/actions/public/getTransactionCount.ts
+++ b/src/actions/public/getTransactionCount.ts
@@ -58,7 +58,7 @@ export async function getTransactionCount<
     | WalletClient<Transport, TChain, TAccount>,
   { address, blockTag = 'latest', blockNumber }: GetTransactionCountParameters,
 ): Promise<GetTransactionCountReturnType> {
-  const count = await client.request({
+  const count = await (client as PublicClient).request({
     method: 'eth_getTransactionCount',
     params: [address, blockNumber ? numberToHex(blockNumber) : blockTag],
   })

--- a/src/actions/public/uninstallFilter.test.ts
+++ b/src/actions/public/uninstallFilter.test.ts
@@ -2,17 +2,16 @@ import { assertType, expect, test } from 'vitest'
 
 import { accounts } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
-import type { Requests } from '../../types/eip1193.js'
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import type { Hash } from '../../types/misc.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
-
 import { createPendingTransactionFilter } from './createPendingTransactionFilter.js'
 import { getFilterChanges } from './getFilterChanges.js'
 import { uninstallFilter } from './uninstallFilter.js'
 
-const request = (() => {}) as unknown as Requests['request']
+const request = (() => {}) as unknown as EIP1193RequestFn
 
 test('default', async () => {
   const filter = await createPendingTransactionFilter(publicClient)

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -2,8 +2,7 @@ import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { localWsUrl } from '../_test/constants.js'
 import { localhost } from '../chains.js'
-import type { Requests } from '../types/eip1193.js'
-
+import type { EIP1193RequestFn, EIP1474Methods } from '../types/eip1193.js'
 import { createClient } from './createClient.js'
 import { createTransport } from './transports/createTransport.js'
 import { custom } from './transports/custom.js'
@@ -15,14 +14,16 @@ test('creates', () => {
     createTransport({
       key: 'mock',
       name: 'Mock Transport',
-      request: vi.fn(async () => null) as unknown as Requests['request'],
+      request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
       type: 'mock',
     })
   const { uid, ...client } = createClient({
     transport: mockTransport,
   })
 
-  assertType<Requests['request']>(client.request)
+  assertType<EIP1193RequestFn<EIP1474Methods, { Strict: false }>>(
+    client.request,
+  )
 
   expect(uid).toBeDefined()
   expect(client).toMatchInlineSnapshot(`
@@ -182,7 +183,7 @@ describe('config', () => {
       createTransport({
         key: 'mock',
         name: 'Mock Transport',
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
         type: 'mock',
       })
     const { uid, ...client } = createClient({
@@ -190,7 +191,9 @@ describe('config', () => {
       transport: mockTransport,
     })
 
-    assertType<Requests['request']>(client.request)
+    assertType<EIP1193RequestFn<EIP1474Methods, { Strict: false }>>(
+      client.request,
+    )
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
@@ -218,7 +221,7 @@ describe('config', () => {
       createTransport({
         key: 'mock',
         name: 'Mock Transport',
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
         type: 'mock',
       })
     const { uid, ...client } = createClient({
@@ -226,7 +229,9 @@ describe('config', () => {
       transport: mockTransport,
     })
 
-    assertType<Requests['request']>(client.request)
+    assertType<EIP1193RequestFn<EIP1474Methods, { Strict: false }>>(
+      client.request,
+    )
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
@@ -254,7 +259,7 @@ describe('config', () => {
       createTransport({
         key: 'mock',
         name: 'Mock Transport',
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
         type: 'mock',
       })
     const { uid, ...client } = createClient({
@@ -262,7 +267,9 @@ describe('config', () => {
       transport: mockTransport,
     })
 
-    assertType<Requests['request']>(client.request)
+    assertType<EIP1193RequestFn<EIP1474Methods, { Strict: false }>>(
+      client.request,
+    )
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {
@@ -290,7 +297,7 @@ describe('config', () => {
       createTransport({
         key: 'mock',
         name: 'Mock Transport',
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
         type: 'mock',
       })
     const { uid, ...client } = createClient({
@@ -298,7 +305,9 @@ describe('config', () => {
       type: 'foo',
     })
 
-    assertType<Requests['request']>(client.request)
+    assertType<EIP1193RequestFn<EIP1474Methods, { Strict: false }>>(
+      client.request,
+    )
     expect(uid).toBeDefined()
     expect(client).toMatchInlineSnapshot(`
       {

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -1,11 +1,11 @@
 import type { Chain } from '../types/chain.js'
-import type { Requests } from '../types/eip1193.js'
-import { uid } from '../utils/uid.js'
-
 import type {
-  BaseRpcRequests,
-  Transport,
-} from './transports/createTransport.js'
+  EIP1193RequestFn,
+  EIP1474Methods,
+  RpcSchema,
+} from '../types/eip1193.js'
+import { uid } from '../utils/uid.js'
+import type { Transport } from './transports/createTransport.js'
 
 export type ClientConfig<
   TTransport extends Transport = Transport,
@@ -30,7 +30,7 @@ export type ClientConfig<
 
 export type Client<
   TTransport extends Transport = Transport,
-  TRequests extends BaseRpcRequests = Requests,
+  TRpcSchema extends RpcSchema | undefined = undefined,
   TChain extends Chain | undefined = Chain | undefined,
 > = {
   /** Chain for the client. */
@@ -42,7 +42,9 @@ export type Client<
   /** Frequency (in ms) for polling enabled actions & events. Defaults to 4_000 milliseconds. */
   pollingInterval: number
   /** Request function wrapped with friendly error handling */
-  request: TRequests['request']
+  request: TRpcSchema extends undefined
+    ? EIP1193RequestFn<EIP1474Methods>
+    : EIP1193RequestFn<TRpcSchema, { Strict: true }>
   /** The RPC transport */
   transport: ReturnType<TTransport>['config'] & ReturnType<TTransport>['value']
   /** The type of client. */
@@ -56,7 +58,7 @@ export type Client<
  */
 export function createClient<
   TTransport extends Transport,
-  TRequests extends BaseRpcRequests,
+  TRpcSchema extends RpcSchema | undefined = undefined,
   TChain extends Chain | undefined = undefined,
 >({
   chain,
@@ -65,14 +67,14 @@ export function createClient<
   pollingInterval = 4_000,
   transport,
   type = 'base',
-}: ClientConfig<TTransport, TChain>): Client<TTransport, TRequests, TChain> {
+}: ClientConfig<TTransport, TChain>): Client<TTransport, TRpcSchema, TChain> {
   const { config, request, value } = transport({ chain, pollingInterval })
   return {
     chain: chain as TChain,
     key,
     name,
     pollingInterval,
-    request,
+    request: request as any,
     transport: { ...config, ...value },
     type,
     uid: uid(),

--- a/src/clients/createPublicClient.test.ts
+++ b/src/clients/createPublicClient.test.ts
@@ -2,8 +2,7 @@ import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { localWsUrl } from '../_test/constants.js'
 import { localhost } from '../chains.js'
-import type { PublicRequests } from '../types/eip1193.js'
-
+import type { EIP1193RequestFn, PublicRpcSchema } from '../index.js'
 import { createPublicClient } from './createPublicClient.js'
 import { createTransport } from './transports/createTransport.js'
 import { custom } from './transports/custom.js'
@@ -23,7 +22,9 @@ test('creates', () => {
     transport: mockTransport,
   })
 
-  assertType<PublicRequests['request']>(client.request)
+  assertType<EIP1193RequestFn<PublicRpcSchema, { Strict: true }>>(
+    client.request,
+  )
 
   expect(uid).toBeDefined()
   expect(client).toMatchInlineSnapshot(`

--- a/src/clients/createPublicClient.ts
+++ b/src/clients/createPublicClient.ts
@@ -1,7 +1,6 @@
 import type { Chain } from '../types/chain.js'
-import type { PublicRequests } from '../types/eip1193.js'
+import type { PublicRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
-
 import { type Client, type ClientConfig, createClient } from './createClient.js'
 import { type PublicActions, publicActions } from './decorators/public.js'
 import type { Transport } from './transports/createTransport.js'
@@ -32,7 +31,7 @@ export type PublicClient<
   TChain extends Chain | undefined = Chain | undefined,
   TIncludeActions extends boolean = true,
 > = Prettify<
-  Client<TTransport, PublicRequests, TChain> &
+  Client<TTransport, PublicRpcSchema, TChain> &
     Pick<PublicClientConfig, 'batch'> &
     (TIncludeActions extends true ? PublicActions<TTransport, TChain> : unknown)
 >

--- a/src/clients/createTestClient.test.ts
+++ b/src/clients/createTestClient.test.ts
@@ -2,8 +2,8 @@ import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { localWsUrl } from '../_test/constants.js'
 import { localhost } from '../chains.js'
-import type { TestRequests } from '../types/eip1193.js'
 
+import { type EIP1193RequestFn, type TestRpcSchema } from '../index.js'
 import { createTestClient } from './createTestClient.js'
 import { createTransport } from './transports/createTransport.js'
 import { http } from './transports/http.js'
@@ -23,7 +23,9 @@ test('creates', () => {
     transport: mockTransport,
   })
 
-  assertType<TestRequests<'anvil'>['request']>(client.request)
+  assertType<EIP1193RequestFn<TestRpcSchema<'anvil'>, { Strict: true }>>(
+    client.request,
+  )
   expect(uid).toBeDefined()
   expect(client).toMatchInlineSnapshot(`
     {

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -1,6 +1,5 @@
 import type { Chain } from '../types/chain.js'
-import type { TestRequests } from '../types/eip1193.js'
-
+import type { TestRpcSchema } from '../types/eip1193.js'
 import { type Client, type ClientConfig, createClient } from './createClient.js'
 import { type TestActions, testActions } from './decorators/test.js'
 import type { Transport } from './transports/createTransport.js'
@@ -24,7 +23,7 @@ export type TestClient<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain | undefined,
   TIncludeActions extends boolean = true,
-> = Client<TTransport, TestRequests<TMode>, TChain> &
+> = Client<TTransport, TestRpcSchema<TMode>, TChain> &
   (TIncludeActions extends true ? TestActions : unknown) & {
     mode: TMode
   }

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -4,8 +4,7 @@ import { accounts, localWsUrl } from '../_test/constants.js'
 import { privateKeyToAccount } from '../accounts/privateKeyToAccount.js'
 import type { JsonRpcAccount, PrivateKeyAccount } from '../accounts/types.js'
 import { localhost } from '../chains.js'
-import type { SignableRequests, WalletRequests } from '../types/eip1193.js'
-
+import type { EIP1193RequestFn, WalletRpcSchema } from '../types/eip1193.js'
 import { createWalletClient } from './createWalletClient.js'
 import { createTransport } from './transports/createTransport.js'
 import { custom } from './transports/custom.js'
@@ -23,7 +22,7 @@ const mockTransport = () =>
 test('creates', () => {
   const { uid, ...client } = createWalletClient({ transport: mockTransport })
 
-  assertType<SignableRequests['request'] & WalletRequests['request']>(
+  assertType<EIP1193RequestFn<WalletRpcSchema, { Strict: true }>>(
     client.request,
   )
   assertType<{

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -3,9 +3,8 @@ import type { Address } from 'abitype'
 import type { Account, JsonRpcAccount } from '../accounts/types.js'
 import { parseAccount } from '../accounts/utils/parseAccount.js'
 import type { Chain } from '../types/chain.js'
-import type { Requests } from '../types/eip1193.js'
+import type { WalletRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
-
 import { type Client, type ClientConfig, createClient } from './createClient.js'
 import { type WalletActions, walletActions } from './decorators/wallet.js'
 import type { Transport } from './transports/createTransport.js'
@@ -31,7 +30,7 @@ export type WalletClient<
   TAccount extends Account | undefined = Account | undefined,
   TIncludeActions extends boolean = true,
 > = Prettify<
-  Client<TTransport, Requests, TChain> &
+  Client<TTransport, WalletRpcSchema, TChain> &
     (TIncludeActions extends true
       ? WalletActions<TChain, TAccount>
       : unknown) & {

--- a/src/clients/transports/createTransport.test.ts
+++ b/src/clients/transports/createTransport.test.ts
@@ -1,14 +1,13 @@
 import { assertType, expect, test, vi } from 'vitest'
 
-import type { Requests } from '../../types/eip1193.js'
-
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import { createTransport } from './createTransport.js'
 
 test('default', () => {
   const transport = createTransport({
     key: 'mock',
     name: 'Mock Transport',
-    request: vi.fn(async () => null) as unknown as Requests['request'],
+    request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
     type: 'mock',
   })
 
@@ -36,7 +35,7 @@ test('value', () => {
     {
       key: 'mock',
       name: 'Mock Transport',
-      request: vi.fn(async () => null) as unknown as Requests['request'],
+      request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
       type: 'mock',
     },
     {

--- a/src/clients/transports/createTransport.ts
+++ b/src/clients/transports/createTransport.ts
@@ -1,22 +1,18 @@
 import type { Chain } from '../../types/chain.js'
-import type { Requests } from '../../types/eip1193.js'
+import type { EIP1193RequestFn } from '../../types/eip1193.js'
 import { buildRequest } from '../../utils/buildRequest.js'
 import type { ClientConfig } from '../createClient.js'
 
-export type BaseRpcRequests = {
-  request(...args: any): Promise<any>
-}
-
 export type TransportConfig<
   TType extends string = string,
-  TRequests extends BaseRpcRequests['request'] = Requests['request'],
+  TEIP1193RequestFn extends EIP1193RequestFn = EIP1193RequestFn,
 > = {
   /** The name of the transport. */
   name: string
   /** The key of the transport. */
   key: string
   /** The JSON-RPC request function that matches the EIP-1193 request spec. */
-  request: TRequests
+  request: TEIP1193RequestFn
   /** The base delay (in ms) between retries. */
   retryDelay?: number
   /** The max number of times to retry. */
@@ -30,7 +26,7 @@ export type TransportConfig<
 export type Transport<
   TType extends string = string,
   TRpcAttributes = Record<string, any>,
-  TRequests extends BaseRpcRequests['request'] = Requests['request'],
+  TEIP1193RequestFn extends EIP1193RequestFn = EIP1193RequestFn,
 > = <TChain extends Chain | undefined = Chain>({
   chain,
 }: {
@@ -40,7 +36,7 @@ export type Transport<
   timeout?: TransportConfig['timeout']
 }) => {
   config: TransportConfig<TType>
-  request: TRequests
+  request: TEIP1193RequestFn
   value?: TRpcAttributes
 }
 

--- a/src/clients/transports/custom.test.ts
+++ b/src/clients/transports/custom.test.ts
@@ -1,7 +1,6 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
-import type { Requests } from '../../types/eip1193.js'
-
+import type { EIP1193RequestFn } from '../../index.js'
 import '../../types/window.js'
 import { type CustomTransport, custom } from './custom.js'
 
@@ -15,7 +14,7 @@ vi.stubGlobal('window', {
 
 test('default', () => {
   const transport = custom({
-    request: vi.fn(async () => null) as unknown as Requests['request'],
+    request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
   })
 
   assertType<CustomTransport>(transport)
@@ -62,7 +61,7 @@ describe('config', () => {
   test('key', () => {
     const transport = custom(
       {
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
       },
       { key: 'mock' },
     )({})
@@ -87,7 +86,7 @@ describe('config', () => {
   test('name', () => {
     const transport = custom(
       {
-        request: vi.fn(async () => null) as unknown as Requests['request'],
+        request: vi.fn(async () => null) as unknown as EIP1193RequestFn,
       },
       {
         name: 'Mock Transport',

--- a/src/clients/transports/custom.ts
+++ b/src/clients/transports/custom.ts
@@ -1,11 +1,10 @@
 import {
-  type BaseRpcRequests,
   type Transport,
   type TransportConfig,
   createTransport,
 } from './createTransport.js'
 
-type EthereumProvider = { request: BaseRpcRequests['request'] }
+type EthereumProvider = { request(...args: any): Promise<any> }
 
 export type CustomTransportConfig = {
   /** The key of the transport. */

--- a/src/clients/transports/fallback.ts
+++ b/src/clients/transports/fallback.ts
@@ -102,7 +102,7 @@ export function fallback(
         key,
         name,
         async request({ method, params }) {
-          const fetch = async (i: number = 0): Promise<any> => {
+          const fetch = async (i = 0): Promise<any> => {
             const transport = transports[i]({ chain, retryCount: 0, timeout })
             try {
               const response = await transport.request({

--- a/src/index.ts
+++ b/src/index.ts
@@ -441,19 +441,21 @@ export {
 } from './types/misc.js'
 export type { Chain } from './types/chain.js'
 export type {
+  AddEthereumChainParameter,
   EIP1193Provider,
+  EIP1193RequestFn,
+  EIP1474Methods,
   ProviderRpcError as EIP1193ProviderRpcError,
   ProviderConnectInfo,
   ProviderMessage,
-  AddEthereumChainParameter,
+  PublicRpcSchema,
   NetworkSync,
-  PublicRequests,
-  Requests,
-  SignableRequests,
+  RpcSchema,
+  TestRpcSchema,
   WatchAssetParams,
   WalletPermissionCaveat,
   WalletPermission,
-  WalletRequests,
+  WalletRpcSchema,
 } from './types/eip1193.js'
 export {
   type FeeHistory,

--- a/src/types/eip1193.test-d.ts
+++ b/src/types/eip1193.test-d.ts
@@ -1,0 +1,278 @@
+import type {
+  EIP1193RequestFn,
+  PublicRpcSchema,
+  TestRpcSchema,
+  WalletRpcSchema,
+} from './eip1193.js'
+import type { Hash, Hex } from './misc.js'
+import type { Quantity, RpcLog, RpcTransaction } from './rpc.js'
+import type { Address } from 'abitype'
+import { expectTypeOf, test } from 'vitest'
+
+test('default', async () => {
+  type Default = EIP1193RequestFn
+
+  const request: Default = null as any
+
+  const x = await request({ method: 'eth_wagmi' })
+  expectTypeOf<typeof x>().toEqualTypeOf<unknown>()
+
+  request({ method: 'eth_wagmi', params: undefined })
+  request({ method: 'eth_wagmi', params: [] })
+  request({ method: 'eth_wagmi', params: [{ foo: 'bar' }] })
+
+  expectTypeOf<Parameters<Default>[0]>().toEqualTypeOf<
+    { method: string } & ({ params: unknown } | { params?: unknown })
+  >()
+  expectTypeOf<ReturnType<Default>>().toEqualTypeOf<Promise<unknown>>()
+})
+
+test('public methods', async () => {
+  type Public = EIP1193RequestFn<PublicRpcSchema, { Strict: false }>
+
+  const request: Public = null as any
+
+  const x1 = await request({ method: 'eth_blockNumber' })
+  expectTypeOf<typeof x1>().toEqualTypeOf<Quantity>()
+
+  const x2 = await request({
+    method: 'eth_newFilter',
+    params: [{ address: '0x', fromBlock: '0x', toBlock: '0x', topics: ['0x'] }],
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<Quantity>()
+
+  const x3 = await request({
+    method: 'eth_getLogs',
+    params: [{ address: '0x', fromBlock: '0x', toBlock: '0x', topics: ['0x'] }],
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<RpcLog[]>()
+
+  // @ts-expect-error
+  request({ method: 'eth_newFilter' })
+  request({ method: 'eth_wagmi' })
+  request({ method: 'eth_wagmi', params: undefined })
+  request({ method: 'eth_wagmi', params: [] })
+  request({ method: 'eth_wagmi', params: [{ foo: 'bar' }] })
+
+  expectTypeOf<Parameters<Public>[0]['method']>().toEqualTypeOf<
+    PublicRpcSchema[number]['Method'] | (string & {})
+  >()
+})
+
+test('public methods (strict)', async () => {
+  type PublicStrict = EIP1193RequestFn<PublicRpcSchema, { Strict: true }>
+
+  const request: PublicStrict = null as any
+
+  const x1 = await request({ method: 'eth_blockNumber' })
+  expectTypeOf<typeof x1>().toEqualTypeOf<Quantity>()
+
+  const x2 = await request({
+    method: 'eth_newFilter',
+    params: [{ address: '0x', fromBlock: '0x', toBlock: '0x', topics: ['0x'] }],
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<Quantity>()
+
+  const x3 = await request({
+    method: 'eth_getLogs',
+    params: [{ address: '0x', fromBlock: '0x', toBlock: '0x', topics: ['0x'] }],
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<RpcLog[]>()
+
+  // @ts-expect-error
+  request({ method: 'eth_newFilter' })
+  // @ts-expect-error
+  request({ method: 'eth_wagmi' })
+
+  expectTypeOf<Parameters<PublicStrict>[0]['method']>().toEqualTypeOf<
+    PublicRpcSchema[number]['Method']
+  >()
+})
+
+test('wallet methods', async () => {
+  type Wallet = EIP1193RequestFn<WalletRpcSchema>
+
+  const request: Wallet = null as any
+
+  const x1 = await request({ method: 'eth_accounts' })
+  expectTypeOf<typeof x1>().toEqualTypeOf<Address[]>()
+
+  const x2 = await request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        from: '0x',
+      },
+    ],
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<Hash>()
+
+  const x3 = await request({
+    method: 'personal_sign',
+    params: ['0x', '0x'],
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<Hex>()
+
+  // @ts-expect-error
+  request({ method: 'eth_sendTransaction' })
+  request({ method: 'eth_wagmi' })
+  request({ method: 'eth_wagmi', params: undefined })
+  request({ method: 'eth_wagmi', params: [] })
+  request({ method: 'eth_wagmi', params: [{ foo: 'bar' }] })
+
+  expectTypeOf<Parameters<Wallet>[0]['method']>().toEqualTypeOf<
+    WalletRpcSchema[number]['Method'] | (string & {})
+  >()
+})
+
+test('wallet methods (strict)', async () => {
+  type Wallet = EIP1193RequestFn<WalletRpcSchema, { Strict: true }>
+
+  const request: Wallet = null as any
+
+  const x1 = await request({ method: 'eth_accounts' })
+  expectTypeOf<typeof x1>().toEqualTypeOf<Address[]>()
+
+  const x2 = await request({
+    method: 'eth_sendTransaction',
+    params: [
+      {
+        from: '0x',
+      },
+    ],
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<Hash>()
+
+  const x3 = await request({
+    method: 'personal_sign',
+    params: ['0x', '0x'],
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<Hex>()
+
+  // @ts-expect-error
+  request({ method: 'eth_sendTransaction' })
+  // @ts-expect-error
+  request({ method: 'eth_wagmi' })
+
+  expectTypeOf<Parameters<Wallet>[0]['method']>().toEqualTypeOf<
+    WalletRpcSchema[number]['Method']
+  >()
+})
+
+test('test methods', async () => {
+  type Test = EIP1193RequestFn<TestRpcSchema<'anvil'>, { Strict: false }>
+
+  const request: Test = null as any
+
+  const x1 = await request({
+    method: 'anvil_addCompilationResult',
+    params: [1],
+  })
+  expectTypeOf<typeof x1>().toEqualTypeOf<any>()
+
+  const x2 = await request({
+    method: 'anvil_enableTraces',
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<void>()
+
+  const x3 = await request({
+    method: 'txpool_content',
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<{
+    pending: Record<`0x${string}`, Record<string, RpcTransaction>>
+    queued: Record<`0x${string}`, Record<string, RpcTransaction>>
+  }>()
+
+  // @ts-expect-error
+  request({ method: 'anvil_addCompilationResult' })
+  request({ method: 'eth_wagmi' })
+  request({ method: 'eth_wagmi', params: undefined })
+  request({ method: 'eth_wagmi', params: [] })
+  request({ method: 'eth_wagmi', params: [{ foo: 'bar' }] })
+
+  expectTypeOf<Parameters<Test>[0]['method']>().toEqualTypeOf<
+    TestRpcSchema<'anvil'>[number]['Method'] | (string & {})
+  >()
+})
+
+test('test methods (strict)', async () => {
+  type Test = EIP1193RequestFn<TestRpcSchema<'anvil'>, { Strict: true }>
+
+  const request: Test = null as any
+
+  const x1 = await request({
+    method: 'anvil_addCompilationResult',
+    params: [1],
+  })
+  expectTypeOf<typeof x1>().toEqualTypeOf<any>()
+
+  const x2 = await request({
+    method: 'anvil_enableTraces',
+  })
+  expectTypeOf<typeof x2>().toEqualTypeOf<void>()
+
+  const x3 = await request({
+    method: 'txpool_content',
+  })
+  expectTypeOf<typeof x3>().toEqualTypeOf<{
+    pending: Record<`0x${string}`, Record<string, RpcTransaction>>
+    queued: Record<`0x${string}`, Record<string, RpcTransaction>>
+  }>()
+
+  // @ts-expect-error
+  request({ method: 'anvil_addCompilationResult' })
+  // @ts-expect-error
+  request({ method: 'eth_wagmi' })
+
+  expectTypeOf<Parameters<Test>[0]['method']>().toEqualTypeOf<
+    TestRpcSchema<'anvil'>[number]['Method']
+  >()
+})
+
+test('custom methods', async () => {
+  type Custom = EIP1193RequestFn<
+    [
+      { Method: 'eth_wagmi'; Parameters: [number]; ReturnType: string },
+      { Method: 'eth_viem'; Parameters?: never; ReturnType: number },
+    ],
+    { Strict: false }
+  >
+
+  const request: Custom = null as any
+
+  const x = await request({ method: 'eth_wagmi', params: [1] })
+  expectTypeOf<typeof x>().toEqualTypeOf<string>()
+
+  // @ts-expect-error
+  request({ method: 'eth_wagmi' })
+  request({ method: 'eth_viem' })
+  request({ method: 'eth_lol' })
+
+  expectTypeOf<Parameters<Custom>[0]['method']>().toEqualTypeOf<
+    (string & {}) | 'eth_wagmi'
+  >()
+})
+
+test('custom methods (strict)', async () => {
+  type Custom = EIP1193RequestFn<
+    [
+      { Method: 'eth_wagmi'; Parameters: [number]; ReturnType: string },
+      { Method: 'eth_viem'; Parameters?: never; ReturnType: number },
+    ],
+    { Strict: true }
+  >
+
+  const request: Custom = null as any
+
+  const x = await request({ method: 'eth_wagmi', params: [1] })
+  expectTypeOf<typeof x>().toEqualTypeOf<string>()
+
+  // @ts-expect-error
+  request({ method: 'eth_wagmi' })
+  // @ts-expect-error
+  request({ method: 'eth_lol' })
+
+  expectTypeOf<Parameters<Custom>[0]['method']>().toEqualTypeOf<
+    'eth_wagmi' | 'eth_viem'
+  >()
+})

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -18,7 +18,11 @@ import type {
 //////////////////////////////////////////////////
 // Provider
 
-export type EIP1193Provider = Requests & Events
+export type EIP1474Methods = [...PublicRpcSchema, ...WalletRpcSchema]
+
+export type EIP1193Provider = Events & {
+  request: EIP1193RequestFn<EIP1474Methods, { Strict: false }>
+}
 
 //////////////////////////////////////////////////
 // Errors
@@ -134,130 +138,153 @@ export type WatchAssetParams = {
   }
 }
 
-export type PublicRequests = {
-  request(args: {
-    /**
-     * @description Returns the version of the current client
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'web3_clientVersion' })
-     * // => 'MetaMask/v1.0.0'
-     */
-    method: 'web3_clientVersion'
-    params?: never
-  }): Promise<string>
-  request(args: {
-    /**
-     * @description Hashes data using the Keccak-256 algorithm
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'web3_sha3', params: ['0x68656c6c6f20776f726c64'] })
-     * // => '0xc94770007dda54cF92009BFF0dE90c06F603a09f'
-     */
-    method: 'web3_sha3'
-    params: [data: Hash]
-  }): Promise<string>
-  request(args: {
-    /**
-     * @description Determines if this client is listening for new network connections
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'net_listening' })
-     * // => true
-     */
-    method: 'net_listening'
-    params?: never
-  }): Promise<boolean>
-  request(args: {
-    /**
-     * @description Returns the number of peers currently connected to this client
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'net_peerCount' })
-     * // => '0x1'
-     */
-    method: 'net_peerCount'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the chain ID associated with the current network
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'net_version' })
-     * // => '1'
-     */
-    method: 'net_version'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the number of the most recent block seen by this client
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_blockNumber' })
-     * // => '0x1b4'
-     * */
-    method: 'eth_blockNumber'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Executes a new message call immediately without submitting a transaction to the network
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_call', params: [{ to: '0x...', data: '0x...' }] })
-     * // => '0x...'
-     */
-    method: 'eth_call'
-    params: [
-      request: Partial<TransactionRequest>,
-      block?: BlockNumber | BlockTag | BlockIdentifier,
-    ]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Returns the chain ID associated with the current network
-     * @example
-     * provider.request({ method: 'eth_chainId' })
-     * // => '1'
-     */
-    method: 'eth_chainId'
-    params?: never
-  }): Promise<Quantity>
-  request(args: { method: 'eth_coinbase'; params?: never }): Promise<Address>
-  request(args: {
-    /**
-     * @description Estimates the gas necessary to complete a transaction without submitting it to the network
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({
-     *  method: 'eth_estimateGas',
-     *  params: [{ from: '0x...', to: '0x...', value: '0x...' }]
-     * })
-     * // => '0x5208'
-     * */
-    method: 'eth_estimateGas'
-    params: [parameters: TransactionRequest, block?: BlockNumber | BlockTag]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns a collection of historical gas information
-     * @link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md
-     * @example
-     * provider.request({
-     *  method: 'eth_feeHistory',
-     *  params: ['4', 'latest', ['25', '75']]
-     * })
-     * // => {
-     * //   oldestBlock: '0x1',
-     * //   baseFeePerGas: ['0x1', '0x2', '0x3', '0x4'],
-     * //   gasUsedRatio: ['0x1', '0x2', '0x3', '0x4'],
-     * //   reward: [['0x1', '0x2'], ['0x3', '0x4'], ['0x5', '0x6'], ['0x7', '0x8']]
-     * // }
-     * */
-    method: 'eth_feeHistory'
-    params: [
+export type PublicRpcSchema = [
+  /**
+   * @description Returns the version of the current client
+   *
+   * @example
+   * provider.request({ method: 'web3_clientVersion' })
+   * // => 'MetaMask/v1.0.0'
+   */
+  {
+    Method: 'web3_clientVersion'
+    Parameters?: never
+    ReturnType: string
+  },
+  /**
+   * @description Hashes data using the Keccak-256 algorithm
+   *
+   * @example
+   * provider.request({ method: 'web3_sha3', params: ['0x68656c6c6f20776f726c64'] })
+   * // => '0xc94770007dda54cF92009BFF0dE90c06F603a09f'
+   */
+  {
+    Method: 'web3_sha3'
+    Parameters: [data: Hash]
+    ReturnType: string
+  },
+  /**
+   * @description Determines if this client is listening for new network connections
+   *
+   * @example
+   * provider.request({ method: 'net_listening' })
+   * // => true
+   */
+  {
+    Method: 'net_listening'
+    Parameters?: never
+    ReturnType: boolean
+  },
+  /**
+   * @description Returns the number of peers currently connected to this client
+   *
+   * @example
+   * provider.request({ method: 'net_peerCount' })
+   * // => '0x1'
+   */
+  {
+    Method: 'net_peerCount'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the chain ID associated with the current network
+   *
+   * @example
+   * provider.request({ method: 'net_version' })
+   * // => '1'
+   */
+  {
+    Method: 'net_version'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the number of the most recent block seen by this client
+   *
+   * @example
+   * provider.request({ method: 'eth_blockNumber' })
+   * // => '0x1b4'
+   */
+  {
+    Method: 'eth_blockNumber'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Executes a new message call immediately without submitting a transaction to the network
+   *
+   * @example
+   * provider.request({ method: 'eth_call', params: [{ to: '0x...', data: '0x...' }] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_call'
+    Parameters:
+      | [transaction: Partial<TransactionRequest>]
+      | [
+          transaction: Partial<TransactionRequest>,
+          block: BlockNumber | BlockTag | BlockIdentifier,
+        ]
+    ReturnType: Hex
+  },
+  /**
+   * @description Returns the chain ID associated with the current network
+   * @example
+   * provider.request({ method: 'eth_chainId' })
+   * // => '1'
+   */
+  {
+    Method: 'eth_chainId'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the client coinbase address.
+   * @example
+   * provider.request({ method: 'eth_coinbase' })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_coinbase'
+    Parameters?: never
+    ReturnType: Address
+  },
+  /**
+   * @description Estimates the gas necessary to complete a transaction without submitting it to the network
+   *
+   * @example
+   * provider.request({
+   *  method: 'eth_estimateGas',
+   *  params: [{ from: '0x...', to: '0x...', value: '0x...' }]
+   * })
+   * // => '0x5208'
+   */
+  {
+    Method: 'eth_estimateGas'
+    Parameters:
+      | [transaction: TransactionRequest]
+      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns a collection of historical gas information
+   *
+   * @example
+   * provider.request({
+   *  method: 'eth_feeHistory',
+   *  params: ['4', 'latest', ['25', '75']]
+   * })
+   * // => {
+   * //   oldestBlock: '0x1',
+   * //   baseFeePerGas: ['0x1', '0x2', '0x3', '0x4'],
+   * //   gasUsedRatio: ['0x1', '0x2', '0x3', '0x4'],
+   * //   reward: [['0x1', '0x2'], ['0x3', '0x4'], ['0x5', '0x6'], ['0x7', '0x8']]
+   * // }
+   * */
+  {
+    Method: 'eth_feeHistory'
+    Parameters: [
       /** Number of blocks in the requested range. Between 1 and 1024 blocks can be requested in a single query. Less than requested may be returned if not all blocks are available. */
       blockCount: Quantity,
       /** Highest number block of the requested range. */
@@ -265,137 +292,153 @@ export type PublicRequests = {
       /** A monotonically increasing list of percentile values to sample from each block's effective priority fees per gas in ascending order, weighted by gas used. */
       rewardPercentiles: number[] | undefined,
     ]
-  }): Promise<FeeHistory>
-  request(args: {
-    /**
-     * @description Returns the current price of gas expressed in wei
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_gasPrice' })
-     * // => '0x09184e72a000'
-     * */
-    method: 'eth_gasPrice'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the balance of an address in wei
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getBalance', params: ['0x...', 'latest'] })
-     * // => '0x12a05...'
-     * */
-    method: 'eth_getBalance'
-    params: [address: Address, block: BlockNumber | BlockTag | BlockIdentifier]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns information about a block specified by hash
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getBlockByHash', params: ['0x...', true] })
-     * // => {
-     * //   number: '0x1b4',
-     * //   hash: '0x...',
-     * //   parentHash: '0x...',
-     * //   ...
-     * // }
-     * */
-    method: 'eth_getBlockByHash'
-    params: [
+    ReturnType: FeeHistory
+  },
+  /**
+   * @description Returns the current price of gas expressed in wei
+   *
+   * @example
+   * provider.request({ method: 'eth_gasPrice' })
+   * // => '0x09184e72a000'
+   */
+  {
+    Method: 'eth_gasPrice'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the balance of an address in wei
+   *
+   * @example
+   * provider.request({ method: 'eth_getBalance', params: ['0x...', 'latest'] })
+   * // => '0x12a05...'
+   */
+  {
+    Method: 'eth_getBalance'
+    Parameters: [
+      address: Address,
+      block: BlockNumber | BlockTag | BlockIdentifier,
+    ]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns information about a block specified by hash
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getBlockByHash', params: ['0x...', true] })
+   * // => {
+   * //   number: '0x1b4',
+   * //   hash: '0x...',
+   * //   parentHash: '0x...',
+   * //   ...
+   * // }
+   */
+  {
+    Method: 'eth_getBlockByHash'
+    Parameters: [
       /** hash of a block */
       hash: Hash,
       /** true will pull full transaction objects, false will pull transaction hashes */
       includeTransactionObjects: boolean,
     ]
-  }): Promise<Block | null>
-  request(args: {
-    /**
-     * @description Returns information about a block specified by number
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getBlockByNumber', params: ['0x1b4', true] })
-     * // => {
-     * //   number: '0x1b4',
-     * //   hash: '0x...',
-     * //   parentHash: '0x...',
-     * //   ...
-     * // }
-     * */
-    method: 'eth_getBlockByNumber'
-    params: [
+    ReturnType: Block | null
+  },
+  /**
+   * @description Returns information about a block specified by number
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getBlockByNumber', params: ['0x1b4', true] })
+   * // => {
+   * //   number: '0x1b4',
+   * //   hash: '0x...',
+   * //   parentHash: '0x...',
+   * //   ...
+   * // }
+   */
+  {
+    Method: 'eth_getBlockByNumber'
+    Parameters: [
       /** block number, or one of "latest", "safe", "finalized", "earliest" or "pending" */
       block: BlockNumber | BlockTag,
       /** true will pull full transaction objects, false will pull transaction hashes */
       includeTransactionObjects: boolean,
     ]
-  }): Promise<Block | null>
-  request(args: {
-    /**
-     * @description Returns the number of transactions in a block specified by block hash
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getBlockTransactionCountByHash', params: ['0x...'] })
-     * // => '0x1'
-     * */
-    method: 'eth_getBlockTransactionCountByHash'
-    params: [hash: Hash]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the number of transactions in a block specified by block number
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getBlockTransactionCountByNumber', params: ['0x1b4'] })
-     * // => '0x1'
-     * */
-    method: 'eth_getBlockTransactionCountByNumber'
-    params: [block: BlockNumber | BlockTag]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the contract code stored at a given address
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getCode', params: ['0x...', 'latest'] })
-     * // => '0x...'
-     * */
-    method: 'eth_getCode'
-    params: [address: Address, block: BlockNumber | BlockTag | BlockIdentifier]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Returns a list of all logs based on filter ID since the last log retrieval
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getFilterChanges', params: ['0x...'] })
-     * // => [{ ... }, { ... }]
-     * */
-    method: 'eth_getFilterChanges'
-    params: [filterId: Quantity]
-  }): Promise<Log[] | Hex[]>
-  request(args: {
-    /**
-     * @description Returns a list of all logs based on filter ID
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getFilterLogs', params: ['0x...'] })
-     * // => [{ ... }, { ... }]
-     * */
-    method: 'eth_getFilterLogs'
-    params: [filterId: Quantity]
-  }): Promise<Log[]>
-  request(args: {
-    /**
-     * @description Returns a list of all logs based on a filter object
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getLogs', params: [{ fromBlock: '0x...', toBlock: '0x...', address: '0x...', topics: ['0x...'] }] })
-     * // => [{ ... }, { ... }]
-     * */
-    method: 'eth_getLogs'
-    params: [
-      parameters: {
+    ReturnType: Block | null
+  },
+  /**
+   * @description Returns the number of transactions in a block specified by block hash
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getBlockTransactionCountByHash', params: ['0x...'] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_getBlockTransactionCountByHash'
+    Parameters: [hash: Hash]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the number of transactions in a block specified by block number
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getBlockTransactionCountByNumber', params: ['0x1b4'] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_getBlockTransactionCountByNumber'
+    Parameters: [block: BlockNumber | BlockTag]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the contract code stored at a given address
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getCode', params: ['0x...', 'latest'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_getCode'
+    Parameters: [
+      address: Address,
+      block: BlockNumber | BlockTag | BlockIdentifier,
+    ]
+    ReturnType: Hex
+  },
+  /**
+   * @description Returns a list of all logs based on filter ID since the last log retrieval
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getFilterChanges', params: ['0x...'] })
+   * // => [{ ... }, { ... }]
+   */
+  {
+    Method: 'eth_getFilterChanges'
+    Parameters: [filterId: Quantity]
+    ReturnType: Log[] | Hex[]
+  },
+  /**
+   * @description Returns a list of all logs based on filter ID
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getFilterLogs', params: ['0x...'] })
+   * // => [{ ... }, { ... }]
+   */
+  {
+    Method: 'eth_getFilterLogs'
+    Parameters: [filterId: Quantity]
+    ReturnType: Log[]
+  },
+  /**
+   * @description Returns a list of all logs based on a filter object
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getLogs', params: [{ fromBlock: '0x...', toBlock: '0x...', address: '0x...', topics: ['0x...'] }] })
+   * // => [{ ... }, { ... }]
+   */
+  {
+    Method: 'eth_getLogs'
+    Parameters: [
+      {
         address?: Address | Address[]
         topics?: LogTopic[]
       } & (
@@ -411,142 +454,157 @@ export type PublicRequests = {
           }
       ),
     ]
-  }): Promise<Log[]>
-  request(args: {
-    /**
-     * @description Returns the value from a storage position at an address
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getStorageAt', params: ['0x...', '0x...', 'latest'] })
-     * // => '0x...'
-     * */
-    method: 'eth_getStorageAt'
-    params: [
+    ReturnType: Log[]
+  },
+  /**
+   * @description Returns the value from a storage position at an address
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getStorageAt', params: ['0x...', '0x...', 'latest'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_getStorageAt'
+    Parameters: [
       address: Address,
       index: Quantity,
       block: BlockNumber | BlockTag | BlockIdentifier,
     ]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Returns information about a transaction specified by block hash and transaction index
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getTransactionByBlockHashAndIndex', params: ['0x...', '0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getTransactionByBlockHashAndIndex'
-    params: [hash: Hash, index: Quantity]
-  }): Promise<Transaction | null>
-  request(args: {
-    /**
-     * @description Returns information about a transaction specified by block number and transaction index
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getTransactionByBlockNumberAndIndex', params: ['0x...', '0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getTransactionByBlockNumberAndIndex'
-    params: [block: BlockNumber | BlockTag, index: Quantity]
-  }): Promise<Transaction | null>
-  request(args: {
-    /**
-     * @description Returns information about a transaction specified by hash
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getTransactionByHash', params: ['0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getTransactionByHash'
-    params: [hash: Hash]
-  }): Promise<Transaction | null>
-  request(args: {
-    /**
-     * @description Returns the number of transactions sent from an address
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getTransactionCount', params: ['0x...', 'latest'] })
-     * // => '0x1'
-     * */
-    method: 'eth_getTransactionCount'
-    params: [address: Address, block: BlockNumber | BlockTag | BlockIdentifier]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the receipt of a transaction specified by hash
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getTransactionReceipt', params: ['0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getTransactionReceipt'
-    params: [hash: Hash]
-  }): Promise<TransactionReceipt | null>
-  request(args: {
-    /**
-     * @description Returns information about an uncle specified by block hash and uncle index position
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getUncleByBlockHashAndIndex', params: ['0x...', '0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getUncleByBlockHashAndIndex'
-    params: [hash: Hash, index: Quantity]
-  }): Promise<Uncle | null>
-  request(args: {
-    /**
-     * @description Returns information about an uncle specified by block number and uncle index position
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getUncleByBlockNumberAndIndex', params: ['0x...', '0x...'] })
-     * // => { ... }
-     * */
-    method: 'eth_getUncleByBlockNumberAndIndex'
-    params: [block: BlockNumber | BlockTag, index: Quantity]
-  }): Promise<Uncle | null>
-  request(args: {
-    /**
-     * @description Returns the number of uncles in a block specified by block hash
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getUncleCountByBlockHash', params: ['0x...'] })
-     * // => '0x1'
-     * */
-    method: 'eth_getUncleCountByBlockHash'
-    params: [hash: Hash]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the number of uncles in a block specified by block number
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_getUncleCountByBlockNumber', params: ['0x...'] })
-     * // => '0x1'
-     * */
-    method: 'eth_getUncleCountByBlockNumber'
-    params: [block: BlockNumber | BlockTag]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Creates a filter to listen for new blocks that can be used with `eth_getFilterChanges`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_newBlockFilter' })
-     * // => '0x1'
-     * */
-    method: 'eth_newBlockFilter'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Creates a filter to listen for specific state changes that can then be used with `eth_getFilterChanges`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_newFilter', params: [{ fromBlock: '0x...', toBlock: '0x...', address: '0x...', topics: ['0x...'] }] })
-     * // => '0x1'
-     * */
-    method: 'eth_newFilter'
-    params: [
+    ReturnType: Hex
+  },
+  /**
+   * @description Returns information about a transaction specified by block hash and transaction index
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getTransactionByBlockHashAndIndex', params: ['0x...', '0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getTransactionByBlockHashAndIndex'
+    Parameters: [hash: Hash, index: Quantity]
+    ReturnType: Transaction | null
+  },
+  /**
+   * @description Returns information about a transaction specified by block number and transaction index
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getTransactionByBlockNumberAndIndex', params: ['0x...', '0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getTransactionByBlockNumberAndIndex'
+    Parameters: [block: BlockNumber | BlockTag, index: Quantity]
+    ReturnType: Transaction | null
+  },
+  /**
+   * @description Returns information about a transaction specified by hash
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getTransactionByHash', params: ['0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getTransactionByHash'
+    Parameters: [hash: Hash]
+    ReturnType: Transaction | null
+  },
+  /**
+   * @description Returns the number of transactions sent from an address
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getTransactionCount', params: ['0x...', 'latest'] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_getTransactionCount'
+    Parameters: [
+      address: Address,
+      block: BlockNumber | BlockTag | BlockIdentifier,
+    ]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the receipt of a transaction specified by hash
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getTransactionReceipt', params: ['0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getTransactionReceipt'
+    Parameters: [hash: Hash]
+    ReturnType: TransactionReceipt | null
+  },
+  /**
+   * @description Returns information about an uncle specified by block hash and uncle index position
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getUncleByBlockHashAndIndex', params: ['0x...', '0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getUncleByBlockHashAndIndex'
+    Parameters: [hash: Hash, index: Quantity]
+    ReturnType: Uncle | null
+  },
+  /**
+   * @description Returns information about an uncle specified by block number and uncle index position
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getUncleByBlockNumberAndIndex', params: ['0x...', '0x...'] })
+   * // => { ... }
+   */
+  {
+    Method: 'eth_getUncleByBlockNumberAndIndex'
+    Parameters: [block: BlockNumber | BlockTag, index: Quantity]
+    ReturnType: Uncle | null
+  },
+  /**
+   * @description Returns the number of uncles in a block specified by block hash
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getUncleCountByBlockHash', params: ['0x...'] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_getUncleCountByBlockHash'
+    Parameters: [hash: Hash]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the number of uncles in a block specified by block number
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_getUncleCountByBlockNumber', params: ['0x...'] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_getUncleCountByBlockNumber'
+    Parameters: [block: BlockNumber | BlockTag]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Creates a filter to listen for new blocks that can be used with `eth_getFilterChanges`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_newBlockFilter' })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_newBlockFilter'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Creates a filter to listen for specific state changes that can then be used with `eth_getFilterChanges`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_newFilter', params: [{ fromBlock: '0x...', toBlock: '0x...', address: '0x...', topics: ['0x...'] }] })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_newFilter'
+    Parameters: [
       filter: {
         fromBlock?: BlockNumber | BlockTag
         toBlock?: BlockNumber | BlockTag
@@ -554,204 +612,222 @@ export type PublicRequests = {
         topics?: LogTopic[]
       },
     ]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Creates a filter to listen for new pending transactions that can be used with `eth_getFilterChanges`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_newPendingTransactionFilter' })
-     * // => '0x1'
-     * */
-    method: 'eth_newPendingTransactionFilter'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Returns the current Ethereum protocol version
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_protocolVersion' })
-     * // => '54'
-     * */
-    method: 'eth_protocolVersion'
-    params?: never
-  }): Promise<string>
-  request(args: {
-    /**
-     * @description Sends and already-signed transaction to the network
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_sendRawTransaction', params: ['0x...'] })
-     * // => '0x...'
-     * */
-    method: 'eth_sendRawTransaction'
-    params: [signedTransaction: Hex]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Destroys a filter based on filter ID
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_uninstallFilter', params: ['0x1'] })
-     * // => true
-     * */
-    method: 'eth_uninstallFilter'
-    params: [
-      /** ID of the filter to destroy */
-      filterId: Quantity,
-    ]
-  }): Promise<boolean>
-}
+    ReturnType: Quantity
+  },
+  /**
+   * @description Creates a filter to listen for new pending transactions that can be used with `eth_getFilterChanges`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_newPendingTransactionFilter' })
+   * // => '0x1'
+   */
+  {
+    Method: 'eth_newPendingTransactionFilter'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Returns the current Ethereum protocol version
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_protocolVersion' })
+   * // => '54'
+   */
+  {
+    Method: 'eth_protocolVersion'
+    Parameters?: never
+    ReturnType: string
+  },
+  /**
+   * @description Sends and already-signed transaction to the network
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_sendRawTransaction', params: ['0x...'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_sendRawTransaction'
+    Parameters: [signedTransaction: Hex]
+    ReturnType: Hash
+  },
+  /**
+   * @description Destroys a filter based on filter ID
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_uninstallFilter', params: ['0x1'] })
+   * // => true
+   */
+  {
+    Method: 'eth_uninstallFilter'
+    Parameters: [filterId: Quantity]
+    ReturnType: boolean
+  },
+]
 
-export type TestRequests<Name extends string> = {
-  request(args: {
-    /**
-     * @description Add information about compiled contracts
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_addcompilationresult
-     */
-    method: `${Name}_addCompilationResult`
-    params: any[]
-  }): Promise<any>
-  request(args: {
-    /**
-     * @description Remove a transaction from the mempool
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_droptransaction
-     */
-    method: `${Name}_dropTransaction`
-    params: [hash: Hash]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Turn on call traces for transactions that are returned to the user when they execute a transaction (instead of just txhash/receipt).
-     */
-    method: `${Name}_enableTraces`
-    params?: never
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Impersonate an account or contract address.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_impersonateaccount
-     */
-    method: `${Name}_impersonateAccount`
-    params: [address: Address]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Returns true if automatic mining is enabled, and false otherwise. See [Mining Modes](https://hardhat.org/hardhat-network/explanation/mining-modes) to learn more.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_getautomine
-     */
-    method: `${Name}_getAutomine`
-  }): Promise<boolean>
-  request(args: {
-    /**
-     * @description Advance the block number of the network by a certain number of blocks
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_mine
-     */
-    method: `${Name}_mine`
-    params: [
+export type TestRpcSchema<TMode extends string> = [
+  /**
+   * @description Add information about compiled contracts
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_addcompilationresult
+   */
+  {
+    Method: `${TMode}_addCompilationResult`
+    Parameters: any[]
+    ReturnType: any
+  },
+  /**
+   * @description Remove a transaction from the mempool
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_droptransaction
+   */
+  {
+    Method: `${TMode}_dropTransaction`
+    Parameters: [hash: Hash]
+    ReturnType: void
+  },
+  /**
+   * @description Turn on call traces for transactions that are returned to the user when they execute a transaction (instead of just txhash/receipt).
+   */
+  {
+    Method: `${TMode}_enableTraces`
+    Parameters?: never
+    ReturnType: void
+  },
+  /**
+   * @description Impersonate an account or contract address.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_impersonateaccount
+   */
+  {
+    Method: `${TMode}_impersonateAccount`
+    Parameters: [address: Address]
+    ReturnType: void
+  },
+  /**
+   * @description Returns true if automatic mining is enabled, and false otherwise. See [Mining Modes](https://hardhat.org/hardhat-network/explanation/mining-modes) to learn more.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_getautomine
+   */
+  {
+    Method: `${TMode}_getAutomine`
+    Parameters?: never
+    ReturnType: boolean
+  },
+  /**
+   * @description Advance the block number of the network by a certain number of blocks
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_mine
+   */
+  {
+    Method: `${TMode}_mine`
+    Parameters: [
       /** Number of blocks to mine. */
       count: Hex,
       /** Interval between each block in seconds. */
       interval: Hex | undefined,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Resets the fork.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_reset
-     */
-    method: `${Name}_reset`
-    params: any[]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Modifies the balance of an account.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setbalance
-     */
-    method: `${Name}_setBalance`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Resets the fork.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_reset
+   */
+  {
+    Method: `${TMode}_reset`
+    Parameters: any[]
+    ReturnType: void
+  },
+  /**
+   * @description Modifies the balance of an account.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setbalance
+   */
+  {
+    Method: `${TMode}_setBalance`
+    Parameters: [
       /** The address of the target account. */
       address: Address,
       /** Amount to send in wei. */
-      value: Quantity,
+      balance: Quantity,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Modifies the bytecode stored at an account's address.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcode
-     */
-    method: `${Name}_setCode`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Modifies the bytecode stored at an account's address.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcode
+   */
+  {
+    Method: `${TMode}_setCode`
+    Parameters: [
       /** The address of the contract. */
       address: Address,
       /** Data bytecode. */
       data: string,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Sets the coinbase address to be used in new blocks.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcoinbase
-     */
-    method: `${Name}_setCoinbase`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Sets the coinbase address to be used in new blocks.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcoinbase
+   */
+  {
+    Method: `${TMode}_setCoinbase`
+    Parameters: [
       /** The address to set as the coinbase address. */
       address: Address,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Enable or disable logging on the test node network.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcoinbase
-     */
-    method: `${Name}_setLoggingEnabled`
-    params: [enabled: boolean]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Change the minimum gas price accepted by the network (in wei).
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setmingasprice
-     */
-    method: `${Name}_setMinGasPrice`
-    params: [gasPrice: Quantity]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Sets the base fee of the next block.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setnextblockbasefeepergas
-     */
-    method: `${Name}_setNextBlockBaseFeePerGas`
-    params: [baseFeePerGas: Quantity]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Modifies an account's nonce by overwriting it.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setnonce
-     */
-    method: `${Name}_setNonce`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Enable or disable logging on the test node network.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setcoinbase
+   */
+  {
+    Method: `${TMode}_setLoggingEnabled`
+    Parameters: [enabled: boolean]
+    ReturnType: void
+  },
+  /**
+   * @description Change the minimum gas price accepted by the network (in wei).
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setmingasprice
+   */
+  {
+    Method: `${TMode}_setMinGasPrice`
+    Parameters: [gasPrice: Quantity]
+    ReturnType: void
+  },
+  /**
+   * @description Sets the base fee of the next block.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setnextblockbasefeepergas
+   */
+  {
+    Method: `${TMode}_setNextBlockBaseFeePerGas`
+    Parameters: [baseFeePerGas: Quantity]
+    ReturnType: void
+  },
+  /**
+   * @description Modifies an account's nonce by overwriting it.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setnonce
+   */
+  {
+    Method: `${TMode}_setNonce`
+    Parameters: [
       /** The account address. */
       address: Address,
       /** The new nonce. */
       nonce: Quantity,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Sets the backend RPC URL.
-     */
-    method: `${Name}_setRpcUrl`
-    params: [url: string]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Writes a single position of an account's storage.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setstorageat
-     */
-    method: `${Name}_setStorageAt`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Sets the backend RPC URL.
+   */
+  {
+    Method: `${TMode}_setRpcUrl`
+    Parameters: [url: string]
+    ReturnType: void
+  },
+  /**
+   * @description Writes a single position of an account's storage.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setstorageat
+   */
+  {
+    Method: `${TMode}_setStorageAt`
+    Parameters: [
       /** The account address. */
       address: Address,
       /** The storage position index. */
@@ -759,302 +835,413 @@ export type TestRequests<Name extends string> = {
       /** The storage value. */
       value: Quantity,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Use this method to stop impersonating an account after having previously used impersonateAccount.
-     * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_stopimpersonatingaccount
-     */
-    method: `${Name}_stopImpersonatingAccount`
-    params: [
+    ReturnType: void
+  },
+  /**
+   * @description Use this method to stop impersonating an account after having previously used impersonateAccount.
+   * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_stopimpersonatingaccount
+   */
+  {
+    Method: `${TMode}_stopImpersonatingAccount`
+    Parameters: [
       /** The address to stop impersonating. */
       address: Address,
     ]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Jump forward in time by the given amount of time, in seconds.
-     * @link https://github.com/trufflesuite/ganache/blob/ef1858d5d6f27e4baeb75cccd57fb3dc77a45ae8/src/chains/ethereum/ethereum/RPC-METHODS.md#evm_increasetime
-     */
-    method: 'evm_increaseTime'
-    params: [seconds: Quantity]
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network.
-     * @link https://hardhat.org/hardhat-network/docs/reference#evm_setautomine
-     */
-    method: 'evm_setAutomine'
-    params: [boolean]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Sets the block's gas limit.
-     * @link https://hardhat.org/hardhat-network/docs/reference#evm_setblockgaslimit
-     */
-    method: 'evm_setBlockGasLimit'
-    params: [gasLimit: Quantity]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Similar to `evm_increaseTime` but sets a block timestamp `interval`.
-     * The timestamp of the next block will be computed as `lastBlock_timestamp` + `interval`
-     */
-    method: `${Name}_setBlockTimestampInterval`
-    params: [seconds: number]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Removes `setBlockTimestampInterval` if it exists
-     */
-    method: `${Name}_removeBlockTimestampInterval`
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Enables (with a numeric argument greater than 0) or disables (with a numeric argument equal to 0), the automatic mining of blocks at a regular interval of milliseconds, each of which will include all pending transactions.
-     * @link https://hardhat.org/hardhat-network/docs/reference#evm_setintervalmining
-     */
-    method: 'evm_setIntervalMining'
-    params: [number]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Set the timestamp of the next block.
-     * @link https://hardhat.org/hardhat-network/docs/reference#evm_setnextblocktimestamp
-     */
-    method: 'evm_setNextBlockTimestamp'
-    params: [Quantity]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @description Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the id of the snapshot that was created.
-     * @link https://hardhat.org/hardhat-network/docs/reference#evm_snapshot
-     */
-    method: 'evm_snapshot'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to.
-     */
-    method: 'evm_revert'
-    params?: [id: Quantity]
-  }): Promise<void>
-  request(args: {
-    /**
-     * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-content
-     */
-    method: 'txpool_content'
-    params?: never
-  }): Promise<{
-    pending: Record<Address, Record<string, Transaction>>
-    queued: Record<Address, Record<string, Transaction>>
-  }>
-  request(args: {
-    /**
-     * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
-     */
-    method: 'txpool_inspect'
-    params?: never
-  }): Promise<{
-    pending: Record<Address, Record<string, string>>
-    queued: Record<Address, Record<string, string>>
-  }>
-  request(args: {
-    /**
-     * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
-     */
-    method: 'txpool_status'
-    params?: never
-  }): Promise<{
-    pending: Quantity
-    queued: Quantity
-  }>
-  request(args: {
-    /**
-     * @description Creates, signs, and sends a new transaction to the network regardless of the signature.
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_sendTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
-     * // => '0x...'
-     * */
-    method: 'eth_sendUnsignedTransaction'
-    params: [request: TransactionRequest]
-  }): Promise<Hash>
-}
+    ReturnType: void
+  },
+  /**
+   * @description Jump forward in time by the given amount of time, in seconds.
+   * @link https://github.com/trufflesuite/ganache/blob/ef1858d5d6f27e4baeb75cccd57fb3dc77a45ae8/src/chains/ethereum/ethereum/RPC-METHODS.md#evm_increasetime
+   */
+  {
+    Method: `${TMode}_increaseTime`
+    Parameters: [seconds: number]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network.
+   * @link https://hardhat.org/hardhat-network/docs/reference#evm_setautomine
+   */
+  {
+    Method: `evm_setAutomine`
+    Parameters: [boolean]
+    ReturnType: void
+  },
+  /**
+   * @description Sets the block's gas limit.
+   * @link https://hardhat.org/hardhat-network/docs/reference#evm_setblockgaslimit
+   */
+  {
+    Method: 'evm_setBlockGasLimit'
+    Parameters: [gasLimit: Quantity]
+    ReturnType: void
+  },
+  /**
+   * @description Jump forward in time by the given amount of time, in seconds.
+   * @link https://github.com/trufflesuite/ganache/blob/ef1858d5d6f27e4baeb75cccd57fb3dc77a45ae8/src/chains/ethereum/ethereum/RPC-METHODS.md#evm_increasetime
+   */
+  {
+    Method: `evm_increaseTime`
+    Parameters: [seconds: Quantity]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Similar to `evm_increaseTime` but sets a block timestamp `interval`.
+   * The timestamp of the next block will be computed as `lastBlock_timestamp` + `interval`
+   */
+  {
+    Method: `${TMode}_setBlockTimestampInterval`
+    Parameters: [seconds: number]
+    ReturnType: void
+  },
+  /**
+   * @description Removes `setBlockTimestampInterval` if it exists
+   */
+  {
+    Method: `${TMode}_removeBlockTimestampInterval`
+    Parameters?: never
+    ReturnType: void
+  },
+  /**
+   * @description Enables (with a numeric argument greater than 0) or disables (with a numeric argument equal to 0), the automatic mining of blocks at a regular interval of milliseconds, each of which will include all pending transactions.
+   * @link https://hardhat.org/hardhat-network/docs/reference#evm_setintervalmining
+   */
+  {
+    Method: 'evm_setIntervalMining'
+    Parameters: [number]
+    ReturnType: void
+  },
+  /**
+   * @description Set the timestamp of the next block.
+   * @link https://hardhat.org/hardhat-network/docs/reference#evm_setnextblocktimestamp
+   */
+  {
+    Method: 'evm_setNextBlockTimestamp'
+    Parameters: [Quantity]
+    ReturnType: void
+  },
+  /**
+   * @description Snapshot the state of the blockchain at the current block. Takes no parameters. Returns the id of the snapshot that was created.
+   * @link https://hardhat.org/hardhat-network/docs/reference#evm_snapshot
+   */
+  {
+    Method: 'evm_snapshot'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Revert the state of the blockchain to a previous snapshot. Takes a single parameter, which is the snapshot id to revert to.
+   */
+  {
+    Method: 'evm_revert'
+    Parameters?: [id: Quantity]
+    ReturnType: void
+  },
+  /**
+   * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-content
+   */
+  {
+    Method: 'txpool_content'
+    Parameters?: never
+    ReturnType: {
+      pending: Record<Address, Record<string, Transaction>>
+      queued: Record<Address, Record<string, Transaction>>
+    }
+  },
+  /**
+   * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
+   */
+  {
+    Method: 'txpool_inspect'
+    Parameters?: never
+    ReturnType: {
+      pending: Record<Address, Record<string, string>>
+      queued: Record<Address, Record<string, string>>
+    }
+  },
+  /**
+   * @link https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-txpool#txpool-inspect
+   */
+  {
+    Method: 'txpool_status'
+    Parameters?: never
+    ReturnType: {
+      pending: Quantity
+      queued: Quantity
+    }
+  },
+  /**
+   * @description Creates, signs, and sends a new transaction to the network regardless of the signature.
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_sendTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_sendUnsignedTransaction'
+    Parameters: [transaction: TransactionRequest]
+    ReturnType: Hash
+  },
+]
 
-export type SignableRequests = {
-  request(args: {
-    /**
-     * @description Creates, signs, and sends a new transaction to the network
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_sendTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
-     * // => '0x...'
-     * */
-    method: 'eth_sendTransaction'
-    params: [request: TransactionRequest]
-  }): Promise<Hash>
-  request(args: {
-    /**
-     * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_sign', params: ['0x...', '0x...'] })
-     * // => '0x...'
-     * */
-    method: 'eth_sign'
-    params: [
+export type WalletRpcSchema = [
+  /**
+   * @description Returns a list of addresses owned by this client
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_accounts' })
+   * // => ['0x0fB69...']
+   */
+  {
+    Method: 'eth_accounts'
+    Parameters?: never
+    ReturnType: Address[]
+  },
+  /**
+   * @description Returns the current chain ID associated with the wallet.
+   * @example
+   * provider.request({ method: 'eth_chainId' })
+   * // => '1'
+   */
+  {
+    Method: 'eth_chainId'
+    Parameters?: never
+    ReturnType: Quantity
+  },
+  /**
+   * @description Estimates the gas necessary to complete a transaction without submitting it to the network
+   *
+   * @example
+   * provider.request({
+   *  method: 'eth_estimateGas',
+   *  params: [{ from: '0x...', to: '0x...', value: '0x...' }]
+   * })
+   * // => '0x5208'
+   */
+  {
+    Method: 'eth_estimateGas'
+    Parameters:
+      | [transaction: TransactionRequest]
+      | [transaction: TransactionRequest, block: BlockNumber | BlockTag]
+    ReturnType: Quantity
+  },
+  /**
+   * @description Requests that the user provides an Ethereum address to be identified by. Typically causes a browser extension popup to appear.
+   * @link https://eips.ethereum.org/EIPS/eip-1102
+   * @example
+   * provider.request({ method: 'eth_requestAccounts' }] })
+   * // => ['0x...', '0x...']
+   */
+  {
+    Method: 'eth_requestAccounts'
+    Parameters?: never
+    ReturnType: Address[]
+  },
+  /**
+   * @description Creates, signs, and sends a new transaction to the network
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_sendTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_sendTransaction'
+    Parameters: [transaction: TransactionRequest]
+    ReturnType: Hash
+  },
+  /**
+   * @description Sends and already-signed transaction to the network
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_sendRawTransaction', params: ['0x...'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_sendRawTransaction'
+    Parameters: [signedTransaction: Hex]
+    ReturnType: Hash
+  },
+  /**
+   * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_sign', params: ['0x...', '0x...'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_sign'
+    Parameters: [
       /** Address to use for signing */
       address: Address,
       /** Data to sign */
       data: Hex,
     ]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Signs a transaction that can be submitted to the network at a later time using with `eth_sendRawTransaction`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_signTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
-     * // => '0x...'
-     * */
-    method: 'eth_signTransaction'
-    params: [request: TransactionRequest]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_signTypedData_v4', params: [{ from: '0x...', data: [{ type: 'string', name: 'message', value: 'hello world' }] }] })
-     * // => '0x...'
-     * */
-    method: 'eth_signTypedData_v4'
-    params: [
+    ReturnType: Hex
+  },
+  /**
+   * @description Signs a transaction that can be submitted to the network at a later time using with `eth_sendRawTransaction`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_signTransaction', params: [{ from: '0x...', to: '0x...', value: '0x...' }] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_signTransaction'
+    Parameters: [request: TransactionRequest]
+    ReturnType: Hex
+  },
+  /**
+   * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_signTypedData_v4', params: [{ from: '0x...', data: [{ type: 'string', name: 'message', value: 'hello world' }] }] })
+   * // => '0x...'
+   */
+  {
+    Method: 'eth_signTypedData_v4'
+    Parameters: [
       /** Address to use for signing */
       address: Address,
       /** Message to sign containing type information, a domain separator, and data */
       message: string,
     ]
-  }): Promise<Hex>
-  request(args: {
-    /**
-     * @description Returns information about the status of this client’s network synchronization
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_syncing' })
-     * // => { startingBlock: '0x...', currentBlock: '0x...', highestBlock: '0x...' }
-     * */
-    method: 'eth_syncing'
-    params?: never
-  }): Promise<NetworkSync | false>
-  request(args: {
-    /**
-     * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'personal_sign', params: ['0x...', '0x...'] })
-     * // => '0x...'
-     * */
-    method: 'personal_sign'
-    params: [
+    ReturnType: Hex
+  },
+  /**
+   * @description Returns information about the status of this client’s network synchronization
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'eth_syncing' })
+   * // => { startingBlock: '0x...', currentBlock: '0x...', highestBlock: '0x...' }
+   */
+  {
+    Method: 'eth_syncing'
+    Parameters?: never
+    ReturnType: NetworkSync | false
+  },
+  /**
+   * @description Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`
+   * @link https://eips.ethereum.org/EIPS/eip-1474
+   * @example
+   * provider.request({ method: 'personal_sign', params: ['0x...', '0x...'] })
+   * // => '0x...'
+   */
+  {
+    Method: 'personal_sign'
+    Parameters: [
       /** Data to sign */
       data: Hex,
       /** Address to use for signing */
       address: Address,
     ]
-  }): Promise<Hex>
-}
-
-export type WalletRequests = {
-  request(args: {
-    /**
-     * @description Returns a list of addresses owned by this client
-     * @link https://eips.ethereum.org/EIPS/eip-1474
-     * @example
-     * provider.request({ method: 'eth_accounts' })
-     * // => ['0x0fB69...']
-     * */
-    method: 'eth_accounts'
-    params?: never
-  }): Promise<Address[]>
-  request(args: {
-    /**
-     * @description Returns the current chain ID associated with the wallet.
-     * @example
-     * provider.request({ method: 'eth_chainId' })
-     * // => '1'
-     */
-    method: 'eth_chainId'
-    params?: never
-  }): Promise<Quantity>
-  request(args: {
-    /**
-     * @description Requests that the user provides an Ethereum address to be identified by. Typically causes a browser extension popup to appear.
-     * @link https://eips.ethereum.org/EIPS/eip-1102
-     * @example
-     * provider.request({ method: 'eth_requestAccounts' })
-     * // => ['0x...', '0x...']
-     * */
-    method: 'eth_requestAccounts'
-    params?: never
-  }): Promise<Address[]>
-  request(args: {
-    /**
-     * @description Requests the given permissions from the user.
-     * @link https://eips.ethereum.org/EIPS/eip-2255
-     * @example
-     * provider.request({ method: 'wallet_requestPermissions', params: [{ eth_accounts: {} }] })
-     * // => { ... }
-     * */
-    method: 'wallet_requestPermissions'
-    params: [permissions: { eth_accounts: Record<string, any> }]
-  }): Promise<WalletPermission[]>
-  request(args: {
-    /**
-     * @description Gets the wallets current permissions.
-     * @link https://eips.ethereum.org/EIPS/eip-2255
-     * @example
-     * provider.request({ method: 'wallet_getPermissions' })
-     * // => { ... }
-     * */
-    method: 'wallet_getPermissions'
-    params?: never
-  }): Promise<WalletPermission[]>
-  request(args: {
-    /**
-     * @description Add an Ethereum chain to the wallet.
-     * @link https://eips.ethereum.org/EIPS/eip-3085
-     * @example
-     * provider.request({ method: 'wallet_addEthereumChain', params: [{ chainId: 1, rpcUrl: 'https://mainnet.infura.io/v3/...' }] })
-     * // => { ... }
-     */
-    method: 'wallet_addEthereumChain'
-    params: [chain: AddEthereumChainParameter]
-  }): Promise<null>
-  request(args: {
-    /**
-     * @description Switch the wallet to the given Ethereum chain.
-     * @link https://eips.ethereum.org/EIPS/eip-3326
-     * @example
-     * provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0xf00' }] })
-     * // => { ... }
-     * */
-    method: 'wallet_switchEthereumChain'
-    params: [chain: { chainId: string }]
-  }): Promise<null>
+    ReturnType: Hex
+  },
+  /**
+   * @description Add an Ethereum chain to the wallet.
+   * @link https://eips.ethereum.org/EIPS/eip-3085
+   * @example
+   * provider.request({ method: 'wallet_addEthereumChain', params: [{ chainId: 1, rpcUrl: 'https://mainnet.infura.io/v3/...' }] })
+   * // => { ... }
+   */
+  {
+    Method: 'wallet_addEthereumChain'
+    Parameters: [chain: AddEthereumChainParameter]
+    ReturnType: null
+  },
+  /**
+   * @description Gets the wallets current permissions.
+   * @link https://eips.ethereum.org/EIPS/eip-2255
+   * @example
+   * provider.request({ method: 'wallet_getPermissions' })
+   * // => { ... }
+   */
+  {
+    Method: 'wallet_getPermissions'
+    Parameters?: never
+    ReturnType: WalletPermission[]
+  },
+  /**
+   * @description Requests the given permissions from the user.
+   * @link https://eips.ethereum.org/EIPS/eip-2255
+   * @example
+   * provider.request({ method: 'wallet_requestPermissions', params: [{ eth_accounts: {} }] })
+   * // => { ... }
+   */
+  {
+    Method: 'wallet_requestPermissions'
+    Parameters: [permissions: { eth_accounts: Record<string, any> }]
+    ReturnType: WalletPermission[]
+  },
+  /**
+   * @description Switch the wallet to the given Ethereum chain.
+   * @link https://eips.ethereum.org/EIPS/eip-3326
+   * @example
+   * provider.request({ method: 'wallet_switchEthereumChain', params: [{ chainId: '0xf00' }] })
+   * // => { ... }
+   */
+  {
+    Method: 'wallet_switchEthereumChain'
+    Parameters: [chain: { chainId: string }]
+    ReturnType: null
+  },
   /**
    * @description Requests that the user tracks the token in their wallet. Returns a boolean indicating if the token was successfully added.
    * @link https://eips.ethereum.org/EIPS/eip-747
    * @example
    * provider.request({ method: 'wallet_watchAsset' }] })
    * // => true
-   * */
-  request(args: {
-    method: 'wallet_watchAsset'
-    params: WatchAssetParams
-  }): Promise<boolean>
+   */
+  {
+    Method: 'wallet_watchAsset'
+    Parameters: [asset: WatchAssetParams]
+    ReturnType: boolean
+  },
+]
+
+///////////////////////////////////////////////////////////////////////////
+// Utils
+
+export type RpcSchema = readonly {
+  Method: string
+  Parameters?: unknown
+  ReturnType: unknown
+}[]
+
+type NoopSchemaItem = {
+  Method: string
+  Parameters: undefined
+  ReturnType: unknown
 }
 
-export type Requests = PublicRequests & SignableRequests & WalletRequests
+export type EIP1193RequestFnConfig = { Strict: boolean }
+
+export type EIP1193RequestFn<
+  TRpcSchema extends RpcSchema | undefined = undefined,
+  TConfig extends EIP1193RequestFnConfig = { Strict: false },
+> = <
+  TMethod extends TRpcSchema extends RpcSchema
+    ? TConfig['Strict'] extends true
+      ? TRpcSchema[number]['Method']
+      : TRpcSchema[number]['Method'] | (string & {})
+    : string,
+  _SchemaItem extends RpcSchema[number] = TRpcSchema extends RpcSchema
+    ? Extract<TRpcSchema[number], { Method: TMethod }> extends never
+      ? NoopSchemaItem
+      : Extract<TRpcSchema[number], { Method: TMethod }>
+    : NoopSchemaItem,
+  _Parameters = _SchemaItem['Parameters'],
+  _ReturnType = _SchemaItem['ReturnType'],
+>(
+  args: {
+    method: TMethod
+  } & (
+    | (_Parameters extends undefined
+        ? { params?: _Parameters }
+        : { params: _Parameters })
+    | (TConfig['Strict'] extends false
+        ? TRpcSchema extends RpcSchema
+          ? never
+          : { params?: unknown }
+        : never)
+  ),
+) => Promise<_ReturnType>

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,10 +1,16 @@
 import type { Abi } from 'abitype'
 
 import type { MaybeExtractEventArgsFromAbi } from './contract.js'
-import type { Requests } from './eip1193.js'
+import type { EIP1193RequestFn, PublicRpcSchema } from './eip1193.js'
 import type { Hex } from './misc.js'
+import type { Filter as Filter_ } from './utils.js'
 
 export type FilterType = 'transaction' | 'block' | 'event'
+
+type FilterRpcSchema = Filter_<
+  PublicRpcSchema,
+  { Method: 'eth_getFilterLogs' | 'eth_getFilterChanges' }
+>
 
 export type Filter<
   TFilterType extends FilterType = 'event',
@@ -15,8 +21,7 @@ export type Filter<
     | undefined = MaybeExtractEventArgsFromAbi<TAbi, TEventName>,
 > = {
   id: Hex
-  // TODO: Narrow `request` to filter-based methods (ie. `eth_getFilterLogs`, etc).
-  request: Requests['request']
+  request: EIP1193RequestFn<FilterRpcSchema>
   type: TFilterType
 } & (TFilterType extends 'event'
   ? TAbi extends Abi


### PR DESCRIPTION
Makes the EIP1193 `request` function more flexible (ie. can now unionize it & use it w/o a function). Will be useful for batch JSON-RPC and secret project.