### PR TITLE
Fix: exception handling when rejecting a request sent to Metamask through walletConnect

### DIFF
--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -4,8 +4,10 @@ import type { WalletClient } from '../../clients/createWalletClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import { AccountNotFoundError } from '../../errors/account.js'
 import type { BaseError } from '../../errors/base.js'
+import { UserRejectedRequestError } from '../../index.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type { Chain, GetChain } from '../../types/chain.js'
+import { ProviderRpcError } from '../../types/eip1193.js'
 import type { Formatter } from '../../types/formatter.js'
 import type { Hash } from '../../types/misc.js'
 import type {
@@ -181,6 +183,15 @@ export async function sendTransaction<
       params: [request],
     })
   } catch (err) {
+
+    /**
+    This error occurs when a transaction is sent to
+    the metamask mobile app through walletconnect and it is rejected.
+     */
+    if(err instanceof ProviderRpcError && err.code === 4001) {
+      throw new UserRejectedRequestError(err);
+    }
+
     throw getTransactionError(err as BaseError, {
       ...args,
       account,


### PR DESCRIPTION
This issue is a PR that fixes an issue where UserRejectedRequestError is not thrown when the user rejects the transaction when calling the sendTransaction function in metamask using walletconnect-legacy-provider.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new error type for when a transaction is rejected through WalletConnect on the Metamask mobile app.

### Detailed summary
- Added `UserRejectedRequestError` import
- Added check for `ProviderRpcError` with code `4001`
- Throws `UserRejectedRequestError` if above condition is met

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->