### PR TITLE
doc: add tuple notice

### DIFF
--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -800,6 +800,9 @@ decodeAbiParameters(
 )
 ```
 
+Notice: different from ethers, viem only supports [standard tuple expression](https://docs.soliditylang.org/en/latest/grammar.html#a4.SolidityParser.tupleExpression) for Human Readable.
+example: `(uint a, string b)` is valid, but `tuple(uint a, string b)` is not.
+
 ### Fragments & Interfaces
 
 In viem, there is no concept of "fragments" & "interfaces". We want to stick as close to the wire as possible and not introduce middleware abstractions and extra layers over ABIs. Instead of working with "fragments", we encourage you to work with the ABI itself.


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR provides information about differences between viem and ethers, specifically regarding tuple expressions and the lack of support for fragments and interfaces in viem.

### Detailed summary:
- Viem only supports standard tuple expressions for Human Readable
- Fragments and interfaces are not supported in viem
- Encourages working with the ABI itself instead of using "fragments"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->