### PR TITLE
feat: compatibility with new universal resolver

### DIFF
--- a/.changeset/eight-hornets-rush.md
+++ b/.changeset/eight-hornets-rush.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Upgraded ENS Universal Resolver contract address.

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@noble/hashes": "1.3.0",
     "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0",
-    "@wagmi/chains": "1.0.0",
+    "@wagmi/chains": "1.1.0",
     "abitype": "0.8.7",
     "isomorphic-ws": "5.0.0",
     "ws": "8.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       '@wagmi/chains':
-        specifier: 1.0.0
-        version: 1.0.0(typescript@5.0.4)
+        specifier: 1.1.0
+        version: 1.1.0(typescript@5.0.4)
       abitype:
         specifier: 0.8.7
         version: 0.8.7(typescript@5.0.4)
@@ -2624,8 +2624,8 @@ packages:
       typescript: 5.0.4
     dev: true
 
-  /@wagmi/chains@1.0.0(typescript@5.0.4):
-    resolution: {integrity: sha512-eNbqRWyHbivcMNq5tbXJks4NaOzVLHnNQauHPeE/EDT9AlpqzcrMc+v2T1/2Iw8zN4zgqB86NCsxeJHJs7+xng==}
+  /@wagmi/chains@1.1.0(typescript@5.0.4):
+    resolution: {integrity: sha512-pWZlxBk0Ql8E7DV8DwqlbBpOyUdaG9UDlQPBxJNALuEK1I0tbQ3AVvSDnlsEIt06UPmPo5o27gzs3hwPQ/A+UA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -13,7 +13,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsAddress } from './getEnsAddress.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16966585n)
+  await setBlockNumber(16966590n)
   await setVitalikResolver()
 })
 
@@ -153,7 +153,7 @@ test('universal resolver contract deployed on later block', async () => {
     "Chain \\"Localhost\\" does not support contract \\"ensUniversalResolver\\".
 
     This could be due to any of the following:
-    - The contract \\"ensUniversalResolver\\" was not deployed until block 16773775 (current block 14353601).
+    - The contract \\"ensUniversalResolver\\" was not deployed until block 16966585 (current block 14353601).
 
     Version: viem@1.0.2"
   `)

--- a/src/actions/ens/getEnsAvatar.test.ts
+++ b/src/actions/ens/getEnsAvatar.test.ts
@@ -21,7 +21,7 @@ beforeAll(async () => {
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })
-  await setBlockNumber(16773780n)
+  await setBlockNumber(16966590n)
 
   return async () => {
     await stopImpersonatingAccount(testClient, {

--- a/src/actions/ens/getEnsName.test.ts
+++ b/src/actions/ens/getEnsName.test.ts
@@ -9,7 +9,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsName } from './getEnsName.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16773780n)
+  await setBlockNumber(16966590n)
 })
 
 test('gets primary name for address', async () => {
@@ -81,7 +81,7 @@ test('universal resolver contract deployed on later block', async () => {
     "Chain \\"Localhost\\" does not support contract \\"ensUniversalResolver\\".
 
     This could be due to any of the following:
-    - The contract \\"ensUniversalResolver\\" was not deployed until block 16773775 (current block 14353601).
+    - The contract \\"ensUniversalResolver\\" was not deployed until block 16966585 (current block 14353601).
 
     Version: viem@1.0.2"
   `)

--- a/src/actions/ens/getEnsResolver.test.ts
+++ b/src/actions/ens/getEnsResolver.test.ts
@@ -9,7 +9,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsResolver } from './getEnsResolver.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16773780n)
+  await setBlockNumber(16966590n)
 })
 
 test('default', async () => {
@@ -80,7 +80,7 @@ test('universal resolver contract deployed on later block', async () => {
     "Chain \\"Localhost\\" does not support contract \\"ensUniversalResolver\\".
 
     This could be due to any of the following:
-    - The contract \\"ensUniversalResolver\\" was not deployed until block 16773775 (current block 14353601).
+    - The contract \\"ensUniversalResolver\\" was not deployed until block 16966585 (current block 14353601).
 
     Version: viem@1.0.2"
   `)

--- a/src/actions/ens/getEnsText.test.ts
+++ b/src/actions/ens/getEnsText.test.ts
@@ -13,7 +13,7 @@ import { http } from '../../clients/transports/http.js'
 import { getEnsText } from './getEnsText.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16773780n)
+  await setBlockNumber(16966590n)
   await setVitalikResolver()
 })
 
@@ -100,7 +100,7 @@ test('universal resolver contract deployed on later block', async () => {
     "Chain \\"Localhost\\" does not support contract \\"ensUniversalResolver\\".
 
     This could be due to any of the following:
-    - The contract \\"ensUniversalResolver\\" was not deployed until block 16773775 (current block 14353601).
+    - The contract \\"ensUniversalResolver\\" was not deployed until block 16966585 (current block 14353601).
 
     Version: viem@1.0.2"
   `)

--- a/src/clients/decorators/public.test.ts
+++ b/src/clients/decorators/public.test.ts
@@ -156,7 +156,7 @@ describe('smoke test', () => {
     'getEnsAddress',
     async () => {
       const blockNumber = await getBlockNumber(publicClient)
-      await setBlockNumber(16773780n)
+      await setBlockNumber(16966590n)
       expect(
         await publicClient.getEnsAddress({ name: 'jxom.eth' }),
       ).toBeDefined()
@@ -169,7 +169,7 @@ describe('smoke test', () => {
     'getEnsAvatar',
     async () => {
       const blockNumber = await getBlockNumber(publicClient)
-      await setBlockNumber(16773780n)
+      await setBlockNumber(16966590n)
       expect(
         await publicClient.getEnsAvatar({ name: 'jxom.eth' }),
       ).toBeDefined()
@@ -182,7 +182,7 @@ describe('smoke test', () => {
     'getEnsName',
     async () => {
       const blockNumber = await getBlockNumber(publicClient)
-      await setBlockNumber(16773780n)
+      await setBlockNumber(16966590n)
       expect(
         await publicClient.getEnsName({ address: address.vitalik }),
       ).toBeDefined()
@@ -195,7 +195,7 @@ describe('smoke test', () => {
     'getEnsResolver',
     async () => {
       const blockNumber = await getBlockNumber(publicClient)
-      await setBlockNumber(16773780n)
+      await setBlockNumber(16966590n)
       expect(
         await publicClient.getEnsResolver({ name: 'jxom.eth' }),
       ).toBeDefined()
@@ -208,7 +208,7 @@ describe('smoke test', () => {
     'getEnsText',
     async () => {
       const blockNumber = await getBlockNumber(publicClient)
-      await setBlockNumber(16773780n)
+      await setBlockNumber(16966590n)
       expect(
         await publicClient.getEnsText({ name: 'jxom.eth', key: 'com.twitter' }),
       ).toBeDefined()

--- a/src/utils/ens/avatar/parseAvatarRecord.test.ts
+++ b/src/utils/ens/avatar/parseAvatarRecord.test.ts
@@ -9,7 +9,7 @@ import {
 import { parseAvatarRecord } from './parseAvatarRecord.js'
 
 beforeAll(async () => {
-  await setBlockNumber(16773780n)
+  await setBlockNumber(16966590n)
 })
 
 test('default', async () => {


### PR DESCRIPTION
The new `UniversalResolver` now reverts with `"Wildcard on non-extended resolvers is not supported"` if it cannot resolve an ENS name. This PR intends to catch those errors and return `null` to ensure behavior is the same.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR upgrades the ENS Universal Resolver contract address and improves error handling in the `getEnsAddress` function. 

### Detailed summary
- Upgrades the ENS Universal Resolver contract address
- Improves error handling in the `getEnsAddress` function

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->