### PR TITLE
Fix withCache errors cached forever

### DIFF
--- a/.changeset/brave-islands-agree.md
+++ b/.changeset/brave-islands-agree.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue in `withCache` where the promise cache would not clear upon rejection.

--- a/src/utils/promise/withCache.ts
+++ b/src/utils/promise/withCache.ts
@@ -59,15 +59,17 @@ export async function withCache<TData>(
     cache.promise.set(promise)
   }
 
-  const data = await promise
+  try {
+    const data = await promise
 
-  // Clear the promise cache so that subsequent invocations will
-  // invoke the promise again.
-  cache.promise.clear()
+    // Store the response in the cache so that subsequent invocations
+    // will return the same response.
+    cache.response.set({ created: new Date(), data })
 
-  // Store the response in the cache so that subsequent invocations
-  // will return the same response.
-  cache.response.set({ created: new Date(), data })
-
-  return data
+    return data
+  } finally {
+    // Clear the promise cache so that subsequent invocations will
+    // invoke the promise again.
+    cache.promise.clear()
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/wagmi-dev/viem/issues/597

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in `withCache` where the promise cache would not clear upon rejection. 

### Detailed summary
- Added a `try` block to wrap the `await` statement.
- Moved the `cache.response.set` call before the `return` statement.
- Added a `finally` block to clear the promise cache.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->