### PR TITLE
Typo in TransactionSerializedEIP2930 description

### DIFF
--- a/site/docs/glossary/types.md
+++ b/site/docs/glossary/types.md
@@ -135,7 +135,7 @@ EIP-1559 transaction hex value – a "0x02"-prefixed string: `"0x02${string}"`
 
 ## `TransactionSerializedEIP2930`
 
-EIP-2930 transaction hex value – a "0x02"-prefixed string: `"0x01${string}"`
+EIP-2930 transaction hex value – a "0x01"-prefixed string: `"0x01${string}"`
 
 ## `TransactionSerializedLegacy`
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the documentation for the `TransactionSerializedEIP2930` type to correct a typo.

### Detailed summary:
- Corrected a typo in the documentation for the `TransactionSerializedEIP2930` type.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->