### PR TITLE
feat: improve ganache test client

### DIFF
--- a/.changeset/tender-coats-cover.md
+++ b/.changeset/tender-coats-cover.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Improved Ganache test actions.

--- a/src/actions/test/getAutomine.ts
+++ b/src/actions/test/getAutomine.ts
@@ -30,7 +30,13 @@ export type GetAutomineReturnType = boolean
 export async function getAutomine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<GetAutomineReturnType> {
-  return await client.request({
-    method: `${client.mode}_getAutomine`,
-  })
+  if (client.mode === 'ganache') {
+    return await client.request({
+      method: 'eth_mining',
+    })
+  } else {
+    return await client.request({
+      method: `${client.mode}_getAutomine`,
+    })
+  }
 }

--- a/src/actions/test/getAutomine.ts
+++ b/src/actions/test/getAutomine.ts
@@ -30,13 +30,11 @@ export type GetAutomineReturnType = boolean
 export async function getAutomine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
 ): Promise<GetAutomineReturnType> {
-  if (client.mode === 'ganache') {
+  if (client.mode === 'ganache')
     return await client.request({
       method: 'eth_mining',
     })
-  } else {
-    return await client.request({
-      method: `${client.mode}_getAutomine`,
-    })
-  }
+  return await client.request({
+    method: `${client.mode}_getAutomine`,
+  })
 }

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -37,15 +37,14 @@ export async function mine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { blocks, interval }: MineParameters,
 ) {
-  if (client.mode === 'ganache') {
+  if (client.mode === 'ganache')
     await client.request({
       method: 'evm_mine',
       params: [{ blocks: numberToHex(blocks) }],
     })
-  } else {
+  else
     await client.request({
       method: `${client.mode}_mine`,
       params: [numberToHex(blocks), numberToHex(interval || 0)],
     })
-  }
 }

--- a/src/actions/test/mine.ts
+++ b/src/actions/test/mine.ts
@@ -37,8 +37,15 @@ export async function mine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { blocks, interval }: MineParameters,
 ) {
-  await client.request({
-    method: `${client.mode}_mine`,
-    params: [numberToHex(blocks), numberToHex(interval || 0)],
-  })
+  if (client.mode === 'ganache') {
+    await client.request({
+      method: 'evm_mine',
+      params: [{ blocks: numberToHex(blocks) }],
+    })
+  } else {
+    await client.request({
+      method: `${client.mode}_mine`,
+      params: [numberToHex(blocks), numberToHex(interval || 0)],
+    })
+  }
 }

--- a/src/actions/test/setAutomine.ts
+++ b/src/actions/test/setAutomine.ts
@@ -29,15 +29,11 @@ export async function setAutomine<TChain extends Chain | undefined>(
   enabled: boolean,
 ) {
   if (client.mode === 'ganache') {
-    if (enabled) {
-      await client.request({ method: 'miner_start' })
-    } else {
-      await client.request({ method: 'miner_stop' })
-    }
-  } else {
+    if (enabled) await client.request({ method: 'miner_start' })
+    else await client.request({ method: 'miner_stop' })
+  } else
     await client.request({
       method: 'evm_setAutomine',
       params: [enabled],
     })
-  }
 }

--- a/src/actions/test/setAutomine.ts
+++ b/src/actions/test/setAutomine.ts
@@ -28,8 +28,16 @@ export async function setAutomine<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   enabled: boolean,
 ) {
-  await client.request({
-    method: 'evm_setAutomine',
-    params: [enabled],
-  })
+  if (client.mode === 'ganache') {
+    if (enabled) {
+      await client.request({ method: 'miner_start' })
+    } else {
+      await client.request({ method: 'miner_stop' })
+    }
+  } else {
+    await client.request({
+      method: 'evm_setAutomine',
+      params: [enabled],
+    })
+  }
 }

--- a/src/actions/test/setBalance.ts
+++ b/src/actions/test/setBalance.ts
@@ -42,15 +42,14 @@ export async function setBalance<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, value }: SetBalanceParameters,
 ) {
-  if (client.mode === 'ganache') {
+  if (client.mode === 'ganache')
     await client.request({
       method: 'evm_setAccountBalance',
       params: [address, numberToHex(value)],
     })
-  } else {
+  else
     await client.request({
       method: `${client.mode}_setBalance`,
       params: [address, numberToHex(value)],
     })
-  }
 }

--- a/src/actions/test/setBalance.ts
+++ b/src/actions/test/setBalance.ts
@@ -42,8 +42,15 @@ export async function setBalance<TChain extends Chain | undefined>(
   client: TestClient<TestClientMode, Transport, TChain>,
   { address, value }: SetBalanceParameters,
 ) {
-  await client.request({
-    method: `${client.mode}_setBalance`,
-    params: [address, numberToHex(value)],
-  })
+  if (client.mode === 'ganache') {
+    await client.request({
+      method: 'evm_setAccountBalance',
+      params: [address, numberToHex(value)],
+    })
+  } else {
+    await client.request({
+      method: `${client.mode}_setBalance`,
+      params: [address, numberToHex(value)],
+    })
+  }
 }

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -667,6 +667,19 @@ export type TestRequests<Name extends string> = {
   request(args: {
     /**
      * @description Modifies the balance of an account.
+     * @link https://ganache.dev/#evm_setAccountBalance
+     */
+    method: `evm_setAccountBalance`
+    params: [
+      /** The address of the target account. */
+      address: Address,
+      /** Amount to send in wei. */
+      value: Quantity,
+    ]
+  }): Promise<void>
+  request(args: {
+    /**
+     * @description Modifies the balance of an account.
      * @link https://hardhat.org/hardhat-network/docs/reference#hardhat_setbalance
      */
     method: `${Name}_setBalance`
@@ -781,6 +794,20 @@ export type TestRequests<Name extends string> = {
   }): Promise<Quantity>
   request(args: {
     /**
+     * @description Enables the automatic mining of new blocks with each new transaction submitted to the network.
+     * @link https://ganache.dev/#miner_start
+     */
+    method: 'miner_start'
+  }): Promise<void>
+  request(args: {
+    /**
+     * @description Disables the automatic mining of new blocks with each new transaction submitted to the network.
+     * @link https://ganache.dev/#miner_stop
+     */
+    method: 'miner_stop'
+  }): Promise<void>
+  request(args: {
+    /**
      * @description Enables or disables, based on the single boolean argument, the automatic mining of new blocks with each new transaction submitted to the network.
      * @link https://hardhat.org/hardhat-network/docs/reference#evm_setautomine
      */
@@ -881,6 +908,29 @@ export type TestRequests<Name extends string> = {
     method: 'eth_sendUnsignedTransaction'
     params: [request: TransactionRequest]
   }): Promise<Hash>
+  request(args: {
+    /**
+     * @description Returns whether the client is actively mining new blocks.
+     * @link https://eips.ethereum.org/EIPS/eip-1474
+     * @example
+     * provider.request({ method: 'eth_mining' })
+     * // => true
+     * */
+    method: 'eth_mining'
+  }): Promise<boolean>
+  request(args: {
+    /**
+     * @description Advance the block number of the network by a certain number of blocks
+     * @link https://ganache.dev/#evm_mine
+     */
+    method: 'evm_mine'
+    params: [
+      {
+        /** Number of blocks to mine. */
+        blocks: Hex
+      },
+    ]
+  }): Promise<void>
 }
 
 export type SignableRequests = {


### PR DESCRIPTION
This commit fixes the few methods I use in Wallet Test Framework, but leaves the majority of them broken.

It also isn't the strictest on typing. It just adds the Ganache-specific RPC endpoints to the `TestRequests` type, instead of more correctly splitting it into two (one for Ganache, and one for anvil/hardhat.)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Ganache test actions and modifies some existing test actions. 

### Detailed summary:
- Added support for Ganache test actions.
- Modified `getAutomine` to work with Ganache.
- Modified `setAutomine` to work with Ganache.
- Modified `setBalance` to work with Ganache.
- Modified `mine` to work with Ganache.
- Added `eth_mining` request to `TestRequests`.
- Added `miner_start` request to `TestRequests`.
- Added `miner_stop` request to `TestRequests`.
- Added `evm_mine` request to `TestRequests`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->