### PR TITLE
Fix function selector computation for functions with no arguments

### DIFF
--- a/.changeset/dull-eyes-speak.md
+++ b/.changeset/dull-eyes-speak.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Fixed computing the function selector for functions with no arguments
+Fixed `getFunctionSelector` for functions with no arguments.

--- a/.changeset/dull-eyes-speak.md
+++ b/.changeset/dull-eyes-speak.md
@@ -1,5 +1,5 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
 Fixed `getFunctionSelector` for functions with no arguments.

--- a/.changeset/dull-eyes-speak.md
+++ b/.changeset/dull-eyes-speak.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Fixed computing the function selector for functions with no arguments

--- a/src/utils/hash/getFunctionSelector.test.ts
+++ b/src/utils/hash/getFunctionSelector.test.ts
@@ -19,4 +19,6 @@ test('creates function signature', () => {
   expect(getFunctionSelector('processAccount(uint256 , address )')).toEqual(
     '0x73933128',
   )
+  expect(getFunctionSelector('claimed()')).toEqual('0xe834a834')
+  expect(getFunctionSelector('function claimed()')).toEqual('0xe834a834')
 })

--- a/src/utils/hash/hashFunction.ts
+++ b/src/utils/hash/hashFunction.ts
@@ -10,7 +10,6 @@ const hash = (value: string) => keccak256(toBytes(value))
 
 export function hashFunction(def: string) {
   const name = extractFunctionName(def)
-  const params = extractFunctionParams(def)
-  if (!params || params.length === 0) return hash(def.replace(/ /g, ''))
+  const params = extractFunctionParams(def) || []
   return hash(`${name}(${params.map(({ type }) => type).join(',')})`)
 }


### PR DESCRIPTION
Current behavior: If you try to compute the function selector of "function claimed()", it will try to hash the following string: "functionclaimed()". 
Expected behavior: It should hash "claimed()" instead

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing `getFunctionSelector` for functions with no arguments. 

### Detailed summary
- Fixed `getFunctionSelector` for functions with no arguments
- Added tests for `getFunctionSelector`
- Refactored `hashFunction` to handle functions with no parameters

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->