### PR TITLE
feat: add contract address to contract type

### DIFF
--- a/.changeset/twenty-donuts-enjoy.md
+++ b/.changeset/twenty-donuts-enjoy.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Expose address and abi on GetContractReturnType
+Added `address` and `abi` properties to Contract Instances.

--- a/.changeset/twenty-donuts-enjoy.md
+++ b/.changeset/twenty-donuts-enjoy.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Expose address and abi on GetContractReturnType

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,4 @@
-lockfileVersion: '6.1'
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
+lockfileVersion: '6.0'
 
 overrides:
   viem: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   viem: workspace:*

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -47,6 +47,8 @@ test('public and wallet client', () => {
     | 'simulate'
     | 'watchEvent'
     | 'write'
+    | 'address'
+    | 'abi'
   >()
 })
 
@@ -57,7 +59,13 @@ test('no wallet client', () => {
   })
 
   expectTypeOf<keyof typeof contract>().toEqualTypeOf<
-    'createEventFilter' | 'estimateGas' | 'read' | 'simulate' | 'watchEvent'
+    | 'createEventFilter'
+    | 'estimateGas'
+    | 'read'
+    | 'simulate'
+    | 'watchEvent'
+    | 'address'
+    | 'abi'
   >()
 })
 
@@ -67,7 +75,9 @@ test('no public client', () => {
     walletClient,
   })
 
-  expectTypeOf<keyof typeof contract>().toEqualTypeOf<'estimateGas' | 'write'>()
+  expectTypeOf<keyof typeof contract>().toEqualTypeOf<
+    'estimateGas' | 'write' | 'address' | 'abi'
+  >()
 })
 
 test('without const assertion on `abi`', () => {
@@ -580,7 +590,7 @@ test('empty abi', () => {
     publicClient,
     walletClient,
   })
-  expectTypeOf(contract).toEqualTypeOf<{}>()
+  expectTypeOf<keyof typeof contract>().toEqualTypeOf<'address' | 'abi'>()
 })
 
 test('argument permutations', async () => {

--- a/src/actions/getContract.test.ts
+++ b/src/actions/getContract.test.ts
@@ -22,6 +22,14 @@ const contract = getContract({
   walletClient,
 })
 
+test('address', () => {
+  expect(contract.address).toBe(wagmiContractConfig.address)
+})
+
+test('abi', () => {
+  expect(contract.abi).toEqual(wagmiContractConfig.abi)
+})
+
 test('createEventFilter', async () => {
   await expect(
     contract.createEventFilter.Transfer({

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -351,7 +351,7 @@ export type GetContractReturnType<
               >
             }
           }
-      : unknown)
+      : unknown) & { address: Address }
 >
 
 /**
@@ -615,6 +615,7 @@ export function getContract<
           },
         },
       )
+  contract.address = address
 
   return contract as unknown as GetContractReturnType<
     TAbi,

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -351,8 +351,8 @@ export type GetContractReturnType<
               >
             }
           }
-      : unknown) & { address: Address }
->
+      : unknown)
+> & { address: Address; abi: TAbi }
 
 /**
  * Gets type-safe interface for performing contract-related actions with a specific `abi` and `address`.
@@ -413,7 +413,9 @@ export function getContract<
       | 'read'
       | 'simulate'
       | 'watchEvent'
-      | 'write']?: unknown
+      | 'write'
+      | 'address'
+      | 'abi']?: unknown
   } = {}
 
   let hasReadFunction = false
@@ -616,6 +618,7 @@ export function getContract<
         },
       )
   contract.address = address
+  contract.abi = abi
 
   return contract as unknown as GetContractReturnType<
     TAbi,


### PR DESCRIPTION
- closes https://github.com/wagmi-dev/viem/discussions/535
- targets https://github.com/wagmi-dev/viem/discussions/504#discussioncomment-6046787

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `address` and `abi` properties to Contract Instances in `getContract` function.

### Detailed summary
- Added `address` and `abi` properties to Contract Instances.
- Updated `getContract` function to include `address` and `abi` as optional parameters.
- Added tests for `address` and `abi` properties.
- Updated `getContract` typings to include `address` and `abi`.
- Added test cases for updated typings.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->