### PR TITLE
chore: exported missing type

### DIFF
--- a/.changeset/rich-clocks-juggle.md
+++ b/.changeset/rich-clocks-juggle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported missing portable type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
   type ParseAbiParameters,
   type TypedData,
   type TypedDataDomain,
+  type TypedDataParameter,
   CircularReferenceError,
   InvalidAbiParameterError,
   InvalidAbiParametersError,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a missing exported portable type and includes changes to the `TypedDataParameter`, `CircularReferenceError`, `InvalidAbiParameterError`, and `InvalidAbiParametersError` types.

### Detailed summary
- Added missing exported portable type for `viem`
- Included changes to the following types:
  - `TypedDataParameter`
  - `CircularReferenceError`
  - `InvalidAbiParameterError`
  - `InvalidAbiParametersError`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->