### PR TITLE
feat: support multiple events in getLogs

### DIFF
--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -30,6 +30,27 @@ const event = {
     name: 'Transfer',
     type: 'event',
   },
+  approve: {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+  },
   unnamed: {
     inputs: [
       {
@@ -88,6 +109,23 @@ describe('default', () => {
     expect(filter.args).toBeUndefined()
     expect(filter.abi).toEqual([event.default])
     expect(filter.eventName).toEqual('Transfer')
+  })
+
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [event.default, event.approve],
+    })
+    assertType<typeof filter>({
+      abi: [event.default, event.approve],
+      eventName: undefined,
+      id: '0x',
+      request,
+      strict: undefined,
+      type: 'event',
+    })
+    expect(filter.args).toBeUndefined()
+    expect(filter.abi).toEqual([event.default, event.approve])
+    expect(filter.eventName).toBeUndefined()
   })
 
   test('args: args (named)', async () => {

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -1,4 +1,4 @@
-import type { Abi, AbiEvent, Address, Narrow } from 'abitype'
+import type { AbiEvent, Address, Narrow } from 'abitype'
 
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
@@ -20,18 +20,21 @@ import { createFilterRequestScope } from '../../utils/filters/createFilterReques
 
 export type CreateEventFilterParameters<
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
-  _Abi extends Abi | readonly unknown[] = [TAbiEvent],
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
   _Args extends
-    | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+    | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
     | undefined = undefined,
 > = {
   address?: Address | Address[]
   fromBlock?: BlockNumber | BlockTag
   toBlock?: BlockNumber | BlockTag
 } & (MaybeExtractEventArgsFromAbi<
-  _Abi,
+  TAbiEvents,
   _EventName
 > extends infer TEventFilterArgs
   ?
@@ -40,6 +43,7 @@ export type CreateEventFilterParameters<
             | TEventFilterArgs
             | (_Args extends TEventFilterArgs ? _Args : never)
           event: Narrow<TAbiEvent>
+          events?: never
           /**
            * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
            * @default false
@@ -49,6 +53,7 @@ export type CreateEventFilterParameters<
       | {
           args?: never
           event?: Narrow<TAbiEvent>
+          events?: never
           /**
            * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
            * @default false
@@ -58,23 +63,38 @@ export type CreateEventFilterParameters<
       | {
           args?: never
           event?: never
+          events: Narrow<TAbiEvents>
+          /**
+           * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
+           * @default false
+           */
+          strict?: TStrict
+        }
+      | {
+          args?: never
+          event?: never
+          events?: never
           strict?: never
         }
   : {
       args?: never
       event?: never
+      events?: never
       strict?: never
     })
 
 export type CreateEventFilterReturnType<
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
-  _Abi extends Abi | readonly unknown[] = [TAbiEvent],
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
   _Args extends
-    | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+    | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
     | undefined = undefined,
-> = Prettify<Filter<'event', _Abi, _EventName, _Args, TStrict>>
+> = Prettify<Filter<'event', TAbiEvents, _EventName, _Args, TStrict>>
 
 /**
  * Creates a [`Filter`](https://viem.sh/docs/glossary/types.html#filter) to listen for new events that can be used with [`getFilterChanges`](https://viem.sh/docs/actions/public/getFilterChanges.html).
@@ -101,12 +121,15 @@ export type CreateEventFilterReturnType<
  */
 export async function createEventFilter<
   TChain extends Chain | undefined,
-  TAbiEvent extends AbiEvent | undefined,
+  TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
-  _Abi extends Abi | readonly unknown[] = [TAbiEvent],
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
   _Args extends
-    | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+    | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
     | undefined = undefined,
 >(
   client: Client<Transport, TChain>,
@@ -114,30 +137,39 @@ export async function createEventFilter<
     address,
     args,
     event,
+    events: events_,
     fromBlock,
     strict,
     toBlock,
   }: CreateEventFilterParameters<
     TAbiEvent,
+    TAbiEvents,
     TStrict,
-    _Abi,
     _EventName,
     _Args
   > = {} as any,
 ): Promise<
-  CreateEventFilterReturnType<TAbiEvent, TStrict, _Abi, _EventName, _Args>
+  CreateEventFilterReturnType<TAbiEvent, TAbiEvents, TStrict, _EventName, _Args>
 > {
+  const events = events_ ?? (event ? [event] : undefined)
+
   const getRequest = createFilterRequestScope(client, {
     method: 'eth_newFilter',
   })
 
   let topics: LogTopic[] = []
-  if (event)
-    topics = encodeEventTopics({
-      abi: [event],
-      eventName: (event as AbiEvent).name,
-      args,
-    } as EncodeEventTopicsParameters)
+  if (events) {
+    topics = [
+      (events as AbiEvent[]).flatMap((event) =>
+        encodeEventTopics({
+          abi: [event],
+          eventName: (event as AbiEvent).name,
+          args,
+        } as EncodeEventTopicsParameters),
+      ),
+    ]
+    if (event) topics = topics[0] as LogTopic[]
+  }
 
   const id = await client.request({
     method: 'eth_newFilter',
@@ -153,7 +185,7 @@ export async function createEventFilter<
   })
 
   return {
-    abi: event ? [event] : undefined,
+    abi: events,
     args,
     eventName: event ? (event as AbiEvent).name : undefined,
     id,
@@ -162,8 +194,8 @@ export async function createEventFilter<
     type: 'event',
   } as unknown as CreateEventFilterReturnType<
     TAbiEvent,
+    TAbiEvents,
     TStrict,
-    _Abi,
     _EventName,
     _Args
   >

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -169,6 +169,95 @@ describe('createEventFilter', () => {
     >()
   })
 
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+        {
+          type: 'event',
+          name: 'Approval',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+  })
+
   test('strict: named', async () => {
     const filter = await createEventFilter(publicClient, {
       event: {
@@ -320,6 +409,37 @@ describe('createContractEventFilter', () => {
           spender?: Address
           value?: bigint
         }
+      | {
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(logs[0].eventName === 'Foo' && logs[0].args).toEqualTypeOf<
+      | false
       | {
           owner?: Address
           spender?: Address

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -15,8 +15,8 @@ import { formatLog } from '../../utils/formatters/log.js'
 
 export type GetFilterChangesParameters<
   TFilterType extends FilterType = FilterType,
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
 > = {
   filter: Filter<TFilterType, TAbi, TEventName, any, TStrict>
@@ -24,8 +24,8 @@ export type GetFilterChangesParameters<
 
 export type GetFilterChangesReturnType<
   TFilterType extends FilterType = FilterType,
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   _AbiEvent extends AbiEvent | undefined = TAbi extends Abi
     ? TEventName extends string
@@ -122,7 +122,7 @@ export async function getFilterChanges<
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TFilterType extends FilterType,
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] | undefined,
   TEventName extends string | undefined,
   TStrict extends boolean | undefined = undefined,
 >(

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -169,6 +169,95 @@ describe('createEventFilter', () => {
     >()
   })
 
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+        {
+          type: 'event',
+          name: 'Approval',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+  })
+
   test('strict: named', async () => {
     const filter = await createEventFilter(publicClient, {
       event: {

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -52,6 +52,27 @@ const event = {
     name: 'Transfer',
     type: 'event',
   },
+  approve: {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+  },
   invalid: {
     inputs: [
       {
@@ -645,6 +666,42 @@ describe('raw events', () => {
       value: 1n,
     })
     expect(logs[1].eventName).toEqual('Transfer')
+  })
+
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [event.default, event.approve],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'approve',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+
+    await mine(testClient, { blocks: 1 })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+    expect(logs.length).toBe(2)
+    expect(logs[0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0].eventName).toEqual('Transfer')
+    expect(logs[1].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(accounts[1].address),
+      value: 1n,
+    })
+    expect(logs[1].eventName).toEqual('Approval')
   })
 
   test('args: fromBlock/toBlock', async () => {

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -13,15 +13,15 @@ import { decodeEventLog } from '../../utils/abi/decodeEventLog.js'
 import { formatLog } from '../../utils/formatters/log.js'
 
 export type GetFilterLogsParameters<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
 > = {
   filter: Filter<'event', TAbi, TEventName, any, TStrict>
 }
 export type GetFilterLogsReturnType<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   _AbiEvent extends AbiEvent | undefined = TAbi extends Abi
     ? TEventName extends string
@@ -59,7 +59,7 @@ export type GetFilterLogsReturnType<
  */
 export async function getFilterLogs<
   TChain extends Chain | undefined,
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] | undefined,
   TEventName extends string | undefined,
   TStrict extends boolean | undefined = undefined,
 >(

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -40,7 +40,6 @@ test('event: const assertion', async () => {
   const logs = await getLogs(publicClient, {
     event,
   })
-  logs[0].topics
   expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<
     [`0x${string}`, `0x${string}`, `0x${string}`]

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -308,23 +308,32 @@ export type PublicActions<
    * })
    */
   createEventFilter: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
-    _Abi extends Abi | readonly unknown[] = [TAbiEvent],
     _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
     _Args extends
-      | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+      | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
       | undefined = undefined,
   >(
     args?: CreateEventFilterParameters<
       TAbiEvent,
+      TAbiEvents,
       TStrict,
-      _Abi,
       _EventName,
       _Args
     >,
   ) => Promise<
-    CreateEventFilterReturnType<TAbiEvent, TStrict, _Abi, _EventName, _Args>
+    CreateEventFilterReturnType<
+      TAbiEvent,
+      TAbiEvents,
+      TStrict,
+      _EventName,
+      _Args
+    >
   >
   /**
    * Creates a Filter to listen for new pending transaction hashes that can be used with [`getFilterChanges`](https://viem.sh/docs/actions/public/getFilterChanges.html).
@@ -807,7 +816,7 @@ export type PublicActions<
    */
   getFilterChanges: <
     TFilterType extends FilterType,
-    TAbi extends Abi | readonly unknown[],
+    TAbi extends Abi | readonly unknown[] | undefined,
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
   >(
@@ -842,7 +851,7 @@ export type PublicActions<
    * const logs = await client.getFilterLogs({ filter })
    */
   getFilterLogs: <
-    TAbi extends Abi | readonly unknown[],
+    TAbi extends Abi | readonly unknown[] | undefined,
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
   >(
@@ -888,11 +897,15 @@ export type PublicActions<
    * const logs = await client.getLogs()
    */
   getLogs: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
   >(
-    args?: GetLogsParameters<TAbiEvent, TStrict>,
-  ) => Promise<GetLogsReturnType<TAbiEvent, TStrict>>
+    args?: GetLogsParameters<TAbiEvent, TAbiEvents, TStrict>,
+  ) => Promise<GetLogsReturnType<TAbiEvent, TAbiEvents, TStrict>>
   /**
    * Returns the value from a storage slot at a given address.
    *
@@ -1336,10 +1349,14 @@ export type PublicActions<
    * })
    */
   watchEvent: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
   >(
-    args: WatchEventParameters<TAbiEvent, TStrict>,
+    args: WatchEventParameters<TAbiEvent, TAbiEvents, TStrict>,
   ) => WatchEventReturnType
   /**
    * Watches and returns pending transaction hashes.
@@ -1406,7 +1423,7 @@ export function publicActions<
     getFilterChanges: (args) => getFilterChanges(client, args),
     getFilterLogs: (args) => getFilterLogs(client, args),
     getGasPrice: () => getGasPrice(client),
-    getLogs: (args) => getLogs(client, args),
+    getLogs: (args) => getLogs(client, args as any),
     getStorageAt: (args) => getStorageAt(client, args),
     getTransaction: (args) => getTransaction(client, args),
     getTransactionConfirmations: (args) =>

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -83,9 +83,13 @@ export type MaybeAbiEventName<TAbiEvent extends AbiEvent | undefined> =
   TAbiEvent extends AbiEvent ? TAbiEvent['name'] : undefined
 
 export type MaybeExtractEventArgsFromAbi<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = undefined,
-> = TEventName extends string ? GetEventArgs<TAbi, TEventName> : undefined
+  TAbi extends Abi | readonly unknown[] | undefined,
+  TEventName extends string | undefined,
+> = TAbi extends Abi | readonly unknown[]
+  ? TEventName extends string
+    ? GetEventArgs<TAbi, TEventName>
+    : undefined
+  : undefined
 
 //////////////////////////////////////////////////////////////////////
 // ABI item name

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -16,7 +16,7 @@ type FilterRpcSchema = Filter_<
 
 export type Filter<
   TFilterType extends FilterType = 'event',
-  TAbi extends Abi | readonly unknown[] = Abi,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
   TEventName extends string | undefined = undefined,
   TArgs extends
     | MaybeExtractEventArgsFromAbi<TAbi, TEventName>

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -17,7 +17,9 @@ export type Log<
   TIndex = number,
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
-  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
+  TAbi extends Abi | readonly unknown[] | undefined = TAbiEvent extends AbiEvent
+    ? [TAbiEvent]
+    : undefined,
   TEventName extends string | undefined = TAbiEvent extends AbiEvent
     ? TAbiEvent['name']
     : undefined,
@@ -79,7 +81,9 @@ type GetTopics<
 
 type GetInferredLogValues<
   TAbiEvent extends AbiEvent | undefined = undefined,
-  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
+  TAbi extends Abi | readonly unknown[] | undefined = TAbiEvent extends AbiEvent
+    ? [TAbiEvent]
+    : undefined,
   TEventName extends string | undefined = TAbiEvent extends AbiEvent
     ? TAbiEvent['name']
     : undefined,
@@ -110,7 +114,7 @@ type GetInferredLogValues<
         [TName in _EventNames]: {
           args: GetEventArgs<
             TAbi,
-            string,
+            TName,
             {
               EnableUnion: false
               IndexedOnly: false


### PR DESCRIPTION
Allows for `event` arg in `getLogs` to accept an array of events.

Just wanted to get a gut check on this before I add tests+docs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving type definitions and adding support for multiple events in the getLogs function.

### Detailed summary
- Updated type definitions in various files.
- Added support for multiple events in the getLogs function.

> The following files were skipped due to too many changes: `src/actions/public/getFilterChanges.test.ts`, `src/actions/public/getFilterChanges.test-d.ts`, `src/actions/public/watchEvent.test.ts`, `src/clients/decorators/public.ts`, `src/actions/public/getLogs.ts`, `src/actions/public/createEventFilter.ts`, `src/actions/public/watchEvent.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->