### PR TITLE
chore: bump abitype

### DIFF
--- a/.changeset/lovely-candles-behave.md
+++ b/.changeset/lovely-candles-behave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated abitype

--- a/.changeset/lovely-candles-behave.md
+++ b/.changeset/lovely-candles-behave.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Updated abitype
+Updated `abitype` to 0.8.7.

--- a/package.json
+++ b/package.json
@@ -111,39 +111,17 @@
   },
   "typesVersions": {
     "*": {
-      "abi": [
-        "./dist/types/abi.d.ts"
-      ],
-      "accounts": [
-        "./dist/types/accounts/index.d.ts"
-      ],
-      "chains": [
-        "./dist/types/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/contract.d.ts"
-      ],
-      "ens": [
-        "./dist/types/ens.d.ts"
-      ],
-      "ethers": [
-        "./dist/types/ethers.d.ts"
-      ],
-      "public": [
-        "./dist/types/public.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "utils": [
-        "./dist/types/utils/index.d.ts"
-      ],
-      "wallet": [
-        "./dist/types/wallet.d.ts"
-      ],
-      "window": [
-        "./dist/types/window.d.ts"
-      ]
+      "abi": ["./dist/types/abi.d.ts"],
+      "accounts": ["./dist/types/accounts/index.d.ts"],
+      "chains": ["./dist/types/chains.d.ts"],
+      "contract": ["./dist/types/contract.d.ts"],
+      "ens": ["./dist/types/ens.d.ts"],
+      "ethers": ["./dist/types/ethers.d.ts"],
+      "public": ["./dist/types/public.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "utils": ["./dist/types/utils/index.d.ts"],
+      "wallet": ["./dist/types/wallet.d.ts"],
+      "window": ["./dist/types/window.d.ts"]
     }
   },
   "dependencies": {
@@ -153,7 +131,7 @@
     "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0",
     "@wagmi/chains": "0.3.1",
-    "abitype": "0.8.2",
+    "abitype": "0.8.7",
     "isomorphic-ws": "5.0.0",
     "ws": "8.12.0"
   },
@@ -183,23 +161,14 @@
   },
   "license": "MIT",
   "repository": "wagmi-dev/viem",
-  "authors": [
-    "awkweb.eth",
-    "jxom.eth"
-  ],
+  "authors": ["awkweb.eth", "jxom.eth"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "eth",
-    "ethereum",
-    "dapps",
-    "wallet",
-    "web3"
-  ],
+  "keywords": ["eth", "ethereum", "dapps", "wallet", "web3"],
   "size-limit": [
     {
       "path": "./dist/cjs/index.js"
@@ -217,9 +186,7 @@
       "vitepress@1.0.0-alpha.61": "patches/vitepress@1.0.0-alpha.61.patch"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1(typescript@5.0.4)
       abitype:
-        specifier: 0.8.2
-        version: 0.8.2(typescript@5.0.4)
+        specifier: 0.8.7
+        version: 0.8.7(typescript@5.0.4)
       isomorphic-ws:
         specifier: 5.0.0
         version: 5.0.0(ws@8.12.0)
@@ -2805,8 +2805,8 @@ packages:
       zod: 3.20.2
     dev: true
 
-  /abitype@0.8.2(typescript@5.0.4):
-    resolution: {integrity: sha512-B1ViNMGpfx/qjVQi0RTc2HEFHuR9uoCoTEkwELT5Y7pBPtBbctYijz9BK6+Kd0hQ3S70FhYTO2dWWk0QNUEXMA==}
+  /abitype@0.8.7(typescript@5.0.4):
+    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `abitype` package to version 0.8.7.

### Detailed summary
- Updates `abitype` to version 0.8.7
- Updates `pnpm-lock.yaml` with new `abitype` version
- Removes unnecessary lines from `package.json`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->