### PR TITLE
refactor: strict mode on `getLogs`, `getFilterChanges`, `getFilterLogs`, `decodeEventLog`

### DIFF
--- a/site/docs/actions/public/createEventFilter.md
+++ b/site/docs/actions/public/createEventFilter.md
@@ -186,10 +186,10 @@ const filter = await publicClient.createEventFilter({
 
 ### Strict Mode
 
-By default, `createEventFilter` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`, however,
-the `args` property will be `undefined` for non-conforming logs as we cannot deterministically decode them.
+By default, `createEventFilter` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`.
+viem will not return a value for arguments that do not conform to the ABI, thus, some arguments on `args` may be undefined.
 
-```ts
+```ts {8}
 const filter = await publicClient.createEventFilter({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),
@@ -197,12 +197,12 @@ const filter = await publicClient.createEventFilter({
 const logs = await publicClient.getFilterLogs({ filter })
 
 logs[0].args
-//      ^? { address: Address, to: Address, value: bigint } | undefined
+//      ^? { address?: Address, to?: Address, value?: bigint }
 ```
 
 You can turn on `strict` mode to only return logs that conform to the indexed & non-indexed arguments on the `event`, meaning that `args` will always be defined. The trade-off is that non-conforming logs will be filtered out.
 
-```ts
+```ts {8}
 const filter = await publicClient.createEventFilter({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),

--- a/site/docs/actions/public/getLogs.md
+++ b/site/docs/actions/public/getLogs.md
@@ -218,21 +218,22 @@ const filter = await publicClient.getLogs({
 
 ### Strict Mode
 
-By default, `getLogs` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`, however, the `args` property will be `undefined` for non-conforming logs as we cannot deterministically decode them.
+By default, `getLogs` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`. 
+viem will not return a value for arguments that do not conform to the ABI, thus, some arguments on `args` may be undefined.
 
-```ts
+```ts {7}
 const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)')
 })
 
 logs[0].args
-//      ^? { address: Address, to: Address, value: bigint } | undefined
+//      ^? { address?: Address, to?: Address, value?: bigint }
 ```
 
 You can turn on `strict` mode to only return logs that conform to the indexed & non-indexed arguments on the `event`, meaning that `args` will always be defined. The trade-off is that non-conforming logs will be filtered out.
 
-```ts
+```ts {7}
 const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),

--- a/site/docs/contract/createContractEventFilter.md
+++ b/site/docs/contract/createContractEventFilter.md
@@ -153,22 +153,22 @@ const filter = await publicClient.createContractEventFilter({
 
 ### Strict Mode
 
-By default, `createContractEventFilter` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`, however,
-the `args` property will be `undefined` for non-conforming logs as we cannot deterministically decode them.
+By default, `createContractEventFilter` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`.
+viem will not return a value for arguments that do not conform to the ABI, thus, some arguments on `args` may be undefined.
 
-```ts
+```ts {7}
 const filter = await publicClient.createContractEventFilter({
   eventName: 'Transfer',
 })
 const logs = await publicClient.getFilterLogs({ filter })
 
 logs[0].args
-//      ^? { address: Address, to: Address, value: bigint } | undefined
+//      ^? { address?: Address, to?: Address, value?: bigint }
 ```
 
 You can turn on `strict` mode to only return logs that conform to the indexed & non-indexed arguments on the `event`, meaning that `args` will always be defined. The trade-off is that non-conforming logs will be filtered out.
 
-```ts
+```ts {7}
 const filter = await publicClient.createContractEventFilter({
   eventName: 'Transfer',
   strict: true

--- a/site/docs/migration-guide.md
+++ b/site/docs/migration-guide.md
@@ -60,11 +60,21 @@ decodeEventLog({
 })
 ```
 
-Previously, the above would only decode the `indexed` arguments.
+Previously, the above would only decode the `indexed` arguments. 
 
-### Minor: `getLogs`, `getFilterLogs`, `getFilterChanges` behavior change
+If you would like to partially decode event logs (previous behavior), you can pass the `strict` argument:
 
-Similarly to the above, `getLogs`, `getFilterLogs`, `getFilterChanges` no longer attempts to decode event args if it does not match the event definition/ABI (`event`) (ie. mismatch between the number of indexed & non-indexed arguments to `topics` & `data`). If there is an error decoding the event args, `args` will be `undefined` on the Log.
+```ts {2-4}
+decodeEventLog({
+  abi: parseAbi(['event Transfer(address indexed, address, uint256)']),
+  data: '0x0000000000000000000000000000000000000000000000000000000000000001'
+  topics: [
+    '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+    '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+  ],
+  strict: true // [!code ++]
+})
+```
 
 ## 0.3.x Breaking changes
 

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -748,6 +748,27 @@ test('argument permutations', async () => {
     .toEqualTypeOf<'WithIndexedUnnamedInputs'>
   expectTypeOf(createEventFilter_2.args).toEqualTypeOf<['foo']>()
 
+  const createEventFilter_loose =
+    await contract.createEventFilter.WithMixedNamedInputs({
+      x: 'foo',
+    })
+  expectTypeOf(createEventFilter_loose.strict).toEqualTypeOf<undefined>()
+
+  const createEventFilter_lax =
+    await contract.createEventFilter.WithMixedNamedInputs({
+      x: 'foo',
+    })
+  expectTypeOf(createEventFilter_lax.strict).toEqualTypeOf<undefined>()
+
+  const createEventFilter_strict =
+    await contract.createEventFilter.WithMixedNamedInputs(
+      {
+        x: 'foo',
+      },
+      { strict: true },
+    )
+  expectTypeOf(createEventFilter_strict.strict).toEqualTypeOf<true>()
+
   // watchEvent
   // @ts-expect-error
   contract.watchEvent.WithoutInputs()

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -858,25 +858,30 @@ type GetEventFilter<
   Options = Prettify<
     Omit<
       CreateContractEventFilterParameters<TAbi, TEventName>,
-      'abi' | 'address' | 'args' | 'eventName'
+      'abi' | 'address' | 'args' | 'eventName' | 'strict'
     >
   >,
   IndexedInputs = Extract<TAbiEvent['inputs'][number], { indexed: true }>,
 > = Narrowable extends true
-  ? <TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined>(
+  ? <
+      TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
+      TStrict extends boolean | undefined = undefined,
+    >(
       ...parameters: IsNever<IndexedInputs> extends true
-        ? [options?: Options]
+        ? [options?: Options & { strict?: TStrict }]
         : [
             args: Args | (Args extends Narrow<TArgs> ? Narrow<TArgs> : never),
-            options?: Options,
+            options?: Options & { strict?: TStrict },
           ]
-    ) => Promise<CreateContractEventFilterReturnType<TAbi, TEventName, TArgs>>
-  : (
+    ) => Promise<
+      CreateContractEventFilterReturnType<TAbi, TEventName, TArgs, TStrict>
+    >
+  : <TStrict extends boolean | undefined = undefined>(
       ...parameters:
-        | [options?: Options]
+        | [options?: Options & { strict?: TStrict }]
         | [
             args: readonly unknown[] | CreateContractFilterOptions,
-            options?: Options,
+            options?: Options & { strict?: TStrict },
           ]
     ) => Promise<CreateContractEventFilterReturnType>
 

--- a/src/actions/public/createContractEventFilter.test.ts
+++ b/src/actions/public/createContractEventFilter.test.ts
@@ -22,6 +22,7 @@ test('default', async () => {
     args: undefined,
     eventName: undefined,
     request,
+    strict: undefined,
   })
   expect(filter.id).toBeDefined()
   expect(filter.type).toBe('event')

--- a/src/actions/public/createContractEventFilter.ts
+++ b/src/actions/public/createContractEventFilter.ts
@@ -85,7 +85,7 @@ export async function createContractEventFilter<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
   TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
-  TStrict extends boolean | undefined,
+  TStrict extends boolean | undefined = undefined,
 >(
   client: PublicClient<Transport, TChain>,
   {

--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -82,6 +82,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter.args).toBeUndefined()
@@ -106,6 +107,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter.args).toEqual({
@@ -129,6 +131,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter2.args).toEqual({
@@ -151,6 +154,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter3.args).toEqual({
@@ -171,6 +175,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter1.args).toEqual([accounts[0].address, accounts[1].address])
@@ -187,6 +192,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter2.args).toEqual([[accounts[0].address, accounts[1].address]])
@@ -203,6 +209,7 @@ describe('default', () => {
       eventName: 'Transfer',
       id: '0x',
       request,
+      strict: undefined,
       type: 'event',
     })
     expect(filter3.args).toEqual([null, accounts[0].address])

--- a/src/actions/public/createEventFilter.ts
+++ b/src/actions/public/createEventFilter.ts
@@ -102,7 +102,7 @@ export type CreateEventFilterReturnType<
 export async function createEventFilter<
   TChain extends Chain | undefined,
   TAbiEvent extends AbiEvent | undefined,
-  TStrict extends boolean | undefined,
+  TStrict extends boolean | undefined = undefined,
   _Abi extends Abi | readonly unknown[] = [TAbiEvent],
   _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
   _Args extends

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -62,16 +62,13 @@ describe('createEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: event: defined as const', async () => {
@@ -116,16 +113,13 @@ describe('createEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: event: defined as `AbiEvent`', async () => {
@@ -170,7 +164,9 @@ describe('createEventFilter', () => {
       [] | [`0x${string}`, ...`0x${string}`[]]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[] | undefined>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly unknown[] | Record<string, unknown>
+    >()
   })
 
   test('strict: named', async () => {
@@ -304,7 +300,7 @@ describe('createContractEventFilter', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, typeof abi>[]
+      Log<bigint, number, undefined, false, typeof abi>[]
     >()
     expectTypeOf(logs[0].topics).toEqualTypeOf<
       | [`0x${string}`, `0x${string}`, `0x${string}`]
@@ -315,23 +311,22 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
         }
-      | undefined
     >()
   })
 
@@ -348,16 +343,13 @@ describe('createContractEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: abi: defined inline', async () => {
@@ -404,16 +396,13 @@ describe('createContractEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: abi: declared as `Abi`', async () => {
@@ -461,7 +450,9 @@ describe('createContractEventFilter', () => {
       [] | [`0x${string}`, ...`0x${string}`[]]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[] | undefined>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly unknown[] | Record<string, unknown>
+    >()
   })
 
   test('strict', async () => {

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -209,9 +209,9 @@ describe('contract events', () => {
       filter,
     })
 
-    assertType<Log<bigint, number, undefined, typeof usdcContractConfig.abi>[]>(
-      logs,
-    )
+    assertType<
+      Log<bigint, number, undefined, false, typeof usdcContractConfig.abi>[]
+    >(logs)
     expect(logs.length).toBe(3)
     expect(logs[0].args).toEqual({
       from: getAddress(address.vitalik),
@@ -265,6 +265,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -298,11 +299,35 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
     >(logs)
     expect(logs.length).toBe(1056)
+  })
+
+  test('args: strict', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi: usdcContractConfig.abi,
+      eventName: 'Transfer',
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    const logs = await getFilterChanges(publicClient, { filter })
+    assertType<
+      Log<
+        bigint,
+        number,
+        undefined,
+        true,
+        typeof usdcContractConfig.abi,
+        'Transfer'
+      >[]
+    >(logs)
+    expect(logs.length).toBe(784)
   })
 
   test('args: singular `from`', async () => {
@@ -340,6 +365,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -388,6 +414,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -442,6 +469,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -490,6 +518,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -663,14 +692,11 @@ describe('events', () => {
       Log<bigint, number, typeof event.default>[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          from: Address
-          to: Address
-          value: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from?: Address
+      to?: Address
+      value?: bigint
+    }>()
 
     expect(logs.length).toBe(2)
     expect(logs[0].args).toEqual({
@@ -722,6 +748,126 @@ describe('events', () => {
       to: '0x393ADf60012809316659Af13A3117ec22D093a38',
       value: 1162592016924672n,
     })
+    expect(logs[0].eventName).toEqual('Transfer')
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(0)
+  })
+
+  test('args: strict = true (named)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    let logs = await getFilterChanges(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from: Address
+      to: Address
+      value: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(0)
+  })
+
+  test('args: strict = false (named)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    let logs = await getFilterChanges(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from?: Address
+      to?: Address
+      value?: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(0)
+  })
+
+  test('args: strict = true (unnamed)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    let logs = await getFilterChanges(publicClient, { filter })
+    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly [`0x${string}`, `0x${string}`, bigint]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(0)
+  })
+
+  test('args: strict = false (unnamed)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    let logs = await getFilterChanges(publicClient, { filter })
+    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | readonly []
+      | readonly [`0x${string}`, `0x${string}`, bigint]
+      | readonly [`0x${string}`, `0x${string}`]
+      | readonly [`0x${string}`]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
     expect(logs[0].eventName).toEqual('Transfer')
 
     logs = await getFilterChanges(publicClient, { filter })

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -62,16 +62,13 @@ describe('createEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: event: defined as const', async () => {
@@ -116,16 +113,13 @@ describe('createEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: event: defined as `AbiEvent`', async () => {
@@ -170,7 +164,9 @@ describe('createEventFilter', () => {
       [] | [`0x${string}`, ...`0x${string}`[]]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[] | undefined>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly unknown[] | Record<string, unknown>
+    >()
   })
 
   test('strict: named', async () => {
@@ -304,7 +300,7 @@ describe('createContractEventFilter', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, typeof abi>[]
+      Log<bigint, number, undefined, false, typeof abi>[]
     >()
     expectTypeOf(logs[0].topics).toEqualTypeOf<
       | [`0x${string}`, `0x${string}`, `0x${string}`]
@@ -315,23 +311,22 @@ describe('createContractEventFilter', () => {
     >()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
         }
-      | undefined
     >()
   })
 
@@ -348,16 +343,13 @@ describe('createContractEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: abi: defined inline', async () => {
@@ -404,16 +396,13 @@ describe('createContractEventFilter', () => {
       [`0x${string}`, `0x${string}`, `0x${string}`, `0x${string}`]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Foo'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          owner: Address
-          spender: Address
-          foo: Address
-          value: bigint
-          bar: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      owner?: Address
+      spender?: Address
+      foo?: Address
+      value?: bigint
+      bar?: bigint
+    }>()
   })
 
   test('args: abi: declared as `Abi`', async () => {
@@ -461,7 +450,9 @@ describe('createContractEventFilter', () => {
       [] | [`0x${string}`, ...`0x${string}`[]]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<string>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<readonly unknown[] | undefined>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly unknown[] | Record<string, unknown>
+    >()
   })
 
   test('strict', async () => {

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -155,21 +155,20 @@ describe('contract events', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, typeof usdcContractConfig.abi>[]
+      Log<bigint, number, undefined, false, typeof usdcContractConfig.abi>[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<
       | {
-          from: Address
-          to: Address
-          value: bigint
+          from?: Address
+          to?: Address
+          value?: bigint
         }
       | {
-          owner: Address
-          spender: Address
-          value: bigint
+          owner?: Address
+          spender?: Address
+          value?: bigint
         }
-      | undefined
     >()
 
     expect(logs.length).toBe(3)
@@ -225,6 +224,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -258,11 +258,35 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
     >(logs)
     expect(logs.length).toBe(1056)
+  })
+
+  test('args: strict', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi: usdcContractConfig.abi,
+      eventName: 'Transfer',
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+    assertType<
+      Log<
+        bigint,
+        number,
+        undefined,
+        true,
+        typeof usdcContractConfig.abi,
+        'Transfer'
+      >[]
+    >(logs)
+    expect(logs.length).toBe(784)
   })
 
   test('args: singular `from`', async () => {
@@ -300,6 +324,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -348,6 +373,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -402,6 +428,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -450,6 +477,7 @@ describe('contract events', () => {
         bigint,
         number,
         undefined,
+        false,
         typeof usdcContractConfig.abi,
         'Transfer'
       >[]
@@ -629,6 +657,115 @@ describe('raw events', () => {
     const logs = await getFilterLogs(publicClient, { filter })
     assertType<Log<bigint, number, typeof event.default>[]>(logs)
     expect(logs.length).toBe(1056)
+  })
+
+  test('args: strict = true (named)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from: Address
+      to: Address
+      value: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = false (named)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from?: Address
+      to?: Address
+      value?: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = true (unnamed)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly [`0x${string}`, `0x${string}`, bigint]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = false (unnamed)', async () => {
+    const filter = await createEventFilter(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+
+    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | readonly []
+      | readonly [`0x${string}`, `0x${string}`, bigint]
+      | readonly [`0x${string}`, `0x${string}`]
+      | readonly [`0x${string}`]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
   })
 
   test('args: singular `from`', async () => {

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -45,16 +45,13 @@ test('event: const assertion', async () => {
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<
     [`0x${string}`, `0x${string}`, `0x${string}`]
   >()
-  expectTypeOf(logs[0]['args']).toEqualTypeOf<
-    | {
-        from: `0x${string}`
-        to: `0x${string}`
-        value: bigint
-        foo: string
-        bar: string
-      }
-    | undefined
-  >()
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<{
+    from?: `0x${string}`
+    to?: `0x${string}`
+    value?: bigint
+    foo?: string
+    bar?: string
+  }>()
 })
 
 test('event: defined inline', async () => {
@@ -95,16 +92,13 @@ test('event: defined inline', async () => {
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<
     [`0x${string}`, `0x${string}`, `0x${string}`]
   >()
-  expectTypeOf(logs[0]['args']).toEqualTypeOf<
-    | {
-        from: `0x${string}`
-        to: `0x${string}`
-        value: bigint
-        foo: string
-        bar: string
-      }
-    | undefined
-  >()
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<{
+    from?: `0x${string}`
+    to?: `0x${string}`
+    value?: bigint
+    foo?: string
+    bar?: string
+  }>()
 })
 
 test('event: declared as `AbiEvent`', async () => {
@@ -136,7 +130,9 @@ test('event: declared as `AbiEvent`', async () => {
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<
     [] | [`0x${string}`, ...`0x${string}`[]]
   >()
-  expectTypeOf(logs[0]['args']).toEqualTypeOf<readonly unknown[] | undefined>()
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<
+    readonly unknown[] | Record<string, unknown>
+  >()
 })
 
 test('inputs: no inputs', async () => {
@@ -149,7 +145,7 @@ test('inputs: no inputs', async () => {
   })
   expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<[`0x${string}`]>()
-  expectTypeOf(logs[0]['args']).toEqualTypeOf<never | undefined>()
+  expectTypeOf(logs[0]['args']).toEqualTypeOf<readonly []>()
 })
 
 test('strict: named', async () => {

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -1,4 +1,3 @@
-import type { Address } from 'abitype'
 import {
   assertType,
   beforeAll,
@@ -165,14 +164,11 @@ describe('events', () => {
       Log<bigint, number, typeof event.default>[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
-    expectTypeOf(logs[0].args).toEqualTypeOf<
-      | {
-          from: Address
-          to: Address
-          value: bigint
-        }
-      | undefined
-    >()
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from?: `0x${string}` | undefined
+      to?: `0x${string}` | undefined
+      value?: bigint | undefined
+    }>()
 
     expect(logs.length).toBe(2)
     expect(logs[0].eventName).toEqual('Transfer')
@@ -221,6 +217,107 @@ describe('events', () => {
       to: '0x9493ACfA6Ce6F907E7C5Dc71288a611811Aa3677',
       value: 995936118n,
     })
+  })
+
+  test('args: strict = true (named)', async () => {
+    const logs = await getLogs(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from: `0x${string}`
+      to: `0x${string}`
+      value: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = false (named)', async () => {
+    const logs = await getLogs(publicClient, {
+      event: event.default,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<{
+      from?: `0x${string}`
+      to?: `0x${string}`
+      value?: bigint
+    }>()
+    expect(logs[0].args).toEqual({
+      from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      to: '0x393ADf60012809316659Af13A3117ec22D093a38',
+      value: 1162592016924672n,
+    })
+
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = true (unnamed)', async () => {
+    const logs = await getLogs(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+      strict: true,
+    })
+
+    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+    expect(logs.length).toBe(784)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      readonly [`0x${string}`, `0x${string}`, bigint]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: strict = false (unnamed)', async () => {
+    const logs = await getLogs(publicClient, {
+      event: event.unnamed,
+      fromBlock: forkBlockNumber - 5n,
+      toBlock: forkBlockNumber,
+    })
+
+    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+    expect(logs.length).toBe(1056)
+
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | readonly []
+      | readonly [`0x${string}`, `0x${string}`, bigint]
+      | readonly [`0x${string}`, `0x${string}`]
+      | readonly [`0x${string}`]
+    >()
+    expect(logs[0].args).toEqual([
+      '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
+      '0x393ADf60012809316659Af13A3117ec22D093a38',
+      1162592016924672n,
+    ])
+
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
+    expect(logs[0].eventName).toEqual('Transfer')
   })
 
   test('args: singular `from`', async () => {

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -199,6 +199,7 @@ import {
 import type { Chain } from '../../types/chain.js'
 import type {
   ContractFunctionConfig,
+  MaybeAbiEventName,
   MaybeExtractEventArgsFromAbi,
 } from '../../types/contract.js'
 import type { FilterType } from '../../types/filter.js'
@@ -277,7 +278,7 @@ export type PublicActions<
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
     TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
-    TStrict extends boolean | undefined,
+    TStrict extends boolean | undefined = undefined,
   >(
     args: CreateContractEventFilterParameters<TAbi, TEventName, TArgs, TStrict>,
   ) => Promise<
@@ -306,10 +307,12 @@ export type PublicActions<
    */
   createEventFilter: <
     TAbiEvent extends AbiEvent | undefined,
-    TStrict extends boolean | undefined,
-    _Abi extends Abi | readonly unknown[],
-    _EventName extends string | undefined,
-    _Args extends MaybeExtractEventArgsFromAbi<_Abi, _EventName> | undefined,
+    TStrict extends boolean | undefined = undefined,
+    _Abi extends Abi | readonly unknown[] = [TAbiEvent],
+    _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
+    _Args extends
+      | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+      | undefined = undefined,
   >(
     args?: CreateEventFilterParameters<
       TAbiEvent,
@@ -804,7 +807,7 @@ export type PublicActions<
     TFilterType extends FilterType,
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
-    TStrict extends boolean | undefined,
+    TStrict extends boolean | undefined = undefined,
   >(
     args: GetFilterChangesParameters<TFilterType, TAbi, TEventName, TStrict>,
   ) => Promise<
@@ -839,7 +842,7 @@ export type PublicActions<
   getFilterLogs: <
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
-    TStrict extends boolean | undefined,
+    TStrict extends boolean | undefined = undefined,
   >(
     args: GetFilterLogsParameters<TAbi, TEventName, TStrict>,
   ) => Promise<GetFilterLogsReturnType<TAbi, TEventName, TStrict>>
@@ -884,7 +887,7 @@ export type PublicActions<
    */
   getLogs: <
     TAbiEvent extends AbiEvent | undefined,
-    TStrict extends boolean | undefined,
+    TStrict extends boolean | undefined = undefined,
   >(
     args?: GetLogsParameters<TAbiEvent, TStrict>,
   ) => Promise<GetLogsReturnType<TAbiEvent, TStrict>>
@@ -1295,8 +1298,9 @@ export type PublicActions<
   watchContractEvent: <
     TAbi extends Abi | readonly unknown[],
     TEventName extends string,
+    TStrict extends boolean | undefined = undefined,
   >(
-    args: WatchContractEventParameters<TAbi, TEventName>,
+    args: WatchContractEventParameters<TAbi, TEventName, TStrict>,
   ) => WatchContractEventReturnType
   /**
    * Watches and returns emitted [Event Logs](https://viem.sh/docs/glossary/terms.html#event-log).
@@ -1329,8 +1333,11 @@ export type PublicActions<
    *   onLogs: (logs) => console.log(logs),
    * })
    */
-  watchEvent: <TAbiEvent extends AbiEvent | undefined>(
-    args: WatchEventParameters<TAbiEvent>,
+  watchEvent: <
+    TAbiEvent extends AbiEvent | undefined,
+    TStrict extends boolean | undefined = undefined,
+  >(
+    args: WatchEventParameters<TAbiEvent, TStrict>,
   ) => WatchEventReturnType
   /**
    * Watches and returns pending transaction hashes.

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -223,9 +223,7 @@ export type GetEventArgs<
     | ([TArgs] extends [never] ? true : false)
     | (readonly unknown[] extends TArgs ? true : false),
 > = true extends FailedToParseArgs
-  ? readonly unknown[]
-  : TArgs extends readonly []
-  ? never
+  ? readonly unknown[] | Record<string, unknown>
   : TArgs
 
 export type GetEventArgsFromTopics<
@@ -233,12 +231,13 @@ export type GetEventArgsFromTopics<
   TEventName extends string,
   TTopics extends LogTopic[],
   TData extends Hex | undefined,
+  TStrict extends boolean = true,
   TAbiEvent extends AbiEvent & { type: 'event' } = TAbi extends Abi
     ? ExtractAbiEvent<TAbi, TEventName>
     : AbiEvent & { type: 'event' },
   TArgs = AbiEventParametersToPrimitiveTypes<
     TAbiEvent['inputs'],
-    { EnableUnion: false; IndexedOnly: false; Required: true }
+    { EnableUnion: false; IndexedOnly: false; Required: TStrict }
   >,
 > = TTopics extends readonly []
   ? TData extends undefined

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -33,20 +33,20 @@ export type Filter<
           abi: TAbi
           args?: never
           eventName?: never
-          strict?: TStrict
+          strict: TStrict
         }
       : TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName>
       ? {
           abi: TAbi
           args: TArgs
           eventName: TEventName
-          strict?: TStrict
+          strict: TStrict
         }
       : {
           abi: TAbi
           args?: never
           eventName: TEventName
-          strict?: TStrict
+          strict: TStrict
         }
     : {
         abi?: never

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -11,17 +11,16 @@ import type {
   GetEventArgs,
 } from './contract.js'
 import type { Hash, Hex } from './misc.js'
-import type { MaybeUndefined } from './utils.js'
 
 export type Log<
   TQuantity = bigint,
   TIndex = number,
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TStrict extends boolean | undefined = undefined,
   TAbi extends Abi | readonly unknown[] = [TAbiEvent],
   TEventName extends string | undefined = TAbiEvent extends AbiEvent
     ? TAbiEvent['name']
     : undefined,
-  TStrict extends boolean | undefined = undefined,
 > = {
   /** The address from which this log originated */
   address: Address
@@ -93,13 +92,14 @@ type GetInferredLogValues<
 > = TAbi extends Abi
   ? TEventName extends string
     ? {
-        args: MaybeUndefined<
-          GetEventArgs<
-            TAbi,
-            TEventName,
-            { EnableUnion: false; IndexedOnly: false; Required: true }
-          >,
-          TStrict extends true ? false : true
+        args: GetEventArgs<
+          TAbi,
+          TEventName,
+          {
+            EnableUnion: false
+            IndexedOnly: false
+            Required: TStrict extends boolean ? TStrict : false
+          }
         >
         /** The event name decoded from `topics`. */
         eventName: TEventName
@@ -108,13 +108,14 @@ type GetInferredLogValues<
       }
     : {
         [TName in _EventNames]: {
-          args: MaybeUndefined<
-            GetEventArgs<
-              TAbi,
-              string,
-              { EnableUnion: false; IndexedOnly: false; Required: true }
-            >,
-            TStrict extends true ? false : true
+          args: GetEventArgs<
+            TAbi,
+            string,
+            {
+              EnableUnion: false
+              IndexedOnly: false
+              Required: TStrict extends boolean ? TStrict : false
+            }
           >
           /** The event name decoded from `topics`. */
           eventName: TName

--- a/src/utils/abi/decodeEventLog.test-d.ts
+++ b/src/utils/abi/decodeEventLog.test-d.ts
@@ -68,6 +68,72 @@ test('named', async () => {
   }>()
 })
 
+test('named (strict = false)', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'tokenId',
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+        ],
+        name: 'Foo',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    eventName: 'Transfer',
+    strict: false,
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<{
+    args: {
+      from?: Address
+      to?: Address
+      tokenId?: bigint
+    }
+    eventName: 'Transfer'
+  }>()
+})
+
 test('unnamed', async () => {
   const event = decodeEventLog({
     abi: [
@@ -101,6 +167,48 @@ test('unnamed', async () => {
 
   expectTypeOf(event).toEqualTypeOf<{
     args: readonly [`0x${string}`, `0x${string}`, bigint]
+    eventName: 'Transfer'
+  }>()
+})
+
+test('unnamed (strict = false)', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: false,
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    eventName: 'Transfer',
+    strict: false,
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<{
+    args:
+      | readonly []
+      | readonly [`0x${string}`, `0x${string}`, bigint]
+      | readonly [`0x${string}`, `0x${string}`]
+      | readonly [`0x${string}`]
     eventName: 'Transfer'
   }>()
 })
@@ -173,6 +281,81 @@ test('unknown eventName', async () => {
           from: Address
           to: Address
           value: bigint
+        }
+        eventName: 'Foo'
+      }
+  >()
+})
+
+test('unknown eventName (strict = false)', async () => {
+  const event = decodeEventLog({
+    abi: [
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'tokenId',
+            type: 'uint256',
+          },
+        ],
+        name: 'Transfer',
+        type: 'event',
+      },
+      {
+        inputs: [
+          {
+            indexed: true,
+            name: 'from',
+            type: 'address',
+          },
+          {
+            indexed: true,
+            name: 'to',
+            type: 'address',
+          },
+          {
+            indexed: false,
+            name: 'value',
+            type: 'uint256',
+          },
+        ],
+        name: 'Foo',
+        type: 'event',
+      },
+    ],
+    data: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    strict: false,
+    topics: [
+      '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      '0x000000000000000000000000d8da6bf26964af9d7eed9e03e53415d37aa96045',
+      '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    ],
+  })
+
+  expectTypeOf(event).toEqualTypeOf<
+    | {
+        args: {
+          from?: Address
+          to?: Address
+          tokenId?: bigint
+        }
+        eventName: 'Transfer'
+      }
+    | {
+        args: {
+          from?: Address
+          to?: Address
+          value?: bigint
         }
         eventName: 'Foo'
       }

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -522,6 +522,98 @@ test('data + event params mismatch', () => {
   )
 })
 
+test('strict', () => {
+  expect(
+    decodeEventLog({
+      abi: [
+        {
+          anonymous: false,
+          inputs: [
+            {
+              indexed: true,
+              internalType: 'address',
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              internalType: 'address',
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              internalType: 'uint256',
+              name: 'id',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      data: '0x0000000000000000000000000000000000000000000000000000000023c34600',
+      strict: false,
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        '0x00000000000000000000000070e8a65d014918798ba424110d5df658cde1cc58',
+      ],
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "args": {
+        "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      },
+      "eventName": "Transfer",
+    }
+  `)
+
+  expect(
+    decodeEventLog({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'id',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      strict: false,
+      topics: [
+        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+        '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+        '0x0000000000000000000000000000000000000000000000000000000000000001',
+      ],
+    }),
+  ).toMatchInlineSnapshot(
+    `
+    {
+      "args": {
+        "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "id": 1n,
+      },
+      "eventName": "Transfer",
+    }
+  `,
+  )
+})
+
 describe('GitHub repros', () => {
   describe('https://github.com/wagmi-dev/viem/issues/168', () => {
     test('zero data string', () => {

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -24,10 +24,12 @@ export type DecodeEventLogParameters<
   TEventName extends string | undefined = string,
   TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
+  TStrict extends boolean = true,
 > = {
   abi: Narrow<TAbi>
   data?: TData
   eventName?: InferEventName<TAbi, TEventName>
+  strict?: TStrict
   topics: [signature: Hex, ...args: TTopics] | []
 }
 
@@ -36,6 +38,7 @@ export type DecodeEventLogReturnType<
   TEventName extends string | undefined = string,
   TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
+  TStrict extends boolean = true,
   _EventNames extends string = TAbi extends Abi
     ? Abi extends TAbi
       ? string
@@ -45,13 +48,13 @@ export type DecodeEventLogReturnType<
   ? Prettify<
       {
         eventName: TEventName
-      } & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData>
+      } & GetEventArgsFromTopics<TAbi, TEventName, TTopics, TData, TStrict>
     >
   : {
       [TName in _EventNames]: Prettify<
         {
           eventName: TName
-        } & GetEventArgsFromTopics<TAbi, TName, TTopics, TData>
+        } & GetEventArgsFromTopics<TAbi, TName, TTopics, TData, TStrict>
       >
     }[_EventNames]
 
@@ -62,16 +65,20 @@ export function decodeEventLog<
   TEventName extends string | undefined = undefined,
   TTopics extends Hex[] = Hex[],
   TData extends Hex | undefined = undefined,
+  TStrict extends boolean = true,
 >({
   abi,
   data,
+  strict: strict_,
   topics,
 }: DecodeEventLogParameters<
   TAbi,
   TEventName,
   TTopics,
-  TData
->): DecodeEventLogReturnType<TAbi, TEventName, TTopics, TData> {
+  TData,
+  TStrict
+>): DecodeEventLogReturnType<TAbi, TEventName, TTopics, TData, TStrict> {
+  const strict = strict_ ?? true
   const [signature, ...argTopics] = topics
   if (!signature)
     throw new AbiEventSignatureEmptyTopicsError({
@@ -110,39 +117,49 @@ export function decodeEventLog<
   // Decode data (non-indexed args).
   const nonIndexedInputs = inputs.filter((x) => !('indexed' in x && x.indexed))
   if (nonIndexedInputs.length > 0) {
-    if (!data || data === '0x')
+    if (data && data !== '0x') {
+      try {
+        const decodedData = decodeAbiParameters(nonIndexedInputs, data)
+        if (decodedData) {
+          if (isUnnamed) args = [...args, ...decodedData]
+          else {
+            for (let i = 0; i < nonIndexedInputs.length; i++) {
+              args[nonIndexedInputs[i].name!] = decodedData[i]
+            }
+          }
+        }
+      } catch (err) {
+        if (strict) {
+          if (err instanceof AbiDecodingDataSizeTooSmallError)
+            throw new DecodeLogDataMismatch({
+              abiItem,
+              data: err.data,
+              params: err.params,
+              size: err.size,
+            })
+          throw err
+        }
+      }
+    } else if (strict) {
       throw new DecodeLogDataMismatch({
         abiItem,
         data: '0x',
         params: nonIndexedInputs,
         size: 0,
       })
-    try {
-      const decodedData = decodeAbiParameters(nonIndexedInputs, data)
-      if (decodedData) {
-        if (isUnnamed) args = [...args, ...decodedData]
-        else {
-          for (let i = 0; i < nonIndexedInputs.length; i++) {
-            args[nonIndexedInputs[i].name!] = decodedData[i]
-          }
-        }
-      }
-    } catch (err) {
-      if (err instanceof AbiDecodingDataSizeTooSmallError)
-        throw new DecodeLogDataMismatch({
-          abiItem,
-          data: err.data,
-          params: err.params,
-          size: err.size,
-        })
-      throw err
     }
   }
 
   return {
     eventName: name,
     args: Object.values(args).length > 0 ? args : undefined,
-  } as unknown as DecodeEventLogReturnType<TAbi, TEventName, TTopics, TData>
+  } as unknown as DecodeEventLogReturnType<
+    TAbi,
+    TEventName,
+    TTopics,
+    TData,
+    TStrict
+  >
 }
 
 function decodeTopic({ param, value }: { param: AbiParameter; value: Hex }) {

--- a/src/utils/abi/encodeEventTopics.test.ts
+++ b/src/utils/abi/encodeEventTopics.test.ts
@@ -63,6 +63,67 @@ test('no args: Transfer(address,address,uint256)', () => {
   ).toEqual([
     '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
   ])
+
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'tokenId',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      eventName: 'Transfer',
+      args: {},
+    }),
+  ).toEqual([
+    '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  ])
+
+  expect(
+    encodeEventTopics({
+      abi: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: true,
+              type: 'address',
+            },
+            {
+              indexed: false,
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+      ],
+      eventName: 'Transfer',
+      args: [],
+    }),
+  ).toEqual([
+    '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+  ])
 })
 
 test('named args: Transfer(address,address,uint256)', () => {
@@ -428,7 +489,6 @@ test("errors: event doesn't exist", () => {
         },
       ],
       eventName: 'Foo',
-      // @ts-expect-error
       args: {},
     }),
   ).toMatchInlineSnapshot(`

--- a/src/utils/abi/encodeEventTopics.ts
+++ b/src/utils/abi/encodeEventTopics.ts
@@ -66,17 +66,22 @@ export function encodeEventTopics<
     )
     const args_ = Array.isArray(args)
       ? args
-      : indexedInputs?.map((x: any) => (args as any)[x.name]) ?? []
-    topics =
-      indexedInputs?.map((param, i) =>
-        Array.isArray(args_[i])
-          ? args_[i].map((_: any, j: number) =>
-              encodeArg({ param, value: args_[i][j] }),
-            )
-          : args_[i]
-          ? encodeArg({ param, value: args_[i] })
-          : null,
-      ) ?? []
+      : Object.values(args).length > 0
+      ? indexedInputs?.map((x: any) => (args as any)[x.name]) ?? []
+      : []
+
+    if (args_.length > 0) {
+      topics =
+        indexedInputs?.map((param, i) =>
+          Array.isArray(args_[i])
+            ? args_[i].map((_: any, j: number) =>
+                encodeArg({ param, value: args_[i][j] }),
+              )
+            : args_[i]
+            ? encodeArg({ param, value: args_[i] })
+            : null,
+        ) ?? []
+    }
   }
   return [signature, ...topics]
 }


### PR DESCRIPTION
This PR refactors changes made in https://github.com/wagmi-dev/viem/pull/547 in preparation for v1 release. 

- Adds `strict` attribute to event Actions & makes "strict" mode opt-in for `getLogs`, `getFilterChanges`, `getFilterLogs` – this means we can remove the behavior change in the v1 migration guide (behaves same as v0).
- Adds `strict` attribute to `decodeEventLog` that is default to truthy (only decode if `data`/`topics` conforms to the ABI event). Consumers can turn off "strict" mode if they want to try and partially decode it.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR changes the behavior of several functions related to decoding event logs and adds a new `strict` parameter to filter out non-conforming logs. It also adds a `strict` parameter to `createContractEventFilter` to control the behavior of the returned logs. 

### Detailed summary
- Adds a new `strict` parameter to `createContractEventFilter` to control the behavior of the returned logs.
- Changes the behavior of `getLogs`, `getFilterLogs`, and `getFilterChanges` to include logs that do not conform to the indexed and non-indexed arguments on the event by default.
- Adds a `strict` parameter to `getLogs`, `getFilterLogs`, and `getFilterChanges` to control the behavior of the returned logs.
- Changes the behavior of `decodeEventLog` to not return a value for arguments that do not conform to the ABI.
- Changes the behavior of `encodeEventTopics` to only encode arguments that conform to the ABI.

> The following files were skipped due to too many changes: `site/docs/actions/public/getLogs.md`, `src/types/log.ts`, `site/docs/actions/public/createEventFilter.md`, `src/actions/public/getLogs.test-d.ts`, `src/utils/abi/decodeEventLog.test.ts`, `src/actions/public/getFilterLogs.ts`, `src/actions/public/getLogs.ts`, `site/docs/contract/decodeEventLog.md`, `src/actions/public/watchContractEvent.ts`, `src/actions/public/watchEvent.ts`, `src/clients/decorators/public.ts`, `src/utils/abi/decodeEventLog.ts`, `src/utils/abi/decodeEventLog.test-d.ts`, `src/actions/public/getLogs.test.ts`, `src/actions/public/getFilterLogs.test-d.ts`, `src/actions/public/getFilterChanges.test-d.ts`, `src/actions/public/getFilterLogs.test.ts`, `src/actions/public/getFilterChanges.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->