### PR TITLE
fix: update the eip712 url for signTypedData

### DIFF
--- a/site/docs/actions/wallet/signTypedData.md
+++ b/site/docs/actions/wallet/signTypedData.md
@@ -14,7 +14,7 @@ head:
 
 # signTypedData
 
-Signs typed data and calculates an Ethereum-specific signature in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`.
+Signs typed data and calculates an Ethereum-specific signature in [https://eips.ethereum.org/EIPS/eip-712](https://eips.ethereum.org/EIPS/eip-712): `sign(keccak256("\x19\x01" ‖ domainSeparator ‖ hashStruct(message)))`
 
 ## Usage
 

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -23,7 +23,7 @@ export type SignTypedDataParameters<
 export type SignTypedDataReturnType = Hex
 
 /**
- * Signs typed data and calculates an Ethereum-specific signature in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`.
+ * Signs typed data and calculates an Ethereum-specific signature in [https://eips.ethereum.org/EIPS/eip-712](https://eips.ethereum.org/EIPS/eip-712): `sign(keccak256("\x19\x01" ‖ domainSeparator ‖ hashStruct(message)))`
  *
  * - Docs: https://viem.sh/docs/actions/wallet/signTypedData.html
  * - JSON-RPC Methods:


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `signTypedData` function to use the newer EIP-712 format for Ethereum-specific signature calculation.

### Detailed summary
- Updates `signTypedData` function to use EIP-712 format.
- Changes documentation and JSON-RPC method references to reflect the new format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->