### PR TITLE
fix(abi): getAbiItem mismatched type

### DIFF
--- a/.changeset/dry-bees-smell.md
+++ b/.changeset/dry-bees-smell.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix getAbiItem return mismatched type when overload with different lengths

--- a/.changeset/dry-bees-smell.md
+++ b/.changeset/dry-bees-smell.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-fix getAbiItem return mismatched type when overload with different lengths
+Fixed `getAbiItem` from returning mismatched type when overload with different lengths.

--- a/src/utils/abi/getAbiItem.test.ts
+++ b/src/utils/abi/getAbiItem.test.ts
@@ -157,18 +157,16 @@ test('overloads: no args', () => {
   `)
 })
 
-test('overload: different lengths', () => {
-  expect(
-    getAbiItem({
-      abi: wagmiContractConfig.abi,
-      name: 'safeTransferFrom',
-      args: [
-        '0x0000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000',
-        420n,
-      ],
-    }),
-  ).toMatchInlineSnapshot(`
+test('overload: different lengths without abi order define effect', () => {
+  const abis = wagmiContractConfig.abi.filter(
+    (abi) => abi.type === 'function' && abi.name === 'safeTransferFrom',
+  )
+  const shortArgs = [
+    '0x0000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000',
+    420n,
+  ] as const
+  const shortSnapshot = `
     {
       "inputs": [
         {
@@ -189,20 +187,14 @@ test('overload: different lengths', () => {
       "stateMutability": "nonpayable",
       "type": "function",
     }
-  `)
-
-  expect(
-    getAbiItem({
-      abi: wagmiContractConfig.abi,
-      name: 'safeTransferFrom',
-      args: [
-        '0x0000000000000000000000000000000000000000',
-        '0x0000000000000000000000000000000000000000',
-        420n,
-        '0x0000000000000000000000000000000000000000',
-      ],
-    }),
-  ).toMatchInlineSnapshot(`
+  `
+  const longArgs = [
+    '0x0000000000000000000000000000000000000000',
+    '0x0000000000000000000000000000000000000000',
+    420n,
+    '0x0000000000000000000000000000000000000000',
+  ] as const
+  const longSnapshot = `
     {
       "inputs": [
         {
@@ -227,7 +219,36 @@ test('overload: different lengths', () => {
       "stateMutability": "nonpayable",
       "type": "function",
     }
-  `)
+  `
+  expect(
+    getAbiItem({
+      abi: abis,
+      name: 'safeTransferFrom',
+      args: shortArgs,
+    }),
+  ).toMatchInlineSnapshot(shortSnapshot)
+  expect(
+    getAbiItem({
+      abi: abis.reverse(),
+      name: 'safeTransferFrom',
+      args: shortArgs,
+    }),
+  ).toMatchInlineSnapshot(shortSnapshot)
+
+  expect(
+    getAbiItem({
+      abi: abis,
+      name: 'safeTransferFrom',
+      args: longArgs,
+    }),
+  ).toMatchInlineSnapshot(longSnapshot)
+  expect(
+    getAbiItem({
+      abi: abis.reverse(),
+      name: 'safeTransferFrom',
+      args: longArgs,
+    }),
+  ).toMatchInlineSnapshot(longSnapshot)
 })
 
 test('overload: different types', () => {

--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -45,6 +45,7 @@ export function getAbiItem<
     }
     if (!abiItem.inputs) continue
     if (abiItem.inputs.length === 0) continue
+    if (abiItem.inputs.length !== args.length) continue
     const matched = (args as readonly unknown[]).every((arg, index) => {
       const abiParameter = 'inputs' in abiItem && abiItem.inputs![index]
       if (!abiParameter) return false


### PR DESCRIPTION
fix #451

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a bug in `getAbiItem` where it returned a mismatched type when an overload with different lengths was present. 

### Detailed summary
- Fixed `getAbiItem` from returning mismatched type when overload with different lengths
- Updated `getAbiItem.test.ts` to test the new behavior

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->