### PR TITLE
Use Chain's TX request Formatter 

### DIFF
--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -41,9 +41,11 @@ export async function sendUnsignedTransaction<
   TChain extends Chain | undefined,
 >(
   client: TestClient<TestClientMode, Transport, TChain>,
+  // TODO - the request parameters should be determined by the chains formatters like SendTransactionParameters are
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
-  const request_ = formatTransactionRequest(request)
+  const formatter = client.chain?.formatters?.transactionRequest || formatTransactionRequest
+  const request_ = formatter(request)
   const hash = await client.request({
     method: 'eth_sendUnsignedTransaction',
     params: [request_],

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -44,7 +44,8 @@ export async function sendUnsignedTransaction<
   // TODO - the request parameters should be determined by the chains formatters like SendTransactionParameters are
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
-  const formatter = client.chain?.formatters?.transactionRequest || formatTransactionRequest
+  const formatter =
+    client.chain?.formatters?.transactionRequest || formatTransactionRequest
   const request_ = formatter(request)
   const hash = await client.request({
     method: 'eth_sendUnsignedTransaction',


### PR DESCRIPTION
use the chains custom transactionRequest formatter if available when sending unsigned transactions



fixes https://github.com/wagmi-dev/viem/issues/664

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `sendUnsignedTransaction` to use the formatter provided by the chain instead of the default one.

### Detailed summary
- Uses chain formatter for `SendUnsignedTransactionParameters`
- Default formatter is used if chain formatter is not available

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->