### PR TITLE
fix(tsconfig): explicit module constraints

### DIFF
--- a/.changeset/khaki-coats-cry.md
+++ b/.changeset/khaki-coats-cry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Turned off `esModuleInterop` & `allowSyntheticDefaultImports` in tsconfig.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,8 @@
     "checkJs": false,
 
     // Interop constraints
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": false,
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": true,
 


### PR DESCRIPTION
These options are viral: enabling them in a package requires all downstream consumers to enable them as well.

Consumers can now opt into these semantics, it also does not require them to do so. Consumers can always safely use alternative import syntaxes (including falling back to `require() `and i`mport()`), or can enable these flags and opt into this behavior themselves.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR turns off `esModuleInterop` and `allowSyntheticDefaultImports` in the `tsconfig` file.

### Detailed summary
- `esModuleInterop` and `allowSyntheticDefaultImports` are set to `false` in `tsconfig.base.json`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->