### PR TITLE
update types in sendTransaction.md

### DIFF
--- a/site/docs/actions/wallet/sendTransaction.md
+++ b/site/docs/actions/wallet/sendTransaction.md
@@ -119,7 +119,7 @@ const hash = await walletClient.sendTransaction({
 
 ### to
 
-- **Type:** `number`
+- **Type:** `0x${string}`
 
 The transaction recipient or contract address.
 
@@ -249,7 +249,7 @@ const hash = await walletClient.sendTransaction({
 
 ### value (optional)
 
-- **Type:** `number`
+- **Type:** `bigint`
 
 Value in wei sent with this transaction.
 


### PR DESCRIPTION
value and to fields previously had incorrect types

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `sendTransaction` function in the wallet module. It changes the `value` parameter type from `number` to `bigint` and updates the `to` parameter type from `number` to `0x${string}`. 

### Detailed summary
- Changes `value` parameter type from `number` to `bigint`
- Updates `to` parameter type from `number` to `0x${string}`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->