### PR TITLE
add `sideEffects: false` to package json in esm folder

### DIFF
--- a/.changeset/modern-rockets-fly.md
+++ b/.changeset/modern-rockets-fly.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-marked package as side effects free
+Marked package as side effects free

--- a/.changeset/modern-rockets-fly.md
+++ b/.changeset/modern-rockets-fly.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+marked package as side effects free

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "bench:ci": "CI=true vitest bench",
     "build": "pnpm run clean && pnpm run build:cjs && pnpm run build:esm && pnpm run build:types",
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
-    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\"}'",
+    "build:esm": "tsc --project tsconfig.build.json --module es2015 --outDir ./dist/esm --removeComments && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --module esnext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
     "changeset": "changeset",
     "changeset:release": "pnpm build && changeset publish",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,21 @@
   ],
   "size-limit": [
     {
-      "path": "./dist/cjs/index.js"
+      "name": "viem (cjs)",
+      "path": "./dist/cjs/index.js",
+      "limit": "60 kB"
+    },
+    {
+      "name": "viem (esm)",
+      "path": "./dist/esm/index.js",
+      "limit": "1.5 kB",
+      "import": "{ defineBlock }"
+    },
+    {
+      "name": "viem/chains",
+      "path": "./dist/esm/chains.js",
+      "limit": "1 kB",
+      "import": "{ mainnet }"
     }
   ],
   "simple-git-hooks": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     {
       "name": "viem/chains",
       "path": "./dist/esm/chains.js",
-      "limit": "1 kB",
+      "limit": "3 kB",
       "import": "{ mainnet }"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
       "limit": "60 kB"
     },
     {
-      "name": "viem (esm)",
+      "name": "viem (tree-shaking check)",
       "path": "./dist/esm/index.js",
       "limit": "1.5 kB",
       "import": "{ defineBlock }"


### PR DESCRIPTION
this PR is part of 
- #661

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on optimizing the `viem` package by marking it as side effects free. Notable changes include:

### Detailed summary
- `viem` package marked as side effects free
- `build:esm` script now includes `sideEffects` property in `package.json`
- Added `size-limit` checks for `viem (cjs)`, `viem (tree-shaking check)`, and `viem/chains`
- Updated `simple-git-hooks` configuration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->