### PR TITLE
fix: remove `tslib` helpers from emit by extracting private function from class

### DIFF
--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -61,12 +61,12 @@ export class BaseError extends Error {
   }
 
   walk(fn?: (err: unknown) => boolean) {
-    return this.#walk(this, fn)
+    return walk(this, fn)
   }
+}
 
-  #walk(err: unknown, fn?: (err: unknown) => boolean): unknown {
-    if (fn?.(err)) return err
-    if ((err as Error).cause) return this.#walk((err as Error).cause, fn)
-    return err
-  }
+function walk(err: unknown, fn?: (err: unknown) => boolean): unknown {
+  if (fn?.(err)) return err
+  if ((err as Error).cause) return walk((err as Error).cause, fn)
+  return err
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR replaces a private method with a standalone function in the `base.ts` file.

### Detailed summary
- Replaces the private `#walk` method with a standalone function `walk`
- `walk` takes two arguments: `err` and an optional `fn` callback function
- `walk` recursively walks through the `err` object and its `cause` property
- `fn` is called with each error object and can stop the recursion by returning `true`
- If no `fn` is provided or all calls to `fn` return `false`, `walk` returns the original `err` object

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->