### PR TITLE
chore: protect against accidentally using syntax that relies on injection of `tslib` helpers

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -28,6 +28,7 @@
     "allowSyntheticDefaultImports": false,
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": true,
+    "importHelpers": true, // This is only used for build validation. Since we do not have `tslib` installed, this will fail if we accidentally make use of anything that'd require injection of helpers.
 
     // Language and environment
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
By adding `importHelpers` true, we tell `tsc` to import the runtime helpers from `tslib` instead of injecting them into every module that relies on them. Since we do not have `tslib` installed, this results in a build error so we are effectively protecting against accidentally introducing syntax that'd require runtime helpers.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `importHelpers` to `tsconfig.base.json` for build validation. It also changes the `moduleResolution` to "NodeNext".

### Detailed summary:
- Added `importHelpers` to `tsconfig.base.json` for build validation
- Changed `moduleResolution` to "NodeNext"

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->