### PR TITLE
Add Custom Chain Serializers

### DIFF
--- a/.changeset/calm-garlics-share.md
+++ b/.changeset/calm-garlics-share.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added ability for chains to specify their own transaction serializer. Exported serializeAccessList and type SerializeTransactionFn.

--- a/.changeset/calm-garlics-share.md
+++ b/.changeset/calm-garlics-share.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added ability for chains to specify their own transaction serializer. Exported serializeAccessList and type SerializeTransactionFn.
+Added custom chain serializers via `chain.serializers`. 

--- a/site/docs/accounts/custom.md
+++ b/site/docs/accounts/custom.md
@@ -36,7 +36,7 @@ const account = toAccount({
   async signMessage({ message }) {
     return signMessage({ message, privateKey })
   },
-  async signTransaction(transaction, serializer) {
+  async signTransaction(transaction, { serializer }) {
     return signTransaction({ privateKey, transaction, serializer })
   },
   async signTypedData(typedData) {
@@ -65,7 +65,7 @@ const account = toAccount({
   async signMessage({ message }) {
     return signMessage({ message, privateKey })
   },
-  async signTransaction(transaction, serializer) {
+  async signTransaction(transaction, { serializer }) {
     return signTransaction({ privateKey, transaction, serializer })
   },
   async signTypedData(typedData) {
@@ -85,7 +85,7 @@ const account = toAccount({
   async signMessage({ message }) { // [!code focus:3]
     return signMessage({ message, privateKey })
   },
-  async signTransaction(transaction, serializer) {
+  async signTransaction(transaction, { serializer }) {
     return signTransaction({ privateKey, transaction, serializer })
   },
   async signTypedData(typedData) {
@@ -104,7 +104,7 @@ const account = toAccount({
   async signMessage({ message }) {
     return signMessage({ message, privateKey })
   },
-  async signTransaction(transaction, serializer) {  // [!code focus:3]
+  async signTransaction(transaction, { serializer }) {  // [!code focus:3]
     return signTransaction({ privateKey, transaction, serializer })
   },
   async signTypedData(typedData) {
@@ -123,7 +123,7 @@ const account = toAccount({
   async signMessage({ message }) {
     return signMessage({ message, privateKey })
   },
-  async signTransaction(transaction, serializer) {
+  async signTransaction(transaction, { serializer }) {
     return signTransaction({ privateKey, transaction, serializer })
   },
   async signTypedData(typedData) {  // [!code focus:3]

--- a/site/docs/accounts/custom.md
+++ b/site/docs/accounts/custom.md
@@ -33,15 +33,15 @@ import { getAddress, signMessage, signTransaction } from './sign-utils' // [!cod
 const privateKey = '0x...' // [!code focus:13]
 const account = toAccount({
   address: getAddress(privateKey),
-  signMessage(message) {
-    return signMessage(message, privateKey)
+  async signMessage({ message }) {
+    return signMessage({ message, privateKey })
   },
-  signTransaction(transaction) {
-    return signTransaction(transaction, privateKey)
+  async signTransaction(transaction, serializer) {
+    return signTransaction({ privateKey, transaction, serializer })
   },
-  signTypedData(typedData) {
-    return signTypedData(typedData, privateKey)
-  }
+  async signTypedData(typedData) {
+    return signTypedData({ ...typedData, privateKey })
+  },
 })
 
 const client = createWalletClient({
@@ -62,15 +62,15 @@ The Address of the Account.
 ```ts
 const account = toAccount({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // [!code focus]
-  signMessage(message) {
-    return signMessage(message, privateKey)
+  async signMessage({ message }) {
+    return signMessage({ message, privateKey })
   },
-  signTransaction(transaction) {
-    return signTransaction(transaction, privateKey)
+  async signTransaction(transaction, serializer) {
+    return signTransaction({ privateKey, transaction, serializer })
   },
-  signTypedData(typedData) {
-    return signTypedData(typedData, privateKey)
-  }
+  async signTypedData(typedData) {
+    return signTypedData({ ...typedData, privateKey })
+  },
 })
 ```
 
@@ -81,15 +81,16 @@ Function to sign a message in [EIP-191 format](https://eips.ethereum.org/EIPS/ei
 ```ts
 const account = toAccount({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  signMessage(message) { // [!code focus:3]
-    return signMessage(message, privateKey)
+
+  async signMessage({ message }) { // [!code focus:3]
+    return signMessage({ message, privateKey })
   },
-  signTransaction(transaction) {
-    return signTransaction(transaction, privateKey)
+  async signTransaction(transaction, serializer) {
+    return signTransaction({ privateKey, transaction, serializer })
   },
-  signTypedData(typedData) {
-    return signTypedData(typedData, privateKey)
-  }
+  async signTypedData(typedData) {
+    return signTypedData({ ...typedData, privateKey })
+  },
 })
 ```
 
@@ -100,15 +101,15 @@ Function to sign a transaction.
 ```ts
 const account = toAccount({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  signMessage(message) { 
-    return signMessage(message, privateKey)
+  async signMessage({ message }) {
+    return signMessage({ message, privateKey })
   },
-  signTransaction(transaction) { // [!code focus:3]
-    return signTransaction(transaction, privateKey)
+  async signTransaction(transaction, serializer) {  // [!code focus:3]
+    return signTransaction({ privateKey, transaction, serializer })
   },
-  signTypedData(typedData) {
-    return signTypedData(typedData, privateKey)
-  }
+  async signTypedData(typedData) {
+    return signTypedData({ ...typedData, privateKey })
+  },
 })
 ```
 
@@ -119,14 +120,14 @@ Function to sign [EIP-712](https://eips.ethereum.org/EIPS/eip-712) typed data.
 ```ts
 const account = toAccount({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  signMessage(message) { 
-    return signMessage(message, privateKey)
+  async signMessage({ message }) {
+    return signMessage({ message, privateKey })
   },
-  signTransaction(transaction) {
-    return signTransaction(transaction, privateKey)
+  async signTransaction(transaction, serializer) {
+    return signTransaction({ privateKey, transaction, serializer })
   },
-  signTypedData(typedData) { // [!code focus:3]
-    return signTypedData(typedData, privateKey)
-  }
+  async signTypedData(typedData) {  // [!code focus:3]
+    return signTypedData({ ...typedData, privateKey })
+  },
 })
 ```

--- a/src/accounts/privateKeyToAccount.ts
+++ b/src/accounts/privateKeyToAccount.ts
@@ -24,8 +24,8 @@ export function privateKeyToAccount(privateKey: Hex): PrivateKeyAccount {
     async signMessage({ message }) {
       return signMessage({ message, privateKey })
     },
-    async signTransaction(transaction) {
-      return signTransaction({ privateKey, transaction })
+    async signTransaction(transaction, serializer) {
+      return signTransaction({ privateKey, transaction, serializer })
     },
     async signTypedData(typedData) {
       return signTypedData({ ...typedData, privateKey })

--- a/src/accounts/privateKeyToAccount.ts
+++ b/src/accounts/privateKeyToAccount.ts
@@ -24,7 +24,7 @@ export function privateKeyToAccount(privateKey: Hex): PrivateKeyAccount {
     async signMessage({ message }) {
       return signMessage({ message, privateKey })
     },
-    async signTransaction(transaction, serializer) {
+    async signTransaction(transaction, { serializer } = {}) {
       return signTransaction({ privateKey, transaction, serializer })
     },
     async signTypedData(typedData) {

--- a/src/accounts/toAccount.test.ts
+++ b/src/accounts/toAccount.test.ts
@@ -29,7 +29,7 @@ describe('toAccount', () => {
         async signMessage() {
           return '0x'
         },
-        async signTransaction() {
+        async signTransaction(_transaction) {
           return '0x'
         },
         async signTypedData() {
@@ -55,7 +55,7 @@ describe('toAccount', () => {
         async signMessage() {
           return '0x'
         },
-        async signTransaction() {
+        async signTransaction(_transaction) {
           return '0x'
         },
         async signTypedData() {

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -3,9 +3,10 @@ import type { HDKey } from '@scure/bip32'
 import type { Address, TypedData } from 'abitype'
 
 import type { Hash, Hex, SignableMessage } from '../types/misc.js'
-import type { TransactionSerializable } from '../types/transaction.js'
+import type { TransactionSerializable, TransactionSerialized } from '../types/transaction.js'
 import type { TypedDataDefinition } from '../types/typedData.js'
 import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
+import type { NoUndefined } from '../types/utils.js'
 
 export type Account<TAddress extends Address = Address> =
   | JsonRpcAccount<TAddress>
@@ -16,13 +17,13 @@ export type CustomSource = {
   address: Address
   signMessage: ({ message }: { message: SignableMessage }) => Promise<Hash>
   signTransaction: <
-    S extends SerializeTransactionFn<TransactionSerializable> = SerializeTransactionFn<TransactionSerializable>,
+    Serializer extends SerializeTransactionFn<TransactionSerializable> = SerializeTransactionFn<TransactionSerializable>,
   >(
-    transaction: S extends undefined
+    transaction: Serializer extends undefined
       ? TransactionSerializable
-      : Parameters<S>[0],
-    serializer?: S,
-  ) => Promise<Hash>
+      : Parameters<Serializer>[0],
+    serializer?: Serializer,
+  ) => Promise<TransactionSerialized<NoUndefined<Parameters<Serializer>[0]['type']>>>
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
     TPrimaryType extends string = string,

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -3,10 +3,12 @@ import type { HDKey } from '@scure/bip32'
 import type { Address, TypedData } from 'abitype'
 
 import type { Hash, Hex, SignableMessage } from '../types/misc.js'
-import type { TransactionSerializable, TransactionSerialized } from '../types/transaction.js'
+import type { TransactionSerializable,  } from '../types/transaction.js'
 import type { TypedDataDefinition } from '../types/typedData.js'
 import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { NoUndefined } from '../types/utils.js'
+
+import type { SignTransactionReturnType } from './utils/signTransaction.js'
 
 export type Account<TAddress extends Address = Address> =
   | JsonRpcAccount<TAddress>
@@ -23,7 +25,7 @@ export type CustomSource = {
       ? TransactionSerializable
       : Parameters<Serializer>[0],
     serializer?: Serializer,
-  ) => Promise<TransactionSerialized<NoUndefined<Parameters<Serializer>[0]['type']>>>
+  ) => Promise<SignTransactionReturnType<NoUndefined<Parameters<Serializer>[0]>>>
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
     TPrimaryType extends string = string,

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -3,11 +3,10 @@ import type { HDKey } from '@scure/bip32'
 import type { Address, TypedData } from 'abitype'
 
 import type { Hash, Hex, SignableMessage } from '../types/misc.js'
-import type { TransactionSerializable,  } from '../types/transaction.js'
+import type { TransactionSerializable } from '../types/transaction.js'
 import type { TypedDataDefinition } from '../types/typedData.js'
-import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { NoUndefined } from '../types/utils.js'
-
+import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { SignTransactionReturnType } from './utils/signTransaction.js'
 
 export type Account<TAddress extends Address = Address> =
@@ -25,7 +24,9 @@ export type CustomSource = {
       ? TransactionSerializable
       : Parameters<Serializer>[0],
     serializer?: Serializer,
-  ) => Promise<SignTransactionReturnType<NoUndefined<Parameters<Serializer>[0]>>>
+  ) => Promise<
+    SignTransactionReturnType<NoUndefined<Parameters<Serializer>[0]>>
+  >
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
     TPrimaryType extends string = string,

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -12,10 +12,17 @@ export type Account<TAddress extends Address = Address> =
   | LocalAccount<string, TAddress>
 
 export type AccountSource = Address | CustomSource
-export type CustomSource<S extends SerializeTransactionFn = SerializeTransactionFn> = {
+export type CustomSource = {
   address: Address
   signMessage: ({ message }: { message: SignableMessage }) => Promise<Hash>
-  signTransaction: (transaction: Parameters<S> | TransactionSerializable, serializer?: S) => Promise<Hash>
+  signTransaction: <
+    S extends SerializeTransactionFn<TransactionSerializable> = SerializeTransactionFn<TransactionSerializable>,
+  >(
+    transaction: S extends undefined
+      ? TransactionSerializable
+      : Parameters<S>[0],
+    serializer?: S,
+  ) => Promise<Hash>
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
     TPrimaryType extends string = string,

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -5,16 +5,17 @@ import type { Address, TypedData } from 'abitype'
 import type { Hash, Hex, SignableMessage } from '../types/misc.js'
 import type { TransactionSerializable } from '../types/transaction.js'
 import type { TypedDataDefinition } from '../types/typedData.js'
+import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 
 export type Account<TAddress extends Address = Address> =
   | JsonRpcAccount<TAddress>
   | LocalAccount<string, TAddress>
 
 export type AccountSource = Address | CustomSource
-export type CustomSource = {
+export type CustomSource<S extends SerializeTransactionFn = SerializeTransactionFn> = {
   address: Address
   signMessage: ({ message }: { message: SignableMessage }) => Promise<Hash>
-  signTransaction: (transaction: TransactionSerializable) => Promise<Hash>
+  signTransaction: (transaction: Parameters<S> | TransactionSerializable, serializer?: S) => Promise<Hash>
   signTypedData: <
     TTypedData extends TypedData | { [key: string]: unknown },
     TPrimaryType extends string = string,

--- a/src/accounts/utils/signTransaction.test.ts
+++ b/src/accounts/utils/signTransaction.test.ts
@@ -16,7 +16,6 @@ import type { SerializeTransactionFn } from '../../utils/transaction/serializeTr
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { signTransaction } from './signTransaction.js'
 
-
 const base = {
   gas: 21000n,
   nonce: 785,

--- a/src/accounts/utils/signTransaction.test.ts
+++ b/src/accounts/utils/signTransaction.test.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expect, test } from 'vitest'
+import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { accounts } from '../../_test/constants.js'
 import type {
@@ -14,6 +14,8 @@ import type {
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 
 import { signTransaction } from './signTransaction.js'
+import type { SerializeTransactionFn } from '../../utils/transaction/serializeTransaction.js'
+import { concatHex, toHex, toRlp } from '../../index.js'
 
 const base = {
   gas: 21000n,
@@ -236,6 +238,67 @@ describe('eip2930', () => {
       }),
     ).toMatchInlineSnapshot(
       '"0x01f854018203118504a817c800825208808080c080a058e29913bc928a79e0536fc588e8fe372464d1ff4feff691c344c0163280c97ea037780b5c99301a67aaacfbe98c83139fd026e30925fc103b7898b53af9cb0658"',
+    )
+  })
+})
+
+describe('with custom EIP2718 serializer', () => {
+  type ExampleTransaction = TransactionSerializable & {
+    type: 'cip42'
+    chainId: number
+    additionalField: `0x${string}`
+  }
+
+  test('default', async () => {
+    const exampleSerializer: SerializeTransactionFn<ExampleTransaction> = vi.fn(
+      function (transaction) {
+        const {
+          chainId,
+          nonce,
+          gas,
+          to,
+          value,
+          additionalField,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          data,
+        } = transaction
+
+        const serializedTransaction = [
+          toHex(chainId),
+          nonce ? toHex(nonce) : '0x',
+          maxPriorityFeePerGas ? toHex(maxPriorityFeePerGas) : '0x',
+          maxFeePerGas ? toHex(maxFeePerGas) : '0x',
+          gas ? toHex(gas) : '0x',
+          additionalField ?? '0x',
+          to ?? '0x',
+          value ? toHex(value) : '0x',
+          data ?? '0x',
+          [],
+        ]
+
+        return concatHex(['0x08', toRlp(serializedTransaction)])
+      },
+    )
+
+    const example2718Transaction: ExampleTransaction = {
+      ...base,
+      type: 'cip42',
+      additionalField: '0x0000',
+      chainId: 42240,
+    }
+
+    const signature = await signTransaction({
+      transaction: example2718Transaction,
+      privateKey: accounts[0].privateKey,
+      serializer: exampleSerializer,
+    })
+    assertType(signature)
+
+    expect(exampleSerializer).toHaveBeenCalledWith(example2718Transaction)
+
+    expect(signature).toMatchInlineSnapshot(
+      '"0x08d282a5008203118080825208820000808080c0"',
     )
   })
 })

--- a/src/accounts/utils/signTransaction.test.ts
+++ b/src/accounts/utils/signTransaction.test.ts
@@ -1,6 +1,7 @@
 import { assertType, describe, expect, test, vi } from 'vitest'
 
 import { accounts } from '../../_test/constants.js'
+import { concatHex, toHex, toRlp } from '../../index.js'
 import type {
   TransactionSerializable,
   TransactionSerializableBase,
@@ -11,11 +12,10 @@ import type {
   TransactionSerializedEIP2930,
   TransactionSerializedLegacy,
 } from '../../types/transaction.js'
-import { parseGwei } from '../../utils/unit/parseGwei.js'
-
-import { signTransaction } from './signTransaction.js'
 import type { SerializeTransactionFn } from '../../utils/transaction/serializeTransaction.js'
-import { concatHex, toHex, toRlp } from '../../index.js'
+import { parseGwei } from '../../utils/unit/parseGwei.js'
+import { signTransaction } from './signTransaction.js'
+
 
 const base = {
   gas: 21000n,

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -6,17 +6,19 @@ import type {
 } from '../../types/transaction.js'
 import { keccak256 } from '../../utils/hash/keccak256.js'
 import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
-import { serializeTransaction, type SerializeTransactionFn } from '../../utils/transaction/serializeTransaction.js'
+import {
+  serializeTransaction,
+  type SerializeTransactionFn,
+} from '../../utils/transaction/serializeTransaction.js'
 
 import { sign } from './sign.js'
 
 export type SignTransactionArgs<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
-  TSerializer extends SerializeTransactionFn = SerializeTransactionFn,
 > = {
   privateKey: Hex
   transaction: TTransactionSerializable
-  serializer?: TSerializer
+  serializer?: SerializeTransactionFn<TTransactionSerializable>
 }
 export type SignTransactionReturnType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -7,8 +7,8 @@ import type {
 import { keccak256 } from '../../utils/hash/keccak256.js'
 import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
 import {
-  serializeTransaction,
   type SerializeTransactionFn,
+  serializeTransaction,
 } from '../../utils/transaction/serializeTransaction.js'
 
 import { sign } from './sign.js'

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -6,15 +6,17 @@ import type {
 } from '../../types/transaction.js'
 import { keccak256 } from '../../utils/hash/keccak256.js'
 import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
-import { serializeTransaction } from '../../utils/transaction/serializeTransaction.js'
+import { serializeTransaction, type SerializeTransactionFn } from '../../utils/transaction/serializeTransaction.js'
 
 import { sign } from './sign.js'
 
 export type SignTransactionArgs<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
+  TSerializer extends SerializeTransactionFn = SerializeTransactionFn,
 > = {
   privateKey: Hex
   transaction: TTransactionSerializable
+  serializer?: TSerializer
 }
 export type SignTransactionReturnType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
@@ -26,12 +28,13 @@ export async function signTransaction<
 >({
   privateKey,
   transaction,
+  serializer = serializeTransaction,
 }: SignTransactionArgs<TTransactionSerializable>): Promise<
   SignTransactionReturnType<TTransactionSerializable>
 > {
   const signature = await sign({
-    hash: keccak256(serializeTransaction(transaction)),
+    hash: keccak256(serializer(transaction)),
     privateKey,
   })
-  return serializeTransaction(transaction, signature)
+  return serializer(transaction, signature)
 }

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -2,7 +2,6 @@ import type { Hex } from '../../types/misc.js'
 import type {
   TransactionSerializable,
   TransactionSerialized,
-  TransactionType,
 } from '../../types/transaction.js'
 import { keccak256 } from '../../utils/hash/keccak256.js'
 import type { GetTransactionType } from '../../utils/transaction/getTransactionType.js'
@@ -22,8 +21,7 @@ export type SignTransactionArgs<
 }
 export type SignTransactionReturnType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
-  TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>,
-> = TransactionSerialized<TTransactionType>
+> = TransactionSerialized<GetTransactionType<TTransactionSerializable>>
 
 export async function signTransaction<
   TTransactionSerializable extends TransactionSerializable,

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -147,9 +147,11 @@ export async function sendTransaction<
 
       if (!chainId) chainId = await getChainId(client)
       const signedRequest = (await account.signTransaction({
-        ...request,
-        chainId,
-      } as TransactionSerializable)) as Hash
+          ...request,
+          chainId,
+        } as TransactionSerializable,
+        chain?.serializer
+      )) as Hash
       return await client.request({
         method: 'eth_sendRawTransaction',
         params: [signedRequest],

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -146,11 +146,12 @@ export async function sendTransaction<
       })
 
       if (!chainId) chainId = await getChainId(client)
-      const signedRequest = (await account.signTransaction({
+      const signedRequest = (await account.signTransaction(
+        {
           ...request,
           chainId,
         } as TransactionSerializable,
-        chain?.serializer
+        chain?.serializer,
       )) as Hash
       return await client.request({
         method: 'eth_sendRawTransaction',

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -146,12 +146,14 @@ export async function sendTransaction<
       })
 
       if (!chainId) chainId = await getChainId(client)
+
+      const serializer = chain?.serializers?.transaction
       const signedRequest = (await account.signTransaction(
         {
           ...request,
           chainId,
         } as TransactionSerializable,
-        chain?.serializer,
+        { serializer },
       )) as Hash
       return await client.request({
         method: 'eth_sendRawTransaction',

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -276,6 +276,7 @@ test('exports actions', () => {
       "recoverMessageAddress": [Function],
       "recoverPublicKey": [Function],
       "recoverTypedDataAddress": [Function],
+      "serializeAccessList": [Function],
       "serializeTransaction": [Function],
       "size": [Function],
       "slice": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -701,7 +701,11 @@ export { parseGwei } from './utils/unit/parseGwei.js'
 export { parseTransaction } from './utils/transaction/parseTransaction.js'
 export { parseUnits } from './utils/unit/parseUnits.js'
 export { prepareRequest } from './utils/transaction/prepareRequest.js'
-export { serializeTransaction } from './utils/transaction/serializeTransaction.js'
+export { serializeAccessList } from './utils/transaction/serializeAccessList.js'
+export {
+  serializeTransaction,
+  type SerializeTransactionFn,
+} from './utils/transaction/serializeTransaction.js'
 export { size } from './utils/data/size.js'
 export { slice, sliceBytes, sliceHex } from './utils/data/slice.js'
 export { stringify } from './utils/stringify.js'

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -3,11 +3,12 @@ import type { Address } from 'abitype'
 
 import type { Formatters } from './formatter.js'
 import type { IsUndefined } from './utils.js'
-import { serializeTransaction } from '../index.js'
+import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 
-type SerializeTransaction = typeof serializeTransaction
-
-export type Chain<TFormatters extends Formatters = Formatters, TSerializer extends SerializeTransaction = SerializeTransaction > = Chain_ & {
+export type Chain<
+  TFormatters extends Formatters = Formatters,
+  TSerializer extends SerializeTransactionFn = SerializeTransactionFn,
+> = Chain_ & {
   formatters?: TFormatters
   serializer?: TSerializer
 }

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,15 +1,15 @@
+import type { TransactionSerializable } from '../types/transaction.js'
 import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { Formatters } from './formatter.js'
 import type { IsUndefined } from './utils.js'
 import type { Chain as Chain_ } from '@wagmi/chains'
 import type { Address } from 'abitype'
 
-export type Chain<
-  TFormatters extends Formatters = Formatters,
-  TSerializer extends SerializeTransactionFn = SerializeTransactionFn,
-> = Chain_ & {
+export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
   formatters?: TFormatters
-  serializer?: TSerializer
+  serializers?: {
+    transaction?: SerializeTransactionFn<TransactionSerializable>
+  }
 }
 
 export type ChainContract = {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -3,9 +3,13 @@ import type { Address } from 'abitype'
 
 import type { Formatters } from './formatter.js'
 import type { IsUndefined } from './utils.js'
+import { serializeTransaction } from '../index.js'
 
-export type Chain<TFormatters extends Formatters = Formatters> = Chain_ & {
+type SerializeTransaction = typeof serializeTransaction
+
+export type Chain<TFormatters extends Formatters = Formatters, TSerializer extends SerializeTransaction = SerializeTransaction > = Chain_ & {
   formatters?: TFormatters
+  serializer?: TSerializer
 }
 
 export type ChainContract = {

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,9 +1,8 @@
-import type { Chain as Chain_ } from '@wagmi/chains'
-import type { Address } from 'abitype'
-
+import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
 import type { Formatters } from './formatter.js'
 import type { IsUndefined } from './utils.js'
-import type { SerializeTransactionFn } from '../utils/transaction/serializeTransaction.js'
+import type { Chain as Chain_ } from '@wagmi/chains'
+import type { Address } from 'abitype'
 
 export type Chain<
   TFormatters extends Formatters = Formatters,

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -201,6 +201,7 @@ export type TransactionSerializableGeneric<
   TIndex = number,
 > = TransactionSerializableBase<TQuantity, TIndex> & {
   accessList?: AccessList
+  chainId?: number
   gasPrice?: TQuantity
   maxFeePerGas?: TQuantity
   maxPriorityFeePerGas?: TQuantity

--- a/src/utils/index.test.ts
+++ b/src/utils/index.test.ts
@@ -144,6 +144,7 @@ test('exports utils', () => {
         "webSocket": [Function],
         "webSocketAsync": [Function],
       },
+      "serializeAccessList": [Function],
       "serializeTransaction": [Function],
       "size": [Function],
       "slice": [Function],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -239,7 +239,7 @@ export {
 } from './transaction/assertTransaction.js'
 export { parseTransaction } from './transaction/parseTransaction.js'
 export { prepareRequest } from './transaction/prepareRequest.js'
-export { serializeTransaction } from './transaction/serializeTransaction.js'
+export { serializeTransaction, type SerializeTransactionFn } from './transaction/serializeTransaction.js'
 export { serializeAccessList } from './transaction/serializeAccessList.js'
 export { formatEther } from './unit/formatEther.js'
 export { formatGwei } from './unit/formatGwei.js'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -239,7 +239,10 @@ export {
 } from './transaction/assertTransaction.js'
 export { parseTransaction } from './transaction/parseTransaction.js'
 export { prepareRequest } from './transaction/prepareRequest.js'
-export { serializeTransaction, type SerializeTransactionFn } from './transaction/serializeTransaction.js'
+export {
+  serializeTransaction,
+  type SerializeTransactionFn,
+} from './transaction/serializeTransaction.js'
 export { serializeAccessList } from './transaction/serializeAccessList.js'
 export { formatEther } from './unit/formatEther.js'
 export { formatGwei } from './unit/formatGwei.js'

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -240,6 +240,7 @@ export {
 export { parseTransaction } from './transaction/parseTransaction.js'
 export { prepareRequest } from './transaction/prepareRequest.js'
 export { serializeTransaction } from './transaction/serializeTransaction.js'
+export { serializeAccessList } from './transaction/serializeAccessList.js'
 export { formatEther } from './unit/formatEther.js'
 export { formatGwei } from './unit/formatGwei.js'
 export { formatUnits } from './unit/formatUnits.js'

--- a/src/utils/transaction/serializeAccessList.test.ts
+++ b/src/utils/transaction/serializeAccessList.test.ts
@@ -1,8 +1,7 @@
-import { describe, expect, test } from 'vitest'
-
-import { serializeAccessList } from './serializeAccessList.js'
-import { InvalidAddressError, type AccessList } from '../../index.js'
 import { InvalidStorageKeySizeError } from '../../errors/transaction.js'
+import { type AccessList, InvalidAddressError } from '../../index.js'
+import { serializeAccessList } from './serializeAccessList.js'
+import { describe, expect, test } from 'vitest'
 
 describe('serializeAccessList', () => {
   test('when accessList is empty', () => {

--- a/src/utils/transaction/serializeAccessList.test.ts
+++ b/src/utils/transaction/serializeAccessList.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest'
+
+import { serializeAccessList } from './serializeAccessList.js'
+import { InvalidAddressError, type AccessList } from '../../index.js'
+import { InvalidStorageKeySizeError } from '../../errors/transaction.js'
+
+describe('serializeAccessList', () => {
+  test('when accessList is empty', () => {
+    expect(serializeAccessList([])).toEqual([])
+  })
+
+  test('when accessList contains in invalid Address', () => {
+    expect(() =>
+      serializeAccessList([{ address: '0x123', storageKeys: [] }]),
+    ).toThrowError(new InvalidAddressError({ address: '0x123' }))
+  })
+
+  test('when accessList contains in invalid Storage Key', () => {
+    const badKey = '0xI like cheese'
+    expect(() =>
+      serializeAccessList([
+        {
+          address: '0x123',
+          storageKeys: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            badKey,
+          ],
+        },
+      ]),
+    ).toThrowError(new InvalidStorageKeySizeError({ storageKey: badKey }))
+  })
+
+  test('with valid accessList', () => {
+    const accessList: AccessList = [
+      {
+        address: '0x0000000000000000000000000000000000000000',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        ],
+      },
+    ]
+
+    expect(serializeAccessList(accessList)).toEqual([
+      [
+        '0x0000000000000000000000000000000000000000',
+        [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        ],
+      ],
+    ])
+  })
+})

--- a/src/utils/transaction/serializeAccessList.ts
+++ b/src/utils/transaction/serializeAccessList.ts
@@ -1,0 +1,39 @@
+import { InvalidAddressError } from '../../errors/address.js'
+import { InvalidStorageKeySizeError } from '../../errors/transaction.js'
+import type { Hex } from '../../types/misc.js'
+import type { AccessList } from '../../types/transaction.js'
+import { isAddress } from '../address/isAddress.js'
+import { type RecursiveArray } from '../encoding/toRlp.js'
+
+/*
+ * Serialize an  EIP-2930 access list
+ * @remarks
+ * Use to create a transaction serializer with support for EIP-2930 access lists
+ *
+ * @param accessList - Array of objects of address and arrays of Storage Keys
+ * @throws InvalidAddressError, InvalidStorageKeySizeError
+ * @returns Array of hex strings
+ */
+export function serializeAccessList(
+  accessList?: AccessList,
+): RecursiveArray<Hex> {
+  if (!accessList || accessList.length === 0) return []
+
+  const serializedAccessList: RecursiveArray<Hex> = []
+  for (let i = 0; i < accessList.length; i++) {
+    const { address, storageKeys } = accessList[i]
+
+    for (let j = 0; j < storageKeys.length; j++) {
+      if (storageKeys[j].length - 2 !== 64) {
+        throw new InvalidStorageKeySizeError({ storageKey: storageKeys[j] })
+      }
+    }
+
+    if (!isAddress(address)) {
+      throw new InvalidAddressError({ address })
+    }
+
+    serializedAccessList.push([address, storageKeys])
+  }
+  return serializedAccessList
+}

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -59,7 +59,7 @@ export function serializeTransaction<
 }
 
 export type SerializeTransactionFn<
-  TTransactionSerializable extends TransactionSerializable,
+  TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
 > = (
   transaction: TTransactionSerializable,
   signature?: Signature,

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -32,6 +32,10 @@ export type SerializedTransactionReturnType<
   TTransactionType extends TransactionType = GetTransactionType<TTransactionSerializable>,
 > = TransactionSerialized<TTransactionType>
 
+export type SerializeTransactionFn<
+  TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
+> = typeof serializeTransaction<TTransactionSerializable>
+
 export function serializeTransaction<
   TTransactionSerializable extends TransactionSerializable,
 >(
@@ -57,16 +61,6 @@ export function serializeTransaction<
     signature,
   ) as SerializedTransactionReturnType<TTransactionSerializable>
 }
-
-export type SerializeTransactionFn<
-  TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
-> = (
-  transaction: TTransactionSerializable,
-  signature?: Signature,
-) => SerializedTransactionReturnType<
-  TTransactionSerializable,
-  GetTransactionType<TTransactionSerializable>
->
 
 function serializeTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -63,6 +63,8 @@ export function serializeTransaction<
   ) as SerializedTransactionReturnType<TTransactionSerializable>
 }
 
+export type SerializeTransactionFn = typeof serializeTransaction
+
 function serializeTransactionEIP1559(
   transaction: TransactionSerializableEIP1559,
   signature?: Signature,


### PR DESCRIPTION
## TLDR 

Allow account.signTransaction to take an optional transactionSerializer argument.

##Why?

Through custom chain formatters viem supports alternative standards. for formatting transactions but not yet for signing them

## How

1) add to signTransaction  an optional argument for a serializer which 

2) add an optional `serializer` property to chain. 

3) if the current chain has a serializer pass as argument to signTransaction function. 

*It is recommended that custom serializers check if the transaction is the type they support and if not call the default viem serializeTransaction function.*
  
 ## Example 
  
// create a customer Serializer ie 
```ts [serializer.ts]

import { SerializeTransactionFn, serializeTransaction } from 'viem/utils'
import { TransactionSerializable } from 'viem/types'

type CustomTX = TransactionSerializable {
  type: 'pip112' // a string representing the tx type this should serialize to a EIP2718 compliant TransactionType https://eips.ethereum.org/EIPS/eip-2718#transactiontype-only-goes-up-to-0x7f
  extraField: // some field the spec for this tx type supports
}

export const serializer: SerializeTransactionFn<CustomTX> = (transaction) => {
  if (specialCase(transaction)) {
    // serialization code here
  } else {
    return serializeTransaction(transaction)
  }
}

```
// Add it to the chain

``` ts
import {serializer } from './serializer'
import {celo} from 'wagmi/chains'

const chainWithSerializer = defineChain({...celo, serializer})

// use chain when creating client
const client = createWalletClient({
  account,
  chain: chainWithSerializer,
  transport: http()
})

```

## other ways to achieve this
 
 technically its possible to add an custom serializer by creating an account using the `toAccount` function. 
 
 This has 2 limitations. 
 1) you must recreated the `privateKeyToAccount`, `signTransaction` just to modify the `serializeTransaction` function. Since` mneumonicToAccount` and `HDKeyToAccount` use privateKeyToAccount they must also be recreated. 
 
 2) it doesnt give an elegent way for there to be multiple serializers such as different chains both having custom serializers. 
 

## related PRS 

# supersedes https://github.com/wagmi-dev/viem/pull/666

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for custom chain serializers and EIP-2930 access lists. It also makes changes to several files, including `utils`, `types`, `accounts`, `actions`, and `transaction`.

### Detailed summary
- Added custom chain serializers via `chain.serializers`
- Added support for EIP-2930 access lists
- Removed `serializeTransaction` from some `utils` files
- Modified `signTransaction` in `accounts/utils/signTransaction.ts`
- Modified `serializeTransaction` in `utils/transaction/serializeTransaction.ts`
- Modified `Account` type in `accounts/types.ts`
- Modified `Chain` type in `types/chain.ts`
- Added tests for `serializeAccessList` and `signTransaction`

> The following files were skipped due to too many changes: `src/accounts/utils/signTransaction.test.ts`, `src/utils/transaction/serializeTransaction.ts`, `src/actions/wallet/sendTransaction.test.ts`, `site/docs/accounts/custom.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->