### PR TITLE
docs(simulateContract): BaseError do not cause

### DIFF
--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -189,7 +189,7 @@ You can access the custom error through the `data` attribute of the error:
 ::: code-group
 
 ```ts {13-27} [example.ts]
-import { BaseError, ContractFunctionRevertedError } from 'viem';
+import { ContractFunctionExecutionError, ContractFunctionRevertedError } from 'viem';
 import { account, walletClient, publicClient } from './config'
 import { wagmiAbi } from './abi'
 
@@ -201,7 +201,7 @@ try {
     account,
   })
 } catch (err) {
-  if (err instanceof BaseError) {
+  if (err instanceof ContractFunctionExecutionError) {
     // Option 1: checking the instance of the error
     if (err.cause instanceof ContractFunctionRevertedError) {
       const cause: ContractFunctionRevertedError = err.cause;


### PR DESCRIPTION
Check `error` to be an instance of `ContractFunctionExecutionError`, as BaseError don't have a `cause`, making the current example code incorrect?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates an import statement and changes an error checking condition in `simulateContract.md`. 

### Detailed summary:
- Updated import statement to use `ContractFunctionExecutionError` instead of `BaseError`
- Changed error checking condition to use `ContractFunctionExecutionError` instead of `BaseError`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->