### PR TITLE
fix: decimals with leading zeroes when rounding up

### DIFF
--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -17,6 +17,7 @@ test('converts number to unit of a given length', () => {
   expect(parseUnits('6942069420.00045678912345', 18)).toMatchInlineSnapshot(
     '6942069420000456789123450000n',
   )
+  expect(parseUnits('1.0536059576998882', 7)).toMatchInlineSnapshot('10536060n')
   expect(
     parseUnits('6942123123123069420.1234544444678912345', 50),
   ).toMatchInlineSnapshot(

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -17,7 +17,6 @@ test('converts number to unit of a given length', () => {
   expect(parseUnits('6942069420.00045678912345', 18)).toMatchInlineSnapshot(
     '6942069420000456789123450000n',
   )
-  expect(parseUnits('1.0536059576998882', 7)).toMatchInlineSnapshot('10536060n')
   expect(
     parseUnits('6942123123123069420.1234544444678912345', 50),
   ).toMatchInlineSnapshot(
@@ -45,6 +44,8 @@ test('decimals === 0', () => {
 })
 
 test('decimals < fraction length', () => {
+  expect(parseUnits('69.23521', 0)).toMatchInlineSnapshot('69n')
+  expect(parseUnits('69.56789', 0)).toMatchInlineSnapshot('70n')
   expect(parseUnits('69.23521', 1)).toMatchInlineSnapshot('692n')
   expect(parseUnits('69.23521', 2)).toMatchInlineSnapshot('6924n')
   expect(parseUnits('69.23221', 2)).toMatchInlineSnapshot('6923n')
@@ -57,6 +58,28 @@ test('decimals < fraction length', () => {
   expect(parseUnits('100000.000999', 3)).toMatchInlineSnapshot('100000001n')
   expect(parseUnits('100000.990999', 3)).toMatchInlineSnapshot('100000991n')
   expect(parseUnits('69.00221', 3)).toMatchInlineSnapshot('69002n')
+  expect(parseUnits('1.0536059576998882', 7)).toMatchInlineSnapshot('10536060n')
+  expect(parseUnits('1.0053059576998882', 7)).toMatchInlineSnapshot('10053060n')
+  expect(parseUnits('1.0000000900000000', 7)).toMatchInlineSnapshot('10000001n')
+  expect(parseUnits('1.0000009900000000', 7)).toMatchInlineSnapshot('10000010n')
+  expect(parseUnits('1.0000099900000000', 7)).toMatchInlineSnapshot('10000100n')
+  expect(parseUnits('1.0000092900000000', 7)).toMatchInlineSnapshot('10000093n')
+  expect(parseUnits('1.5536059576998882', 7)).toMatchInlineSnapshot('15536060n')
+  expect(parseUnits('1.0536059476998882', 7)).toMatchInlineSnapshot('10536059n')
+  expect(parseUnits('1.4545454545454545', 7)).toMatchInlineSnapshot('14545455n')
+  expect(parseUnits('1.1234567891234567', 7)).toMatchInlineSnapshot('11234568n')
+  expect(parseUnits('1.8989898989898989', 7)).toMatchInlineSnapshot('18989899n')
+  expect(parseUnits('9.9999999999999999', 7)).toMatchInlineSnapshot(
+    '100000000n',
+  )
+  expect(parseUnits('0.0536059576998882', 7)).toMatchInlineSnapshot('536060n')
+  expect(parseUnits('0.0053059576998882', 7)).toMatchInlineSnapshot('53060n')
+  expect(parseUnits('0.0000000900000000', 7)).toMatchInlineSnapshot('1n')
+  expect(parseUnits('0.0000009900000000', 7)).toMatchInlineSnapshot('10n')
+  expect(parseUnits('0.0000099900000000', 7)).toMatchInlineSnapshot('100n')
+  expect(parseUnits('0.0000092900000000', 7)).toMatchInlineSnapshot('93n')
+  expect(parseUnits('0.0999999999999999', 7)).toMatchInlineSnapshot('1000000n')
+  expect(parseUnits('0.0099999999999999', 7)).toMatchInlineSnapshot('100000n')
   expect(parseUnits('0.00000000059', 9)).toMatchInlineSnapshot('1n')
   expect(parseUnits('0.0000000003', 9)).toMatchInlineSnapshot('0n')
   expect(parseUnits('69.00000000000', 9)).toMatchInlineSnapshot('69000000000n')

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -18,13 +18,11 @@ export function parseUnits(value: `${number}`, decimals: number) {
       fraction.slice(decimals),
     ]
 
-    const zeroes = left.match(/^0+/)?.[0].length ?? 0
-
     const rounded = Math.round(Number(`${unit}.${right}`))
-    if (rounded > 9)
-      fraction = `${zeroes ? left.slice(0, zeroes - 1) : ''}${
-        BigInt(left) + 1n
-      }0`
+    if (rounded > 9) {
+      const leftLen = left.length;
+      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(leftLen + 1, "0");
+    }
     else fraction = `${left}${rounded}`
 
     if (fraction.length > decimals) {

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -19,10 +19,8 @@ export function parseUnits(value: `${number}`, decimals: number) {
     ]
 
     const rounded = Math.round(Number(`${unit}.${right}`))
-    if (rounded > 9) {
-      const leftLen = left.length;
-      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(leftLen + 1, "0");
-    }
+    if (rounded > 9)
+      fraction = `${BigInt(left) + BigInt(1)}0`.padStart(left.length + 1, '0')
     else fraction = `${left}${rounded}`
 
     if (fraction.length > decimals) {


### PR DESCRIPTION
PR aiming at fixing the stripping of the decimal leading zeroes when using `parseUnits` when the last decimal is rounded-up.

Explanation: 
Simplified the logic by removing the `zeroes` variable and using the `length` of the `left` decimals part + 1 (the `unit` "slot") to handle the rounding.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR improves the `parseUnits` function in `src/utils/unit/parseUnits.ts` to handle decimal precision more accurately. 

### Detailed summary
- Replaces `Math.floor` with `Math.round` for more accurate rounding
- Simplifies code by removing unnecessary string manipulation
- Adds tests for edge cases with decimal precision

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->