### PR TITLE
chore: support custom transaction formatters on `sendUnsignedTransaction`

### DIFF
--- a/.changeset/curvy-deers-compare.md
+++ b/.changeset/curvy-deers-compare.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support custom transaction formatters on `sendUnsignedTransaction`.

--- a/src/actions/test/sendUnsignedTransaction.test.ts
+++ b/src/actions/test/sendUnsignedTransaction.test.ts
@@ -2,9 +2,13 @@ import { expect, test } from 'vitest'
 
 import { accounts, address } from '../../_test/constants.js'
 import { publicClient, testClient } from '../../_test/utils.js'
+import { celo } from '../../chains.js'
+import { createTestClient } from '../../clients/createTestClient.js'
+import { defineChain } from '../../utils/chain.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { getBalance } from '../public/getBalance.js'
 
+import { http } from '../../index.js'
 import { mine } from './mine.js'
 import { sendUnsignedTransaction } from './sendUnsignedTransaction.js'
 import { setBalance } from './setBalance.js'
@@ -44,6 +48,57 @@ test('sends unsigned transaction', async () => {
   ).toMatchInlineSnapshot('10000000000000000000000n')
 
   await mine(testClient, { blocks: 1 })
+
+  expect(
+    await getBalance(publicClient, { address: targetAccount.address }),
+  ).toMatchInlineSnapshot('10001000000000000000000n')
+  expect(
+    await getBalance(publicClient, { address: sourceAccount.address }),
+  ).toBeLessThan(balance)
+})
+
+test('sends unsigned transaction (w/ formatter)', async () => {
+  const chain = defineChain({
+    ...testClient.chain,
+    formatters: {
+      transactionRequest: celo.formatters.transactionRequest,
+    },
+  })
+  const testClient2 = createTestClient({
+    chain,
+    mode: 'anvil',
+    transport: http(),
+  })
+
+  await setBalance(testClient2, {
+    address: targetAccount.address,
+    value: targetAccount.balance,
+  })
+  await setBalance(testClient2, {
+    address: sourceAccount.address,
+    value: parseEther('10000'),
+  })
+
+  const balance = await getBalance(publicClient, {
+    address: sourceAccount.address,
+  })
+
+  expect(
+    await sendUnsignedTransaction(testClient2, {
+      from: sourceAccount.address,
+      to: targetAccount.address,
+      value: parseEther('1'),
+    }),
+  ).toBeDefined()
+
+  expect(
+    await getBalance(publicClient, { address: targetAccount.address }),
+  ).toMatchInlineSnapshot('10000000000000000000000n')
+  expect(
+    await getBalance(publicClient, { address: sourceAccount.address }),
+  ).toMatchInlineSnapshot('10000000000000000000000n')
+
+  await mine(testClient2, { blocks: 1 })
 
   expect(
     await getBalance(publicClient, { address: targetAccount.address }),

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -4,11 +4,27 @@ import type {
 } from '../../clients/createTestClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import type { Chain } from '../../types/chain.js'
+import type { Formatter } from '../../types/formatter.js'
 import type { Hash } from '../../types/misc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
-import { formatTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import type { MergeIntersectionProperties } from '../../types/utils.js'
+import { extract } from '../../utils/formatters/extract.js'
+import { type Formatted, format } from '../../utils/formatters/format.js'
+import {
+  type TransactionRequestFormatter,
+  formatTransactionRequest,
+} from '../../utils/formatters/transactionRequest.js'
 
-export type SendUnsignedTransactionParameters = TransactionRequest
+type FormattedTransactionRequest<
+  TFormatter extends Formatter | undefined = Formatter,
+> = MergeIntersectionProperties<
+  Formatted<TFormatter, TransactionRequest, true>,
+  TransactionRequest
+>
+
+export type SendUnsignedTransactionParameters<
+  TChain extends Chain | undefined = Chain | undefined,
+> = FormattedTransactionRequest<TransactionRequestFormatter<TChain>>
 
 export type SendUnsignedTransactionReturnType = Hash
 
@@ -41,15 +57,45 @@ export async function sendUnsignedTransaction<
   TChain extends Chain | undefined,
 >(
   client: TestClient<TestClientMode, Transport, TChain>,
-  // TODO - the request parameters should be determined by the chains formatters like SendTransactionParameters are
-  request: SendUnsignedTransactionParameters,
+  args: SendUnsignedTransactionParameters<TChain>,
 ): Promise<SendUnsignedTransactionReturnType> {
-  const formatter =
-    client.chain?.formatters?.transactionRequest || formatTransactionRequest
-  const request_ = formatter(request)
+  const {
+    accessList,
+    data,
+    from,
+    gas,
+    gasPrice,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    nonce,
+    to,
+    value,
+    ...rest
+  } = args
+
+  const formatter = client.chain?.formatters?.transactionRequest
+  const request = format(
+    {
+      accessList,
+      data,
+      from,
+      gas,
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      nonce,
+      to,
+      value,
+      // Pick out extra data that might exist on the chain's transaction request type.
+      ...extract(rest, { formatter }),
+    } as TransactionRequest,
+    {
+      formatter: formatter || formatTransactionRequest,
+    },
+  )
   const hash = await client.request({
     method: 'eth_sendUnsignedTransaction',
-    params: [request_],
+    params: [request],
   })
   return hash
 }

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -41,9 +41,11 @@ export async function sendUnsignedTransaction<
   TChain extends Chain | undefined,
 >(
   client: TestClient<TestClientMode, Transport, TChain>,
+  // TODO - the request parameters should be determined by the chains formatters like SendTransactionParameters are
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
-  const request_ = formatTransactionRequest(request)
+  const formatter = client.chain?.formatters?.transactionRequest || formatTransactionRequest
+  const request_ = formatter(request)
   const hash = await client.request({
     method: 'eth_sendUnsignedTransaction',
     params: [request_],

--- a/src/actions/test/sendUnsignedTransaction.ts
+++ b/src/actions/test/sendUnsignedTransaction.ts
@@ -44,7 +44,8 @@ export async function sendUnsignedTransaction<
   // TODO - the request parameters should be determined by the chains formatters like SendTransactionParameters are
   request: SendUnsignedTransactionParameters,
 ): Promise<SendUnsignedTransactionReturnType> {
-  const formatter = client.chain?.formatters?.transactionRequest || formatTransactionRequest
+  const formatter =
+    client.chain?.formatters?.transactionRequest || formatTransactionRequest
   const request_ = formatter(request)
   const hash = await client.request({
     method: 'eth_sendUnsignedTransaction',


### PR DESCRIPTION
dupe of #665

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for custom transaction formatters on `sendUnsignedTransaction`. It also defines a new type `FormattedTransactionRequest` and updates the `SendUnsignedTransactionParameters` type to use it.

### Detailed summary
- Adds support for custom transaction formatters on `sendUnsignedTransaction`
- Defines a new type `FormattedTransactionRequest`
- Updates the `SendUnsignedTransactionParameters` type to use `FormattedTransactionRequest`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->