### PR TITLE
refactor: txn types

### DIFF
--- a/.changeset/beige-eggs-cough.md
+++ b/.changeset/beige-eggs-cough.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Refactored serializable/serialized transaction types.

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -12,7 +12,7 @@ import type {
 export type Index = `0x${string}`
 export type Quantity = `0x${string}`
 export type Status = '0x0' | '0x1'
-export type TransactionType = '0x0' | '0x1' | '0x2'
+export type TransactionType = '0x0' | '0x1' | '0x2' | (string & {})
 
 export type RpcBlock = Block<Quantity, RpcTransaction>
 export type RpcBlockNumber = BlockNumber<Quantity>

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -9,7 +9,7 @@ import type { ValueOf } from './utils.js'
 
 export type AccessList = { address: Address; storageKeys: Hex[] }[]
 
-export type TransactionType = ValueOf<typeof transactionType>
+export type TransactionType = ValueOf<typeof transactionType> | (string & {})
 
 export type TransactionReceipt<
   TQuantity = bigint,
@@ -153,10 +153,15 @@ export type TransactionRequest<TQuantity = bigint, TIndex = number> =
 export type TransactionSerializedEIP1559 = `0x02${string}`
 export type TransactionSerializedEIP2930 = `0x01${string}`
 export type TransactionSerializedLegacy = Hex
+export type TransactionSerializedGeneric = Hex
 export type TransactionSerialized<TType extends TransactionType = 'legacy'> =
-  | (TType extends 'eip1559' ? TransactionSerializedEIP1559 : never)
-  | (TType extends 'eip2930' ? TransactionSerializedEIP2930 : never)
-  | (TType extends 'legacy' ? TransactionSerializedLegacy : never)
+  TType extends 'eip1559'
+    ? TransactionSerializedEIP1559
+    : TType extends 'eip2930'
+    ? TransactionSerializedEIP2930
+    : TType extends 'legacy'
+    ? TransactionSerializedLegacy
+    : TransactionSerializedGeneric
 
 export type TransactionSerializableBase<
   TQuantity = bigint,
@@ -191,7 +196,19 @@ export type TransactionSerializableEIP1559<
     type?: 'eip1559'
     yParity?: number
   }
+export type TransactionSerializableGeneric<
+  TQuantity = bigint,
+  TIndex = number,
+> = TransactionSerializableBase<TQuantity, TIndex> & {
+  accessList?: AccessList
+  gasPrice?: TQuantity
+  maxFeePerGas?: TQuantity
+  maxPriorityFeePerGas?: TQuantity
+  type: string
+}
+
 export type TransactionSerializable<TQuantity = bigint, TIndex = number> =
   | TransactionSerializableLegacy<TQuantity, TIndex>
   | TransactionSerializableEIP2930<TQuantity, TIndex>
   | TransactionSerializableEIP1559<TQuantity, TIndex>
+  | TransactionSerializableGeneric<TQuantity, TIndex>

--- a/src/utils/formatters/transactionReceipt.test.ts
+++ b/src/utils/formatters/transactionReceipt.test.ts
@@ -109,6 +109,27 @@ test('formats', () => {
   `)
 })
 
+test('unknown type', () => {
+  expect(
+    formatTransactionReceipt({
+      type: '0x7e',
+    }),
+  ).toMatchInlineSnapshot(`
+    {
+      "blockNumber": null,
+      "contractAddress": null,
+      "cumulativeGasUsed": null,
+      "effectiveGasPrice": null,
+      "gasUsed": null,
+      "logs": null,
+      "status": null,
+      "to": null,
+      "transactionIndex": null,
+      "type": "0x7e",
+    }
+  `)
+})
+
 test('nullish values', () => {
   expect(
     formatTransactionReceipt({

--- a/src/utils/formatters/transactionReceipt.ts
+++ b/src/utils/formatters/transactionReceipt.ts
@@ -62,7 +62,9 @@ export function formatTransactionReceipt(
       ? statuses[transactionReceipt.status]
       : null,
     type: transactionReceipt.type
-      ? transactionType[transactionReceipt.type]
+      ? transactionType[
+          transactionReceipt.type as keyof typeof transactionType
+        ] || transactionReceipt.type
       : null,
   } as TransactionReceipt
 }

--- a/src/utils/transaction/getTransactionType.test.ts
+++ b/src/utils/transaction/getTransactionType.test.ts
@@ -20,6 +20,12 @@ describe('type', () => {
     assertType<'legacy'>(type)
     expect(type).toEqual('legacy')
   })
+
+  test('other', () => {
+    const type = getTransactionType({ type: '0x7e' } as const)
+    assertType<'0x7e'>(type)
+    expect(type).toEqual('0x7e')
+  })
 })
 
 describe('attributes', () => {

--- a/src/utils/transaction/getTransactionType.ts
+++ b/src/utils/transaction/getTransactionType.ts
@@ -1,24 +1,25 @@
 import { InvalidSerializableTransactionError } from '../../errors/transaction.js'
 import type {
-  AccessList,
   TransactionSerializable,
+  TransactionSerializableEIP1559,
+  TransactionSerializableEIP2930,
+  TransactionSerializableGeneric,
+  TransactionSerializableLegacy,
 } from '../../types/transaction.js'
 
 export type GetTransactionType<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
 > =
-  | (TTransactionSerializable['maxFeePerGas'] extends bigint
+  | (TTransactionSerializable extends TransactionSerializableLegacy
+      ? 'legacy'
+      : never)
+  | (TTransactionSerializable extends TransactionSerializableEIP1559
       ? 'eip1559'
       : never)
-  | (TTransactionSerializable['maxPriorityFeePerGas'] extends bigint
-      ? 'eip1559'
+  | (TTransactionSerializable extends TransactionSerializableEIP2930
+      ? 'eip2930'
       : never)
-  | (TTransactionSerializable['gasPrice'] extends bigint
-      ? TTransactionSerializable['accessList'] extends AccessList
-        ? 'eip2930'
-        : 'legacy'
-      : never)
-  | (TTransactionSerializable['type'] extends string
+  | (TTransactionSerializable extends TransactionSerializableGeneric
       ? TTransactionSerializable['type']
       : never)
 

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -49,18 +49,18 @@ export function serializeTransaction<
     return serializeTransactionEIP1559(
       transaction as TransactionSerializableEIP1559,
       signature,
-    ) as SerializedTransactionReturnType
+    ) as SerializedTransactionReturnType<TTransactionSerializable>
 
   if (type === 'eip2930')
     return serializeTransactionEIP2930(
       transaction as TransactionSerializableEIP2930,
       signature,
-    ) as SerializedTransactionReturnType
+    ) as SerializedTransactionReturnType<TTransactionSerializable>
 
   return serializeTransactionLegacy(
     transaction as TransactionSerializableLegacy,
     signature,
-  ) as SerializedTransactionReturnType
+  ) as SerializedTransactionReturnType<TTransactionSerializable>
 }
 
 function serializeTransactionEIP1559(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors transaction types to improve serialization and adds support for a new `TransactionSerializableGeneric` type.

### Detailed summary
- Refactored `TransactionType` to support serialization improvements
- Added a new `TransactionSerializableGeneric` type
- Updated `TransactionReceipt` to handle unknown types
- Added a new `getTransactionType` test case for unknown types

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->