### PR TITLE
fix: format blocks in watchBlocks subscription

### DIFF
--- a/.changeset/good-oranges-tap.md
+++ b/.changeset/good-oranges-tap.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed block formatting in `watchBlocks` for WebSocket subscriptions.

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -50,6 +50,7 @@ describe('poll', () => {
     unwatch()
     expect(blocks.length).toBe(4)
     expect(prevBlocks.length).toBe(3)
+    expect(typeof blocks[0].number).toBe('bigint')
   })
 
   test('args: includeTransactions', async () => {
@@ -586,6 +587,7 @@ describe('subscribe', () => {
     unwatch()
     expect(blocks.length).toBe(5)
     expect(prevBlocks.length).toBe(4)
+    expect(typeof blocks[0].number).toBe('bigint')
   })
 
   describe('behavior', () => {

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -3,6 +3,8 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type { GetTransportConfig } from '../../types/transport.js'
+import { formatBlock } from '../../utils/formatters/block.js'
+import { format } from '../../utils/formatters/format.js'
 import { observe } from '../../utils/observe.js'
 import { poll } from '../../utils/poll.js'
 import { stringify } from '../../utils/stringify.js'
@@ -170,7 +172,9 @@ export function watchBlocks<
           params: ['newHeads'],
           onData(data: any) {
             if (!active) return
-            const block = data.result
+            const block = format(data.result, {
+              formatter: client.chain?.formatters?.block || formatBlock,
+            })
             onBlock(block, prevBlock)
             prevBlock = block
           },


### PR DESCRIPTION
fixes #725

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a block formatting issue in `watchBlocks` for WebSocket subscriptions. It also adds a new formatter function and uses it to format block data.

### Detailed summary
- Fixed block formatting in `watchBlocks` for WebSocket subscriptions.
- Added a new `formatBlock` function.
- Used `formatBlock` to format block data in `watchBlocks`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->