### PR TITLE
refactor: signedTypeData types

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,16 +106,36 @@
   },
   "typesVersions": {
     "*": {
-      "abi": ["./dist/types/abi.d.ts"],
-      "accounts": ["./dist/types/accounts/index.d.ts"],
-      "chains": ["./dist/types/chains.d.ts"],
-      "contract": ["./dist/types/contract.d.ts"],
-      "ens": ["./dist/types/ens.d.ts"],
-      "public": ["./dist/types/public.d.ts"],
-      "test": ["./dist/types/test.d.ts"],
-      "utils": ["./dist/types/utils/index.d.ts"],
-      "wallet": ["./dist/types/wallet.d.ts"],
-      "window": ["./dist/types/window.d.ts"]
+      "abi": [
+        "./dist/types/abi.d.ts"
+      ],
+      "accounts": [
+        "./dist/types/accounts/index.d.ts"
+      ],
+      "chains": [
+        "./dist/types/chains.d.ts"
+      ],
+      "contract": [
+        "./dist/types/contract.d.ts"
+      ],
+      "ens": [
+        "./dist/types/ens.d.ts"
+      ],
+      "public": [
+        "./dist/types/public.d.ts"
+      ],
+      "test": [
+        "./dist/types/test.d.ts"
+      ],
+      "utils": [
+        "./dist/types/utils/index.d.ts"
+      ],
+      "wallet": [
+        "./dist/types/wallet.d.ts"
+      ],
+      "window": [
+        "./dist/types/window.d.ts"
+      ]
     }
   },
   "peerDependencies": {
@@ -163,14 +183,23 @@
   },
   "license": "MIT",
   "repository": "wagmi-dev/viem",
-  "authors": ["awkweb.eth", "jxom.eth"],
+  "authors": [
+    "awkweb.eth",
+    "jxom.eth"
+  ],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": ["eth", "ethereum", "dapps", "wallet", "web3"],
+  "keywords": [
+    "eth",
+    "ethereum",
+    "dapps",
+    "wallet",
+    "web3"
+  ],
   "size-limit": [
     {
       "name": "viem (cjs)",
@@ -202,7 +231,9 @@
       "vitepress@1.0.0-alpha.61": "patches/vitepress@1.0.0-alpha.61.patch"
     },
     "peerDependencyRules": {
-      "ignoreMissing": ["@algolia/client-search"]
+      "ignoreMissing": [
+        "@algolia/client-search"
+      ]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -178,28 +178,19 @@
     "simple-git-hooks": "^2.8.1",
     "size-limit": "^8.2.4",
     "typescript": "^5.0.4",
-    "vite": "^4.1.4",
+    "vite": "^4.3.9",
     "vitest": "~0.30.1"
   },
   "license": "MIT",
   "repository": "wagmi-dev/viem",
-  "authors": [
-    "awkweb.eth",
-    "jxom.eth"
-  ],
+  "authors": ["awkweb.eth", "jxom.eth"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "eth",
-    "ethereum",
-    "dapps",
-    "wallet",
-    "web3"
-  ],
+  "keywords": ["eth", "ethereum", "dapps", "wallet", "web3"],
   "size-limit": [
     {
       "name": "viem (cjs)",

--- a/package.json
+++ b/package.json
@@ -106,36 +106,16 @@
   },
   "typesVersions": {
     "*": {
-      "abi": [
-        "./dist/types/abi.d.ts"
-      ],
-      "accounts": [
-        "./dist/types/accounts/index.d.ts"
-      ],
-      "chains": [
-        "./dist/types/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/contract.d.ts"
-      ],
-      "ens": [
-        "./dist/types/ens.d.ts"
-      ],
-      "public": [
-        "./dist/types/public.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "utils": [
-        "./dist/types/utils/index.d.ts"
-      ],
-      "wallet": [
-        "./dist/types/wallet.d.ts"
-      ],
-      "window": [
-        "./dist/types/window.d.ts"
-      ]
+      "abi": ["./dist/types/abi.d.ts"],
+      "accounts": ["./dist/types/accounts/index.d.ts"],
+      "chains": ["./dist/types/chains.d.ts"],
+      "contract": ["./dist/types/contract.d.ts"],
+      "ens": ["./dist/types/ens.d.ts"],
+      "public": ["./dist/types/public.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "utils": ["./dist/types/utils/index.d.ts"],
+      "wallet": ["./dist/types/wallet.d.ts"],
+      "window": ["./dist/types/window.d.ts"]
     }
   },
   "peerDependencies": {
@@ -153,7 +133,7 @@
     "@scure/bip32": "1.3.0",
     "@scure/bip39": "1.2.0",
     "@wagmi/chains": "1.1.0",
-    "abitype": "0.8.7",
+    "abitype": "0.8.11",
     "isomorphic-ws": "5.0.0",
     "ws": "8.12.0"
   },
@@ -222,9 +202,7 @@
       "vitepress@1.0.0-alpha.61": "patches/vitepress@1.0.0-alpha.61.patch"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.0.4)
       abitype:
-        specifier: 0.8.7
-        version: 0.8.7(typescript@5.0.4)
+        specifier: 0.8.11
+        version: 0.8.11(typescript@5.0.4)
       isomorphic-ws:
         specifier: 5.0.0
         version: 5.0.0(ws@8.12.0)
@@ -2805,8 +2805,8 @@ packages:
       zod: 3.20.2
     dev: true
 
-  /abitype@0.8.7(typescript@5.0.4):
-    resolution: {integrity: sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==}
+  /abitype@0.8.11(typescript@5.0.4):
+    resolution: {integrity: sha512-bM4v2dKvX08sZ9IU38IN5BKmN+ZkOSd2oI4a9f0ejHYZQYV6cDr7j+d95ga0z2XHG36Y4jzoG5Z7qDqxp7fi/A==}
     peerDependencies:
       typescript: '>=5.0.4'
       zod: ^3 >=3.19.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,8 +101,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       vite:
-        specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        specifier: ^4.3.9
+        version: 4.3.9(@types/node@18.16.3)
       vitest:
         specifier: ~0.30.1
         version: 0.30.1(@vitest/ui@0.30.1)
@@ -118,7 +118,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/blocks/fetching-blocks:
     dependencies:
@@ -131,7 +131,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/blocks/watching-blocks:
     dependencies:
@@ -144,7 +144,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/clients/public-client:
     dependencies:
@@ -157,7 +157,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/clients/wallet-client:
     dependencies:
@@ -185,7 +185,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/contracts/deploying-contracts:
     dependencies:
@@ -213,7 +213,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/contracts/multicall:
     dependencies:
@@ -226,7 +226,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/contracts/reading-contracts:
     dependencies:
@@ -239,7 +239,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/contracts/writing-to-contracts:
     dependencies:
@@ -267,7 +267,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/ens:
     dependencies:
@@ -280,7 +280,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/filters-and-logs/block-event-logs:
     dependencies:
@@ -293,7 +293,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/filters-and-logs/event-logs:
     dependencies:
@@ -306,7 +306,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/signing/typed-data:
     dependencies:
@@ -334,7 +334,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/transactions/fetching-transactions:
     dependencies:
@@ -347,7 +347,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   examples/transactions/sending-transactions:
     dependencies:
@@ -375,7 +375,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   playgrounds/browser:
     dependencies:
@@ -403,7 +403,7 @@ importers:
         version: 5.0.3
       vite:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@18.16.3)
+        version: 4.1.4
 
   playgrounds/bun:
     dependencies:
@@ -2340,7 +2340,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.20.12)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.4(@types/node@18.16.3)
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2476,7 +2476,7 @@ packages:
       '@vue/shared': 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
-      postcss: 8.4.21
+      postcss: 8.4.24
       source-map: 0.6.1
     dev: true
 
@@ -5221,6 +5221,12 @@ packages:
     hasBin: true
     dev: true
 
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /nanospinner@1.1.0:
     resolution: {integrity: sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==}
     dependencies:
@@ -5631,6 +5637,15 @@ packages:
       source-map-js: 1.0.2
     dev: true
 
+  /postcss@8.4.24:
+    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /preact@10.4.1:
     resolution: {integrity: sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q==}
     dev: true
@@ -5905,6 +5920,14 @@ packages:
 
   /rollup@3.20.0:
     resolution: {integrity: sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /rollup@3.25.1:
+    resolution: {integrity: sha512-tywOR+rwIt5m2ZAWSe5AIJcTat8vGlnPFAv15ycCrw33t6iFsXZ6mzHVFh2psSjxQPmI+xgzMZZizUAukBI4aQ==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -6603,7 +6626,7 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.1.4(@types/node@18.16.3)
+      vite: 4.3.9(@types/node@18.16.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6614,7 +6637,7 @@ packages:
       - terser
     dev: true
 
-  /vite@4.1.4(@types/node@18.16.3):
+  /vite@4.1.4:
     resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6639,7 +6662,6 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.16.3
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
@@ -6677,6 +6699,39 @@ packages:
       postcss: 8.4.21
       resolve: 1.22.1
       rollup: 3.20.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /vite@4.3.9(@types/node@18.16.3):
+    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.3
+      esbuild: 0.17.7
+      postcss: 8.4.24
+      rollup: 3.25.1
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -6764,7 +6819,7 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.4.0
-      vite: 4.1.4(@types/node@18.16.3)
+      vite: 4.3.9(@types/node@18.16.3)
       vite-node: 0.30.1(@types/node@18.16.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/src/accounts/types.ts
+++ b/src/accounts/types.ts
@@ -16,8 +16,8 @@ export type CustomSource = {
   signMessage: ({ message }: { message: SignableMessage }) => Promise<Hash>
   signTransaction: (transaction: TransactionSerializable) => Promise<Hash>
   signTypedData: <
-    TTypedData extends TypedData | { [key: string]: unknown },
-    TPrimaryType extends string = string,
+    const TTypedData extends TypedData | Record<string, unknown>,
+    TPrimaryType extends keyof TTypedData = keyof TTypedData,
   >(
     typedData: TypedDataDefinition<TTypedData, TPrimaryType>,
   ) => Promise<Hash>

--- a/src/accounts/utils/signTypedData.ts
+++ b/src/accounts/utils/signTypedData.ts
@@ -11,8 +11,8 @@ import { sign } from './sign.js'
 import { signatureToHex } from './signatureToHex.js'
 
 export type SignTypedDataParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
 > = TypedDataDefinition<TTypedData, TPrimaryType> & {
   /** The private key to sign with. */
   privateKey: Hex
@@ -27,8 +27,8 @@ export type SignTypedDataReturnType = Hex
  * @returns The signature.
  */
 export async function signTypedData<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
 >({
   privateKey,
   ...typedData

--- a/src/actions/public/verifyTypedData.ts
+++ b/src/actions/public/verifyTypedData.ts
@@ -3,13 +3,16 @@ import type { PublicClient } from '../../clients/createPublicClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
 import type { ByteArray, Hex } from '../../types/misc.js'
 import type { TypedDataDefinition } from '../../types/typedData.js'
-import { hashTypedData } from '../../utils/index.js'
+import {
+  type HashTypedDataParameters,
+  hashTypedData,
+} from '../../utils/index.js'
 import { type VerifyHashParameters, verifyHash } from './verifyHash.js'
 import type { Address, TypedData } from 'abitype'
 
 export type VerifyTypedDataParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
 > = Omit<VerifyHashParameters, 'hash'> &
   TypedDataDefinition<TTypedData, TPrimaryType> & {
     /** The address to verify the typed data for. */
@@ -29,7 +32,11 @@ export type VerifyTypedDataReturnType = boolean
  * @param parameters - {@link VerifyTypedDataParameters}
  * @returns Whether or not the signature is valid. {@link VerifyTypedDataReturnType}
  */
-export async function verifyTypedData<TChain extends Chain | undefined,>(
+export async function verifyTypedData<
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
+  TChain extends Chain | undefined,
+>(
   client: PublicClient<Transport, TChain>,
   {
     address,
@@ -39,9 +46,14 @@ export async function verifyTypedData<TChain extends Chain | undefined,>(
     types,
     domain,
     ...callRequest
-  }: VerifyTypedDataParameters,
+  }: VerifyTypedDataParameters<TTypedData, TPrimaryType>,
 ): Promise<VerifyTypedDataReturnType> {
-  const hash = hashTypedData({ message, primaryType, types, domain })
+  const hash = hashTypedData({
+    message,
+    primaryType,
+    types,
+    domain,
+  } as HashTypedDataParameters)
   return verifyHash(client, {
     address,
     hash,

--- a/src/actions/wallet/signTypedData.test-d.ts
+++ b/src/actions/wallet/signTypedData.test-d.ts
@@ -150,9 +150,7 @@ test('`types` not const asserted', () => {
   type Result = Parameters<
     typeof walletClient.signTypedData<typeof types_, typeof primaryType>
   >[0]
-  expectTypeOf<Result['message']>().toEqualTypeOf<{
-    [key: string]: unknown
-  }>()
+  expectTypeOf<Result['message']>().toEqualTypeOf<Record<string, unknown>>()
 })
 
 test('`types` declared as `TypedData`', () => {
@@ -176,7 +174,5 @@ test('`types` declared as `TypedData`', () => {
   type Result = Parameters<
     typeof walletClient.signTypedData<typeof types_, typeof primaryType>
   >[0]
-  expectTypeOf<Result['message']>().toEqualTypeOf<{
-    [key: string]: unknown
-  }>()
+  expectTypeOf<Result['message']>().toEqualTypeOf<Record<string, unknown>>()
 })

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -14,8 +14,8 @@ import { stringify } from '../../utils/stringify.js'
 import { validateTypedData } from '../../utils/typedData.js'
 
 export type SignTypedDataParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
   TAccount extends Account | undefined = undefined,
 > = GetAccountParameter<TAccount> &
   TypedDataDefinition<TTypedData, TPrimaryType>
@@ -121,8 +121,8 @@ export type SignTypedDataReturnType = Hex
  * })
  */
 export async function signTypedData<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
 >(

--- a/src/clients/decorators/wallet.ts
+++ b/src/clients/decorators/wallet.ts
@@ -410,8 +410,8 @@ export type WalletActions<
    * })
    */
   signTypedData: <
-    TTypedData extends TypedData | { [key: string]: unknown },
-    TPrimaryType extends string,
+    const TTypedData extends TypedData | Record<string, unknown>,
+    TPrimaryType extends keyof TTypedData,
   >(
     args: SignTypedDataParameters<TTypedData, TPrimaryType, TAccount>,
   ) => Promise<SignTypedDataReturnType>

--- a/src/index.ts
+++ b/src/index.ts
@@ -453,7 +453,6 @@ export type {
   EIP1193Provider,
   EIP1193RequestFn,
   EIP1474Methods,
-  ProviderRpcError as EIP1193ProviderRpcError,
   ProviderConnectInfo,
   ProviderMessage,
   PublicRpcSchema,
@@ -466,6 +465,7 @@ export type {
   WalletPermission,
   WalletRpcSchema,
 } from './types/eip1193.js'
+export { ProviderRpcError as EIP1193ProviderRpcError } from './types/eip1193.js'
 export type {
   FeeHistory,
   FeeValues,
@@ -479,7 +479,6 @@ export type {
 export type {
   GetTypedDataDomain,
   GetTypedDataMessage,
-  GetTypedDataPrimaryType,
   GetTypedDataTypes,
   TypedDataDefinition,
 } from './types/typedData.js'

--- a/src/types/typedData.ts
+++ b/src/types/typedData.ts
@@ -1,81 +1,72 @@
 import type {
-  Narrow,
   TypedData,
   TypedDataDomain,
   TypedDataToPrimitiveTypes,
 } from 'abitype'
 
 export type TypedDataDefinition<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
-> = {
-  primaryType: GetTypedDataPrimaryType<TTypedData, TPrimaryType>
-} & GetTypedDataMessage<TTypedData, TPrimaryType> &
+  TTypedData extends TypedData | Record<string, unknown> =
+    | TypedData
+    | Record<string, unknown>,
+  TPrimaryType extends keyof TTypedData | 'EIP712Domain' = keyof TTypedData,
+> = GetTypedDataPrimaryType<TTypedData, TPrimaryType> &
+  GetTypedDataMessage<TTypedData, TPrimaryType> &
   GetTypedDataTypes<TTypedData, TPrimaryType> &
   GetTypedDataDomain<TTypedData, TPrimaryType>
 
 export type GetTypedDataDomain<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
-  TSchema = TTypedData extends TypedData
+  TTypedData extends TypedData | Record<string, unknown>,
+  TPrimaryType extends keyof TTypedData | 'EIP712Domain',
+  ///
+  Schema extends Record<string, unknown> = TTypedData extends TypedData
     ? TypedDataToPrimitiveTypes<TTypedData>
-    : { [key: string]: any },
-  TDomain = TSchema extends { EIP712Domain: infer Domain }
+    : { [_: string]: any },
+  TDomain = Schema extends { EIP712Domain: infer Domain }
     ? Domain
     : TypedDataDomain,
 > = TPrimaryType extends 'EIP712Domain'
-  ? {
-      domain: TDomain
-    }
-  : {
-      domain?: TDomain
-    }
+  ? { domain: TDomain }
+  : { domain?: TDomain }
 
 export type GetTypedDataMessage<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
-  TSchema = TTypedData extends TypedData
+  TTypedData extends TypedData | Record<string, unknown>,
+  TPrimaryType extends keyof TTypedData | 'EIP712Domain',
+  ///
+  Schema extends Record<string, unknown> = TTypedData extends TypedData
     ? TypedDataToPrimitiveTypes<TTypedData>
-    : { [key: string]: any },
-  TMessage = TSchema[TPrimaryType extends keyof TSchema
+    : { [_: string]: any },
+  Message extends Schema[keyof Schema] = Schema[TPrimaryType extends keyof Schema
     ? TPrimaryType
-    : keyof TSchema],
+    : keyof Schema],
 > = TPrimaryType extends 'EIP712Domain'
   ? {}
-  : { [key: string]: any } extends TMessage // Check if we were able to infer the shape of typed data
+  : { [key: string]: any } extends Message // Check if we were able to infer the shape of typed data
   ? {
       /**
        * Data to sign
        *
        * Use a [const assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) on {@link types} for type inference.
        */
-      message: { [key: string]: unknown }
+      message: Record<string, unknown>
     }
   : {
       /** Data to sign */
-      message: TMessage
+      message: Message
     }
 
 export type GetTypedDataPrimaryType<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
-> = TTypedData extends TypedData
-  ? keyof TTypedData extends infer AbiFunctionNames
-    ?
-        | AbiFunctionNames
-        | (TPrimaryType extends AbiFunctionNames ? TPrimaryType : never)
-        | (TypedData extends TTypedData ? string : never)
-        | 'EIP712Domain'
-    : never
-  : TPrimaryType
+  TTypedData extends TypedData | Record<string, unknown>,
+  TPrimaryType extends keyof TTypedData,
+> = {
+  primaryType:
+    | TPrimaryType // infer value
+    | keyof TTypedData // show all values
+    | 'EIP712Domain'
+}
 
 export type GetTypedDataTypes<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown>,
+  TPrimaryType extends keyof TTypedData | 'EIP712Domain',
 > = TPrimaryType extends 'EIP712Domain'
-  ? {
-      types?: Narrow<TTypedData>
-    }
-  : {
-      types: Narrow<TTypedData>
-    }
+  ? { types?: TTypedData }
+  : { types: TTypedData }

--- a/src/utils/signature/hashTypedData.ts
+++ b/src/utils/signature/hashTypedData.ts
@@ -16,15 +16,15 @@ type MessageTypeProperty = {
 }
 
 export type HashTypedDataParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
 > = TypedDataDefinition<TTypedData, TPrimaryType>
 
 export type HashTypedDataReturnType = Hex
 
 export function hashTypedData<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
 >({
   domain: domain_,
   message,

--- a/src/utils/signature/recoverTypedDataAddress.ts
+++ b/src/utils/signature/recoverTypedDataAddress.ts
@@ -7,16 +7,16 @@ import { hashTypedData } from './hashTypedData.js'
 import { recoverAddress } from './recoverAddress.js'
 
 export type RecoverTypedDataAddressParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
 > = TypedDataDefinition<TTypedData, TPrimaryType> & {
   signature: Hex | ByteArray
 }
 export type RecoverTypedDataAddressReturnType = Address
 
 export async function recoverTypedDataAddress<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
 >({
   domain,
   message,

--- a/src/utils/signature/verifyTypedData.ts
+++ b/src/utils/signature/verifyTypedData.ts
@@ -11,8 +11,8 @@ import {
 } from './recoverTypedDataAddress.js'
 
 export type VerifyTypedDataParameters<
-  TTypedData extends TypedData | { [key: string]: unknown } = TypedData,
-  TPrimaryType extends string = string,
+  TTypedData extends TypedData | Record<string, unknown> = TypedData,
+  TPrimaryType extends keyof TTypedData = keyof TTypedData,
 > = TypedDataDefinition<TTypedData, TPrimaryType> & {
   /** The address to verify the typed data for. */
   address: Address
@@ -35,8 +35,8 @@ export type VerifyTypedDataReturnType = boolean
  * @returns Whether or not the signature is valid. {@link VerifyTypedDataReturnType}
  */
 export async function verifyTypedData<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
 >({
   address,
   domain,

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -11,8 +11,8 @@ import { numberToHex } from './encoding/toHex.js'
 import { bytesRegex, integerRegex } from './regex.js'
 
 export function validateTypedData<
-  TTypedData extends TypedData | { [key: string]: unknown },
-  TPrimaryType extends string = string,
+  const TTypedData extends TypedData | Record<string, unknown>, // `Record<string, unknown>` allows for non-const asserted types
+  TPrimaryType extends keyof TTypedData,
 >({
   domain,
   message,
@@ -68,7 +68,7 @@ export function validateTypedData<
 
   if (primaryType !== 'EIP712Domain') {
     // Validate message types.
-    const type = types[primaryType]
+    const type = types[primaryType as string]
     validateData(type, message as Record<string, unknown>)
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates and standardizes the typing of `TypedData` objects throughout the codebase. It also updates several dependencies. 

### Detailed summary
- Updates `abitype`, `isomorphic-ws`, and `ws` dependencies
- Standardizes `TypedData` typing throughout the codebase using `Record<string, unknown>` and `keyof` instead of `{ [key: string]: unknown }` and `string`
- Updates typing in several functions related to `TypedData`, including `signTypedData`, `hashTypedData`, `recoverTypedDataAddress`, and `verifyTypedData`

> The following files were skipped due to too many changes: `src/types/typedData.ts`, `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->