### PR TITLE
docs: multicall return value when allowFailure is false

### DIFF
--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -101,6 +101,10 @@ export const publicClient = createPublicClient({
 
 An array of results with accompanying status.
 
+Additionally, when [`allowFailue`](#allowfailure-optional) is set to `false`, it directly returns an array of inferred data:
+
+`(<inferred>)[]`
+
 ## Parameters
 
 ### contracts.address


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new feature to the `multicall` contract that allows it to directly return an array of inferred data when `allowFailure` is set to `false`. 

### Detailed summary
- Added support for returning an array of inferred data when `allowFailure` is set to `false` in the `multicall` contract. 
- Updated the documentation in `multicall.md` to reflect this new feature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->