### PR TITLE
docs: typo

### DIFF
--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -101,7 +101,7 @@ export const publicClient = createPublicClient({
 
 An array of results with accompanying status.
 
-Additionally, when [`allowFailue`](#allowfailure-optional) is set to `false`, it directly returns an array of inferred data:
+Additionally, when [`allowFailure`](#allowfailure-optional) is set to `false`, it directly returns an array of inferred data:
 
 `(<inferred>)[]`
 


### PR DESCRIPTION
Oops my bad 🤦

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a typo in the `multicall.md` file and updates the documentation to reflect the correct spelling of a parameter.

### Detailed summary
- Fixed a typo in `multicall.md` file.
- Updated documentation to correct spelling of `allowFailure` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->