### PR TITLE
fix: function selector from ABI with tuple components

### DIFF
--- a/.changeset/weak-parents-sell.md
+++ b/.changeset/weak-parents-sell.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+hashAbiItem now handles tuple types with components

--- a/src/utils/hash/getFunctionSelector.test.ts
+++ b/src/utils/hash/getFunctionSelector.test.ts
@@ -118,4 +118,52 @@ test('creates function signature from `AbiFunction`', () => {
       stateMutability: 'view',
     }),
   ).toEqual('0xe834a834')
+
+  expect(
+    getFunctionSelector({
+      inputs: [
+        {
+          internalType: 'uint256',
+          name: 'card',
+          type: 'uint256',
+        },
+        {
+          components: [
+            {
+              internalType: 'uint256',
+              name: 'Onetime',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'Daily',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint256',
+              name: 'Monthly',
+              type: 'uint256',
+            },
+            {
+              internalType: 'uint32',
+              name: 'Seqno',
+              type: 'uint32',
+            },
+            {
+              internalType: 'bool',
+              name: 'Enabled',
+              type: 'bool',
+            },
+          ],
+          internalType: 'struct WhalesCardV1.PendingLimits',
+          name: 'limits',
+          type: 'tuple',
+        },
+      ],
+      name: 'setLimits',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    }),
+  ).toEqual('0xbc75a138')
 })

--- a/src/utils/hash/hashFunction.ts
+++ b/src/utils/hash/hashFunction.ts
@@ -16,5 +16,16 @@ export function hashFunction(def: string) {
 }
 
 export function hashAbiItem(def: AbiFunction | AbiEvent) {
-  return hash(`${def.name}(${def.inputs.map(({ type }) => type).join(',')})`)
+  return hash(
+    `${def.name}(${def.inputs
+      .map((input) => {
+        const maybeComponents = (input as any).components
+        let typeReplacement: string | null = null
+        if (input.type === 'tuple' && Array.isArray(maybeComponents)) {
+          typeReplacement = `(${maybeComponents.map((a) => a.type).join(',')})`
+        }
+        return typeReplacement ?? input.type
+      })
+      .join(',')})`,
+  )
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds support for tuple types with components to the `hashAbiItem` function and includes a new test case for `getFunctionSelector`.

### Detailed summary
- `hashAbiItem` now handles tuple types with components
- Added a new test case for `getFunctionSelector` with a tuple input parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->