### PR TITLE
Fix `EIP712Domain` to support empty string name

### DIFF
--- a/.changeset/chilly-dots-sparkle.md
+++ b/.changeset/chilly-dots-sparkle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for empty string in EIP712Domain name field.

--- a/src/actions/wallet/signTypedData.test.ts
+++ b/src/actions/wallet/signTypedData.test.ts
@@ -253,6 +253,30 @@ describe('args: domain: chainId', () => {
 })
 
 describe('args: domain: name', () => {
+  test('empty name', async () => {
+    const signature = await signTypedData(walletClient, {
+      ...typedData.complex,
+      domain: {
+        name: '',
+      },
+      account: jsonRpcAccount,
+      primaryType: 'Mail',
+    })
+    expect(signature).toEqual(
+      '0x270eb0f0209a0d43d328327dad9b04bf1ec67dc1fca3fb3235385b7b4a64410621fea5d2d64d3ef41266b17fffda854bc03083ba7ce8e9b740d643ac9dc98e911c',
+    )
+    expect(
+      await recoverTypedDataAddress({
+        ...typedData.complex,
+        domain: {
+          name: '',
+        },
+        primaryType: 'Mail',
+        signature,
+      }),
+    ).toEqual(getAddress(jsonRpcAccount))
+  })
+
   test('json-rpc account', async () => {
     const signature = await signTypedData(walletClient, {
       ...typedData.complex,

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -143,7 +143,7 @@ export async function signTypedData<
 
   const types = {
     EIP712Domain: [
-      domain?.name && { name: 'name', type: 'string' },
+      domain?.name != null && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
       domain?.chainId && { name: 'chainId', type: 'uint256' },
       domain?.verifyingContract && {

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -49,6 +49,27 @@ test('no domain', () => {
   )
 })
 
+test('domain: empty name', () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { name: '' },
+      primaryType: 'Mail',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
+  )
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { name: '' },
+      primaryType: 'Mail',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
+  )
+})
+
 test('minimal valid typed message', function () {
   const hash = hashTypedData({
     types: {

--- a/src/utils/signature/hashTypedData.ts
+++ b/src/utils/signature/hashTypedData.ts
@@ -34,7 +34,7 @@ export function hashTypedData<
   const domain: TypedDataDomain = typeof domain_ === 'undefined' ? {} : domain_
   const types = {
     EIP712Domain: [
-      domain?.name && { name: 'name', type: 'string' },
+      domain?.name != null && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
       domain?.chainId && { name: 'chainId', type: 'uint256' },
       domain?.verifyingContract && {


### PR DESCRIPTION
Hi,

We are migrating our web app to support the latest version of `viem`. However we were blocked by being unable to sign messages using `signTypedData` with an empty string as `name` in the domain structure.

According to the [spec](https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator) fields should not be considered **only if absent**, but the current implementation doesn't take into account that `name` could be `''` which is a **valid string**.

Thanks!

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for empty string in the `EIP712Domain` name field. It includes changes to `signTypedData.ts`, `hashTypedData.ts`, `hashTypedData.test.ts`, and `signTypedData.test.ts`.

### Detailed summary:
- Added support for empty string in `EIP712Domain` name field
- Changed comparison from `&&` to `!= null` in `signTypedData.ts` and `hashTypedData.ts`
- Added test case for empty name in `hashTypedData.test.ts` and `signTypedData.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->