### PR TITLE
adds serializer for Celo CIP 42 transactions

### DIFF
--- a/.changeset/nervous-chefs-rescue.md
+++ b/.changeset/nervous-chefs-rescue.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added serializer for Celo CIP-42 transactions.

--- a/src/chains/index.ts
+++ b/src/chains/index.ts
@@ -3,6 +3,7 @@ import * as chains from '@wagmi/chains'
 import { defineChain } from '../utils/chain.js'
 import { celoFormatters } from './formatters/celo.js'
 import { optimismFormatters } from './formatters/optimism.js'
+import { celoSerializers } from './serializers/celo.js'
 
 export const arbitrum = /*#__PURE__*/ defineChain(chains.arbitrum)
 export const arbitrumGoerli = /*#__PURE__*/ defineChain(chains.arbitrumGoerli)
@@ -19,12 +20,15 @@ export const bscTestnet = /*#__PURE__*/ defineChain(chains.bscTestnet)
 export const canto = /*#__PURE__*/ defineChain(chains.canto)
 export const celo = /*#__PURE__*/ defineChain(chains.celo, {
   formatters: celoFormatters,
+  serializers: celoSerializers,
 })
 export const celoAlfajores = /*#__PURE__*/ defineChain(chains.celoAlfajores, {
   formatters: celoFormatters,
+  serializers: celoSerializers,
 })
 export const celoCannoli = /*#__PURE__*/ defineChain(chains.celoCannoli, {
   formatters: celoFormatters,
+  serializers: celoSerializers,
 })
 export const cronos = /*#__PURE__*/ defineChain(chains.cronos)
 export const crossbell = /*#__PURE__*/ defineChain(chains.crossbell)

--- a/src/chains/serializers/celo.test.ts
+++ b/src/chains/serializers/celo.test.ts
@@ -1,0 +1,110 @@
+import { accounts } from '../../_test/constants.js'
+import {
+  type TransactionSerializableEIP1559,
+  parseEther,
+  parseGwei,
+  parseTransaction,
+} from '../../index.js'
+import {
+  type TransactionSerializableCIP42,
+  serializeTransaction,
+} from './celo.js'
+import { describe, expect, test } from 'vitest'
+
+describe('cip42', () => {
+  const baseTransaction: TransactionSerializableCIP42 = {
+    to: accounts[0].address,
+    chainId: 42220,
+    nonce: 0,
+    maxFeePerGas: parseGwei('2'),
+    maxPriorityFeePerGas: parseGwei('2'),
+    value: parseEther('1'),
+    type: 'cip42',
+  }
+  test('should be able to serialize a cip42 transaction', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+    }
+
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf282a4ec80847735940084773594008080808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+  test('args: feeCurrency', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      feeCurrency: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73',
+    }
+
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84682a4ec80847735940084773594008094d8763cba276a3738e6de85b4b3bf5fded6d6ca73808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: Access List', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      accessList: [
+        {
+          address: '0x0000000000000000000000000000000000000000',
+          storageKeys: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          ],
+        },
+      ],
+    }
+
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf88e82a4ec80847735940084773594008080808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080f85bf859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+  })
+
+  test('args: data', () => {
+    const args: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      data: '0x1234',
+    }
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual(
+      '0x7cf482a4ec80847735940084773594008080808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a7640000821234c0',
+    )
+  })
+
+  test('when type is not defined but has cip42 fields', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      feeCurrency: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73',
+      type: undefined,
+    }
+
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84682a4ec80847735940084773594008094d8763cba276a3738e6de85b4b3bf5fded6d6ca73808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+})
+
+describe('when not cip42', () => {
+  const baseTransaction: TransactionSerializableEIP1559 = {
+    to: accounts[0].address,
+    chainId: 1,
+    nonce: 0,
+    maxFeePerGas: parseGwei('2'),
+    maxPriorityFeePerGas: parseGwei('2'),
+    value: parseEther('1'),
+  }
+  test('it calls the standard serializeTransaction', () => {
+    const serialized = serializeTransaction({ ...baseTransaction })
+    expect(serialized).toEqual(
+      '0x02ed0180847735940084773594008094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+    expect(parseTransaction(serialized)).toEqual({
+      to: accounts[0].address,
+      chainId: 1,
+      maxFeePerGas: parseGwei('2'),
+      maxPriorityFeePerGas: parseGwei('2'),
+      value: parseEther('1'),
+      type: 'eip1559',
+    })
+  })
+})

--- a/src/chains/serializers/celo.test.ts
+++ b/src/chains/serializers/celo.test.ts
@@ -64,6 +64,27 @@ describe('cip42', () => {
     )
   })
 
+  test('args: paying gatewayFee', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      gatewayFeeRecipient: accounts[5].address,
+      gatewayFee: parseEther('0.1'),
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf86282a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a949965507d1a55bcc2695c58ba16fb37d819b0a4dc88016345785d8a000094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: nonce', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      nonce: 20,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84682a4ec14847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
   test('with signature', async () => {
     const signed = await signTransaction({
       privateKey: accounts[0].privateKey,
@@ -188,7 +209,7 @@ describe('when param values are not right', () => {
     }
 
     expect(() => serializeTransaction(transaction)).toThrowError(
-      `Chain ID "${-1}" is invalid.`
+      `Chain ID "${-1}" is invalid.`,
     )
   })
 })

--- a/src/chains/serializers/celo.test.ts
+++ b/src/chains/serializers/celo.test.ts
@@ -181,6 +181,16 @@ describe('when param values are not right', () => {
       'Either `feeCurrency` or `gatewayFeeRecipient` must be provided for CIP-42 transactions.',
     )
   })
+  test('when chainID is invalid', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseTransaction,
+      chainId: -1,
+    }
+
+    expect(() => serializeTransaction(transaction)).toThrowError(
+      `Chain ID "${-1}" is invalid.`
+    )
+  })
 })
 
 describe('when not cip42', () => {

--- a/src/chains/serializers/celo.test.ts
+++ b/src/chains/serializers/celo.test.ts
@@ -2,6 +2,7 @@ import { accounts } from '../../_test/constants.js'
 import { signTransaction } from '../../accounts/utils/signTransaction.js'
 import {
   FeeCapTooHighError,
+  InvalidAddressError,
   TipAboveFeeCapError,
   type TransactionSerializableEIP1559,
   parseEther,
@@ -14,30 +15,21 @@ import {
 } from './celo.js'
 import { describe, expect, test } from 'vitest'
 
+const baseCip42: TransactionSerializableCIP42 = {
+  to: accounts[0].address,
+  chainId: 42220,
+  nonce: 0,
+  maxFeePerGas: parseGwei('2'),
+  maxPriorityFeePerGas: parseGwei('2'),
+  value: parseEther('1'),
+  feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+  type: 'cip42',
+}
+
 describe('cip42', () => {
-  const baseTransaction: TransactionSerializableCIP42 = {
-    to: accounts[0].address,
-    chainId: 42220,
-    nonce: 0,
-    maxFeePerGas: parseGwei('2'),
-    maxPriorityFeePerGas: parseGwei('2'),
-    value: parseEther('1'),
-    feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
-    type: 'cip42',
-  }
   test('should be able to serialize a cip42 transaction', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
-    }
-
-    expect(serializeTransaction(transaction)).toEqual(
-      '0x7cf84682a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
-    )
-  })
-  test('args: feeCurrency', () => {
-    const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
-      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+      ...baseCip42,
     }
 
     expect(serializeTransaction(transaction)).toEqual(
@@ -45,9 +37,9 @@ describe('cip42', () => {
     )
   })
 
-  test('args: Access List', () => {
+  test('args: accessList', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       accessList: [
         {
           address: '0x0000000000000000000000000000000000000000',
@@ -64,42 +56,9 @@ describe('cip42', () => {
     )
   })
 
-  test('args: paying gatewayFee', () => {
-    const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
-      gatewayFeeRecipient: accounts[5].address,
-      gatewayFee: parseEther('0.1'),
-    }
-    expect(serializeTransaction(transaction)).toEqual(
-      '0x7cf86282a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a949965507d1a55bcc2695c58ba16fb37d819b0a4dc88016345785d8a000094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
-    )
-  })
-
-  test('args: nonce', () => {
-    const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
-      nonce: 20,
-    }
-    expect(serializeTransaction(transaction)).toEqual(
-      '0x7cf84682a4ec14847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
-    )
-  })
-
-  test('with signature', async () => {
-    const signed = await signTransaction({
-      privateKey: accounts[0].privateKey,
-      transaction: baseTransaction,
-      serializer: serializeTransaction,
-    })
-
-    expect(signed).toEqual(
-      '0x7cf88982a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c080a01ae1d60446ad5fdd620e1982050dc315ff9a0f61b32bcc2a3cdadd0571a76df7a073aba459b3aef6796d5f2a9979551c29f66586821b5613d5080d00782b07c280',
-    )
-  })
-
   test('args: data', () => {
     const args: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       data: '0x1234',
     }
     const serialized = serializeTransaction(args)
@@ -108,9 +67,107 @@ describe('cip42', () => {
     )
   })
 
-  test('when type is not defined but has cip42 fields', () => {
+  test('args: feeCurrency (absent)', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
+      gatewayFeeRecipient: accounts[0].address,
+      gatewayFee: parseEther('0.1'),
+      feeCurrency: undefined,
+    }
+
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84e82a4ec8084773594008477359400808094f39fd6e51aad88f6f4ce6ab8827279cfffb9226688016345785d8a000094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: gas', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      gas: 69420n,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84982a4ec808477359400847735940083010f2c94765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: gas (absent)', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      gas: undefined,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84682a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: gatewayFee', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      gatewayFeeRecipient: accounts[5].address,
+      gatewayFee: parseEther('0.1'),
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf86282a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a949965507d1a55bcc2695c58ba16fb37d819b0a4dc88016345785d8a000094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: maxFeePerGas (absent)', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      // @ts-expect-error
+      maxFeePerGas: undefined,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84282a4ec808477359400808094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: maxPriorityFeePerGas (absent)', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      // @ts-expect-error
+      maxPriorityFeePerGas: undefined,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84282a4ec808084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: nonce', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      nonce: 20,
+    }
+    expect(serializeTransaction(transaction)).toEqual(
+      '0x7cf84682a4ec14847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: to (absent)', () => {
+    const args: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      to: undefined,
+    }
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual(
+      '0x7cf282a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808080880de0b6b3a764000080c0',
+    )
+  })
+
+  test('args: value (absent)', () => {
+    const args: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      value: undefined,
+    }
+    const serialized = serializeTransaction(args)
+    expect(serialized).toEqual(
+      '0x7cf83e82a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb922668080c0',
+    )
+  })
+
+  test('type is undefined but has cip42 fields', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
       feeCurrency: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73',
       type: undefined,
     }
@@ -121,20 +178,61 @@ describe('cip42', () => {
   })
 })
 
-describe('when param values are not right', () => {
-  const baseTransaction: TransactionSerializableCIP42 = {
-    feeCurrency: '0xd8763cba276a3738e6de85b4b3bf5fded6d6ca73',
-    to: accounts[0].address,
-    chainId: 42220,
-    nonce: 0,
-    maxFeePerGas: parseGwei('2'),
-    maxPriorityFeePerGas: parseGwei('2'),
-    value: parseEther('1'),
-    type: 'cip42',
-  }
+test('signed', async () => {
+  const signed = await signTransaction({
+    privateKey: accounts[0].privateKey,
+    transaction: baseCip42,
+    serializer: serializeTransaction,
+  })
+
+  expect(signed).toEqual(
+    '0x7cf88982a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c080a01ae1d60446ad5fdd620e1982050dc315ff9a0f61b32bcc2a3cdadd0571a76df7a073aba459b3aef6796d5f2a9979551c29f66586821b5613d5080d00782b07c280',
+  )
+})
+
+test('signature', () => {
+  expect(
+    serializeTransaction(
+      baseCip42,
+
+      {
+        r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        v: 28n,
+      },
+    ),
+  ).toEqual(
+    '0x7cf88982a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+  )
+  expect(
+    serializeTransaction(
+      baseCip42,
+
+      {
+        r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        v: 27n,
+      },
+    ),
+  ).toEqual(
+    '0x7cf88982a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+  )
+})
+
+describe('invalid params', () => {
+  test('invalid to', () => {
+    const transaction: TransactionSerializableCIP42 = {
+      ...baseCip42,
+      to: '0xdeadbeef',
+    }
+    expect(() => serializeTransaction(transaction)).toThrowError(
+      InvalidAddressError,
+    )
+  })
+
   test('maxPriorityFeePerGas is higher than maxPriorityFee', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       maxPriorityFeePerGas: parseGwei('5000000000'),
       maxFeePerGas: parseGwei('1'),
     }
@@ -142,9 +240,10 @@ describe('when param values are not right', () => {
       TipAboveFeeCapError,
     )
   })
+
   test('maxFeePerGas is too high', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       maxPriorityFeePerGas: parseGwei('5000000000'),
       maxFeePerGas:
         115792089237316195423570985008687907853269984665640564039457584007913129639938n,
@@ -153,9 +252,10 @@ describe('when param values are not right', () => {
       FeeCapTooHighError,
     )
   })
-  test('when fee Currency is not an address', () => {
+
+  test('feeCurrency is not an address', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       // @ts-expect-error
       feeCurrency: 'CUSD',
     }
@@ -164,9 +264,9 @@ describe('when param values are not right', () => {
     )
   })
 
-  test('when gasPrice is defined', () => {
+  test('gasPrice is defined', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       // @ts-expect-error
       gasPrice: 1,
     }
@@ -175,25 +275,26 @@ describe('when param values are not right', () => {
     )
   })
 
-  test('when only one of the gateWayFee fields is defined', () => {
+  test('only one of the gateWayFee fields is defined', () => {
     const transactionA: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       gatewayFeeRecipient: accounts[7].address,
     }
     expect(() => serializeTransaction(transactionA)).toThrowError(
       '`gatewayFee` and `gatewayFeeRecipient` must be provided together.',
     )
     const transactionB: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       gatewayFee: 1000023434343n,
     }
     expect(() => serializeTransaction(transactionB)).toThrowError(
       '`gatewayFee` and `gatewayFeeRecipient` must be provided together.',
     )
   })
-  test('when the transaction looks like cip42 but does not have values for either feeCurrency or gatewayFee', () => {
+
+  test('transaction looks like cip42 but does not have values for either feeCurrency or gatewayFee', () => {
     const transaction = {
-      ...baseTransaction,
+      ...baseCip42,
       feeCurrency: undefined,
       gatewayFee: undefined,
       gatewayFeeRecipient: undefined,
@@ -202,9 +303,10 @@ describe('when param values are not right', () => {
       'Either `feeCurrency` or `gatewayFeeRecipient` must be provided for CIP-42 transactions.',
     )
   })
-  test('when chainID is invalid', () => {
+
+  test('chainID is invalid', () => {
     const transaction: TransactionSerializableCIP42 = {
-      ...baseTransaction,
+      ...baseCip42,
       chainId: -1,
     }
 
@@ -214,8 +316,8 @@ describe('when param values are not right', () => {
   })
 })
 
-describe('when not cip42', () => {
-  const baseTransaction: TransactionSerializableEIP1559 = {
+describe('not cip42', () => {
+  const transaction: TransactionSerializableEIP1559 = {
     to: accounts[0].address,
     chainId: 1,
     nonce: 0,
@@ -223,8 +325,9 @@ describe('when not cip42', () => {
     maxPriorityFeePerGas: parseGwei('2'),
     value: parseEther('1'),
   }
+
   test('it calls the standard serializeTransaction', () => {
-    const serialized = serializeTransaction({ ...baseTransaction })
+    const serialized = serializeTransaction(transaction)
     expect(serialized).toEqual(
       '0x02ed0180847735940084773594008094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0',
     )

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -1,0 +1,158 @@
+import type {
+  TransactionSerializable,
+  TransactionSerializableGeneric,
+} from '../../types/transaction.js'
+
+import {
+  type Address,
+  BaseError,
+  FeeCapTooHighError,
+  InvalidAddressError,
+  InvalidChainIdError,
+  type SerializeTransactionFn,
+  type Signature,
+  TipAboveFeeCapError,
+  concatHex,
+  isAddress,
+  serializeAccessList,
+  serializeTransaction as viemSerializeTransaction,
+  toHex,
+  toRlp,
+  trim,
+} from '../../index.js'
+
+export type TransactionSerializableCIP42 = TransactionSerializableGeneric & {
+  feeCurrency?: Address
+  gatewayFeeRecipient?: Address
+  gatewayFee?: bigint
+  chainId: number
+  type: 'cip42'
+}
+
+export type TransactionSerializableIncludingCIP42 =
+  | TransactionSerializableCIP42
+  | TransactionSerializable
+
+type SerializedCIP42TransactionReturnType = `0x7c${string}`
+
+export const serializeTransaction: SerializeTransactionFn<TransactionSerializableIncludingCIP42> =
+  function (tx, signature?: Signature) {
+    // handle celo's feeCurrency Transactions
+    if (couldBeCIP42(tx)) {
+      return serializeTransactionCIP42(
+        tx as TransactionSerializableCIP42,
+        signature,
+      )
+    }
+    // handle rest of tx types
+    return viemSerializeTransaction(tx as TransactionSerializable, signature)
+  }
+
+// There shall be a typed transaction with the code 0x7c that has the following format:
+// 0x7c || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, feecurrency, gatewayFeeRecipient, gatewayfee, destination, amount, data, access_list, signature_y_parity, signature_r, signature_s]).
+// This will be in addition to the type 0x02 transaction as specified in EIP-1559.
+function serializeTransactionCIP42(
+  transaction: TransactionSerializableCIP42,
+  signature?: Signature,
+): SerializedCIP42TransactionReturnType {
+  assertTransactionCIP42(transaction)
+  const {
+    chainId,
+    gas,
+    nonce,
+    to,
+    value,
+    maxFeePerGas,
+    maxPriorityFeePerGas,
+    accessList,
+    feeCurrency,
+    gatewayFeeRecipient,
+    gatewayFee,
+    data,
+  } = transaction
+
+  const serializedTransaction = [
+    toHex(chainId),
+    nonce ? toHex(nonce) : '0x',
+    maxPriorityFeePerGas ? toHex(maxPriorityFeePerGas) : '0x',
+    maxFeePerGas ? toHex(maxFeePerGas) : '0x',
+    gas ? toHex(gas) : '0x',
+    feeCurrency ?? '0x',
+    gatewayFeeRecipient ?? '0x',
+    gatewayFee ? toHex(gatewayFee) : '0x',
+    to ?? '0x',
+    value ? toHex(value) : '0x',
+    data ?? '0x',
+    serializeAccessList(accessList),
+  ]
+
+  if (signature) {
+    serializedTransaction.push(
+      signature.v === 27n ? '0x' : toHex(1), // yParity
+      trim(signature.r),
+      trim(signature.s),
+    )
+  }
+
+  return concatHex([
+    '0x7c',
+    toRlp(serializedTransaction),
+  ]) as SerializedCIP42TransactionReturnType
+}
+
+// process as CIP42 if any of these fields are present realistically gatewayfee is not used but is part of spec
+function couldBeCIP42(tx: TransactionSerializableIncludingCIP42) {
+  const maybeCIP42 = tx as TransactionSerializableCIP42
+  if (
+    tx.type === 'cip42' ||
+    maybeCIP42.feeCurrency ||
+    maybeCIP42.gatewayFee ||
+    maybeCIP42.gatewayFeeRecipient
+  ) {
+    return true
+  }
+  return false
+}
+
+function assertTransactionCIP42(transaction: TransactionSerializableCIP42) {
+  const {
+    chainId,
+    maxPriorityFeePerGas,
+    gasPrice,
+    maxFeePerGas,
+    to,
+    feeCurrency,
+    gatewayFee,
+    gatewayFeeRecipient,
+  } = transaction
+  // TODO  should this throw for any chain id not one of celo's chains or is that to restrictive?
+  if (chainId <= 0) throw new InvalidChainIdError({ chainId })
+  if (to && !isAddress(to)) throw new InvalidAddressError({ address: to })
+  if (gasPrice)
+    throw new BaseError(
+      '`gasPrice` is not a valid CIP-42 Transaction attribute.',
+    )
+  if (maxFeePerGas && maxFeePerGas > 2n ** 256n - 1n)
+    throw new FeeCapTooHighError({ maxFeePerGas })
+  if (
+    maxPriorityFeePerGas &&
+    maxFeePerGas &&
+    maxPriorityFeePerGas > maxFeePerGas
+  )
+    throw new TipAboveFeeCapError({ maxFeePerGas, maxPriorityFeePerGas })
+
+  if (
+    (gatewayFee && !gatewayFeeRecipient) ||
+    (gatewayFeeRecipient && !gatewayFee)
+  ) {
+    throw new BaseError(
+      '`gatewayFee` and `gatewayFeeRecipient` must be provided together.',
+    )
+  }
+
+  if (feeCurrency && !feeCurrency?.startsWith('0x')) {
+    throw new BaseError(
+      '`feeCurrency` MUST be a token address for CIP-42 transactions.',
+    )
+  }
+}

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -1,12 +1,14 @@
 import type {
+  AccessList,
   TransactionSerializable,
-  TransactionSerializableGeneric,
+  TransactionSerializableBase,
 } from '../../types/transaction.js'
 
 import {
   type Address,
   BaseError,
   FeeCapTooHighError,
+  type FeeValuesEIP1559,
   InvalidAddressError,
   InvalidChainIdError,
   type SerializeTransactionFn,
@@ -21,13 +23,19 @@ import {
   trim,
 } from '../../index.js'
 
-export type TransactionSerializableCIP42 = TransactionSerializableGeneric & {
-  feeCurrency?: Address
-  gatewayFeeRecipient?: Address
-  gatewayFee?: bigint
-  chainId: number
-  type: 'cip42'
-}
+export type TransactionSerializableCIP42<
+  TQuantity = bigint,
+  TIndex = number,
+> = TransactionSerializableBase<TQuantity, TIndex> &
+  FeeValuesEIP1559<TQuantity> & {
+    accessList?: AccessList
+    gasPrice?: never
+    feeCurrency?: Address
+    gatewayFeeRecipient?: Address
+    gatewayFee?: TQuantity
+    chainId: number
+    type?: 'cip42'
+  }
 
 export type TransactionSerializableIncludingCIP42 =
   | TransactionSerializableCIP42

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -129,10 +129,10 @@ function serializeTransactionCIP42(
 function couldBeCIP42(tx: TransactionSerializableCelo) {
   const maybeCIP42 = tx as TransactionSerializableCIP42
   if (
-    maybeCIP42.maxFeePerGas &&
-    maybeCIP42.maxPriorityFeePerGas &&
+    'maxFeePerGas' in maybeCIP42 &&
+    'maxPriorityFeePerGas' in maybeCIP42 &&
     ('feeCurrency' in maybeCIP42 ||
-      'gateWayFee' in maybeCIP42 ||
+      'gatewayFee' in maybeCIP42 ||
       'gatewayFeeRecipient' in maybeCIP42)
   )
     return true

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -131,9 +131,9 @@ function couldBeCIP42(tx: TransactionSerializableCelo) {
   if (
     maybeCIP42.maxFeePerGas &&
     maybeCIP42.maxPriorityFeePerGas &&
-    (maybeCIP42.feeCurrency ||
-      maybeCIP42.gatewayFee ||
-      maybeCIP42.gatewayFeeRecipient)
+    ('feeCurrency' in maybeCIP42 ||
+      'gateWayFee' in maybeCIP42 ||
+      'gatewayFeeRecipient' in maybeCIP42)
   )
     return true
   return false

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -140,7 +140,10 @@ function assertTransactionCIP42(transaction: TransactionSerializableCIP42) {
     throw new BaseError(
       '`gasPrice` is not a valid CIP-42 Transaction attribute.',
     )
-  if (maxFeePerGas && maxFeePerGas > 2n ** 256n - 1n)
+  // maxFeePerGas must be less than 2^256 - 1: however writing like that caused exceptions to be raised
+  const MAX_MAX_FEE_PER_GAS =
+    115792089237316195423570985008687907853269984665640564039457584007913129639935n
+  if (maxFeePerGas && maxFeePerGas > MAX_MAX_FEE_PER_GAS)
     throw new FeeCapTooHighError({ maxFeePerGas })
   if (
     maxPriorityFeePerGas &&

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -163,4 +163,10 @@ function assertTransactionCIP42(transaction: TransactionSerializableCIP42) {
       '`feeCurrency` MUST be a token address for CIP-42 transactions.',
     )
   }
+
+  if (!feeCurrency && !gatewayFeeRecipient) {
+    throw new BaseError(
+      'Either `feeCurrency` or `gatewayFeeRecipient` must be provided for CIP-42 transactions.',
+    )
+  }
 }

--- a/src/chains/serializers/celo.ts
+++ b/src/chains/serializers/celo.ts
@@ -108,14 +108,15 @@ function serializeTransactionCIP42(
   ]) as SerializedCIP42TransactionReturnType
 }
 
-// process as CIP42 if any of these fields are present realistically gatewayfee is not used but is part of spec
+// process as CIP42 if any of these fields are present. realistically gatewayfee is not used but is part of spec
 function couldBeCIP42(tx: TransactionSerializableIncludingCIP42) {
   const maybeCIP42 = tx as TransactionSerializableCIP42
   if (
-    tx.type === 'cip42' ||
-    maybeCIP42.feeCurrency ||
-    maybeCIP42.gatewayFee ||
-    maybeCIP42.gatewayFeeRecipient
+    maybeCIP42.maxFeePerGas &&
+    maybeCIP42.maxPriorityFeePerGas &&
+    (maybeCIP42.feeCurrency ||
+      maybeCIP42.gatewayFee ||
+      maybeCIP42.gatewayFeeRecipient)
   ) {
     return true
   }
@@ -133,7 +134,6 @@ function assertTransactionCIP42(transaction: TransactionSerializableCIP42) {
     gatewayFee,
     gatewayFeeRecipient,
   } = transaction
-  // TODO  should this throw for any chain id not one of celo's chains or is that to restrictive?
   if (chainId <= 0) throw new InvalidChainIdError({ chainId })
   if (to && !isAddress(to)) throw new InvalidAddressError({ address: to })
   if (gasPrice)


### PR DESCRIPTION
followup from #691

A custom Serializer supporting Celo CIP-42 (fee currency) Transactions.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added serializer for Celo CIP-42 transactions.
- Imported `celoSerializers` in `src/chains/index.ts`.
- Added `serializeTransaction` function in `src/chains/serializers/celo.ts`.
- Added utility functions and types related to CIP-42 transactions in `src/chains/serializers/celo.ts`.
- Added tests for CIP-42 transaction serialization in `src/chains/serializers/celo.test.ts`.

> The following files were skipped due to too many changes: `src/chains/serializers/celo.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->