### PR TITLE
Fix EIP712Domain to support empty string name

### DIFF
--- a/.changeset/chilly-dots-sparkle.md
+++ b/.changeset/chilly-dots-sparkle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added support for empty string in EIP712Domain name field.

--- a/.changeset/silent-boxes-walk.md
+++ b/.changeset/silent-boxes-walk.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where empty `name` on `EIP712Domain` would generate the wrong signature.

--- a/src/actions/wallet/signTypedData.test.ts
+++ b/src/actions/wallet/signTypedData.test.ts
@@ -203,6 +203,30 @@ describe('args: domain: empty', () => {
 })
 
 describe('args: domain: chainId', () => {
+  test('zeroish chainId', async () => {
+    const signature = await signTypedData(walletClient, {
+      ...typedData.complex,
+      domain: {
+        chainId: 0,
+      },
+      account: jsonRpcAccount,
+      primaryType: 'Mail',
+    })
+    expect(signature).toEqual(
+      '0x0ab57c83d3eebb0015ea5382d70aae9a5724a35fb9904f52c505bf783c10364639c126471a542ac6a1b5dcd8f1dc2dc5b1ce346f063ff6104750d53029a7c8cb1c',
+    )
+    expect(
+      await recoverTypedDataAddress({
+        ...typedData.complex,
+        domain: {
+          chainId: 0,
+        },
+        primaryType: 'Mail',
+        signature,
+      }),
+    ).toEqual(getAddress(jsonRpcAccount))
+  })
+
   test('json-rpc account', async () => {
     const signature = await signTypedData(walletClient, {
       ...typedData.complex,

--- a/src/actions/wallet/signTypedData.test.ts
+++ b/src/actions/wallet/signTypedData.test.ts
@@ -253,6 +253,30 @@ describe('args: domain: chainId', () => {
 })
 
 describe('args: domain: name', () => {
+  test('empty name', async () => {
+    const signature = await signTypedData(walletClient, {
+      ...typedData.complex,
+      domain: {
+        name: '',
+      },
+      account: jsonRpcAccount,
+      primaryType: 'Mail',
+    })
+    expect(signature).toEqual(
+      '0x270eb0f0209a0d43d328327dad9b04bf1ec67dc1fca3fb3235385b7b4a64410621fea5d2d64d3ef41266b17fffda854bc03083ba7ce8e9b740d643ac9dc98e911c',
+    )
+    expect(
+      await recoverTypedDataAddress({
+        ...typedData.complex,
+        domain: {
+          name: '',
+        },
+        primaryType: 'Mail',
+        signature,
+      }),
+    ).toEqual(getAddress(jsonRpcAccount))
+  })
+
   test('json-rpc account', async () => {
     const signature = await signTypedData(walletClient, {
       ...typedData.complex,

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -143,7 +143,7 @@ export async function signTypedData<
 
   const types = {
     EIP712Domain: [
-      domain?.name && { name: 'name', type: 'string' },
+      domain?.name != null && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
       domain?.chainId && { name: 'chainId', type: 'uint256' },
       domain?.verifyingContract && {

--- a/src/actions/wallet/signTypedData.ts
+++ b/src/actions/wallet/signTypedData.ts
@@ -143,9 +143,12 @@ export async function signTypedData<
 
   const types = {
     EIP712Domain: [
-      domain?.name != null && { name: 'name', type: 'string' },
+      typeof domain?.name === 'string' && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
-      domain?.chainId && { name: 'chainId', type: 'uint256' },
+      typeof domain?.chainId === 'number' && {
+        name: 'chainId',
+        type: 'uint256',
+      },
       domain?.verifyingContract && {
         name: 'verifyingContract',
         type: 'address',

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -59,15 +59,6 @@ test('domain: empty name', () => {
   ).toMatchInlineSnapshot(
     '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
   )
-  expect(
-    hashTypedData({
-      ...typedData.complex,
-      domain: { name: '' },
-      primaryType: 'Mail',
-    }),
-  ).toMatchInlineSnapshot(
-    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
-  )
 })
 
 test('minimal valid typed message', function () {

--- a/src/utils/signature/hashTypedData.test.ts
+++ b/src/utils/signature/hashTypedData.test.ts
@@ -49,6 +49,27 @@ test('no domain', () => {
   )
 })
 
+test('domain: empty name', () => {
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { name: '' },
+      primaryType: 'Mail',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
+  )
+  expect(
+    hashTypedData({
+      ...typedData.complex,
+      domain: { name: '' },
+      primaryType: 'Mail',
+    }),
+  ).toMatchInlineSnapshot(
+    '"0xc3f4f9ebd774352940f60aebbc83fcee20d0b17eb42bd1b20c91a748001ecb53"',
+  )
+})
+
 test('minimal valid typed message', function () {
   const hash = hashTypedData({
     types: {

--- a/src/utils/signature/hashTypedData.ts
+++ b/src/utils/signature/hashTypedData.ts
@@ -34,7 +34,7 @@ export function hashTypedData<
   const domain: TypedDataDomain = typeof domain_ === 'undefined' ? {} : domain_
   const types = {
     EIP712Domain: [
-      domain?.name && { name: 'name', type: 'string' },
+      domain?.name != null && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
       domain?.chainId && { name: 'chainId', type: 'uint256' },
       domain?.verifyingContract && {

--- a/src/utils/signature/hashTypedData.ts
+++ b/src/utils/signature/hashTypedData.ts
@@ -34,9 +34,12 @@ export function hashTypedData<
   const domain: TypedDataDomain = typeof domain_ === 'undefined' ? {} : domain_
   const types = {
     EIP712Domain: [
-      domain?.name != null && { name: 'name', type: 'string' },
+      typeof domain?.name === 'string' && { name: 'name', type: 'string' },
       domain?.version && { name: 'version', type: 'string' },
-      domain?.chainId && { name: 'chainId', type: 'uint256' },
+      typeof domain?.chainId === 'number' && {
+        name: 'chainId',
+        type: 'uint256',
+      },
       domain?.verifyingContract && {
         name: 'verifyingContract',
         type: 'address',


### PR DESCRIPTION
Dupe of #754

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for empty strings in the `name` field of `EIP712Domain` and fixes a bug where empty `name` would generate the wrong signature.

### Detailed summary
- Added support for empty string in `EIP712Domain` name field.
- Fixed an issue where empty `name` on `EIP712Domain` would generate the wrong signature.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->