### PR TITLE
add more size-limit checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,16 +207,40 @@
       "limit": "60 kB"
     },
     {
+      "name": "viem",
+      "path": "./dist/esm/index.js",
+      "limit": "50 kB",
+      "import": "*"
+    },
+    {
+      "name": "viem/chains",
+      "path": "./dist/esm/chains/index.js",
+      "limit": "11 kB",
+      "import": "*"
+    },
+    {
+      "name": "viem/ens",
+      "path": "./dist/esm/ens.js",
+      "limit": "45 kB",
+      "import": "*"
+    },
+    {
       "name": "viem (tree-shaking check)",
       "path": "./dist/esm/index.js",
       "limit": "1.5 kB",
       "import": "{ defineBlock }"
     },
     {
-      "name": "viem/chains",
-      "path": "./dist/esm/chains.js",
-      "limit": "1100 B",
+      "name": "viem/chains (tree-shaking check)",
+      "path": "./dist/esm/chains/index.js",
+      "limit": "900 B",
       "import": "{ mainnet }"
+    },
+    {
+      "name": "viem/ens (tree-shaking check)",
+      "path": "./dist/esm/ens.js",
+      "limit": "18 kB",
+      "import": "{ getEnsAvatar }"
     }
   ],
   "simple-git-hooks": {


### PR DESCRIPTION
- add some new checks
- fix `viem/chains`
- tweak limits

is it worth adding a size-limit check to the CI pipeline?

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new modules to the project and updates the size limits for existing ones.

### Detailed summary:
- Added `viem`, `viem/chains`, and `viem/ens` modules
- Updated size limits for `viem`, `viem/chains`, and `viem/ens`
- Added tree-shaking checks for `viem`, `viem/chains`, and `viem/ens`
- Removed `viem/chains.js` file path and replaced it with `viem/chains/index.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->