### PR TITLE
Support sending simulate calls in batch via Multicall

### DIFF
--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -168,7 +168,6 @@ test('args: dataSuffix', async () => {
   })
   expect(spy).toHaveBeenCalledWith(publicClient, {
     account: accounts[0].address,
-    batch: false,
     data: '0x1249c58b12345678',
     to: wagmiContractConfig.address,
   })

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -127,7 +127,6 @@ export async function simulateContract<
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
   try {
     const { data } = await call(client, {
-      batch: false,
       data: `${calldata}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
       to: address,
       ...callRequest,


### PR DESCRIPTION
Fixes #766 by simply removing the `batch: false` hardcode in the `call`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the `batch` property from a function call in `simulateContract.ts` and updates the corresponding test in `simulateContract.test.ts`.

### Detailed summary
- Removed `batch` property from function call in `simulateContract.ts`
- Updated corresponding test in `simulateContract.test.ts` to remove `batch` property and add `data` property with a specific value

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->