### PR TITLE
fix: export decodeDeployData

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,6 +126,7 @@ test('exports actions', () => {
       "createWalletClient": [Function],
       "custom": [Function],
       "decodeAbiParameters": [Function],
+      "decodeDeployData": [Function],
       "decodeErrorResult": [Function],
       "decodeEventLog": [Function],
       "decodeFunctionData": [Function],

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,6 +518,11 @@ export {
   decodeAbiParameters,
 } from './utils/abi/decodeAbiParameters.js'
 export {
+  type DecodeDeployDataParameters,
+  type DecodeDeployDataReturnType,
+  decodeDeployData,
+} from './utils/abi/decodeDeployData.js'
+export {
   type DecodeErrorResultParameters,
   type DecodeErrorResultReturnType,
   decodeErrorResult,


### PR DESCRIPTION
Seems like this export just got missed.

The docs (https://viem.sh/docs/contract/decodeDeployData.html) are also wrong, they're showing how to use `decodeFunctionData` but I couldn't figure out how to fix them. Sorry about that.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `decodeDeployData` to the codebase. 

### Detailed summary
- Added `decodeDeployData` function to `src/index.ts`
- Exported `DecodeDeployDataParameters` and `DecodeDeployDataReturnType` types from `decodeDeployData.js`
- Imported `decodeAbiParameters` from `decodeAbiParameters.js` in `src/index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->