### PR TITLE
docs: Correct example and link for Prettify type

### DIFF
--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -176,9 +176,9 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 /**
  * @description Combines members of an intersection into a readable type.
  *
- * @link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg
+ * {@link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg}
  * @example
- * Prettify<{ a: string } | { b: string } | { c: number, d: bigint }>
+ * Prettify<{ a: string } & { b: string } & { c: number, d: bigint }>
  * => { a: string, b: string, c: number, d: bigint }
  */
 export type Prettify<T> = {

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -176,7 +176,7 @@ export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 /**
  * @description Combines members of an intersection into a readable type.
  *
- * {@link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg}
+ * @see {@link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg}
  * @example
  * Prettify<{ a: string } & { b: string } & { c: number, d: bigint }>
  * => { a: string, b: string, c: number, d: bigint }


### PR DESCRIPTION
Correct example and link for [Prettify](https://github.com/wagmi-dev/viem/blob/018ec87e5aa39f973ae03e04ba81284a44c39bc6/src/types/utils.ts#L184) utility type

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates a JSDoc comment in `utils.ts` to fix a broken link and improve readability. 

### Detailed summary
- Updates a broken link in the JSDoc comment for the `Prettify` type in `utils.ts`
- Changes the union type to an intersection type in the JSDoc example for `Prettify` to improve readability

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->