### PR TITLE
feat: add `withJsonRpcAccount` 

### DIFF
--- a/.changeset/fast-buttons-share.md
+++ b/.changeset/fast-buttons-share.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `withJsonRpcAccount`

--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -204,6 +204,10 @@ export const sidebar: DefaultTheme.Sidebar = {
               text: 'requestAddresses',
               link: '/docs/actions/wallet/requestAddresses',
             },
+            {
+              text: 'withJsonRpcAccount',
+              link: '/docs/actions/wallet/withJsonRpcAccount',
+            },
           ],
         },
         {

--- a/site/docs/accounts/jsonRpc.md
+++ b/site/docs/accounts/jsonRpc.md
@@ -41,7 +41,7 @@ If we want to dynamically retrieve the Accounts from the Client instead, we can 
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
-const client = createWalletClient({
+const client = await createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
 }).withJsonRpcAccount({ method: 'request' }) // [!code ++]

--- a/site/docs/accounts/jsonRpc.md
+++ b/site/docs/accounts/jsonRpc.md
@@ -34,3 +34,17 @@ const client = createWalletClient({
   transport: custom(window.ethereum)
 })
 ```
+
+If we want to dynamically retrieve the Accounts from the Client instead, we can use the `withJsonRpcAccount` function. This will make a call to `eth_requestAccounts` and set the first Account as the Client's Account:
+
+```ts
+import { createWalletClient, custom } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const client = createWalletClient({
+  chain: mainnet,
+  transport: custom(window.ethereum)
+}).withJsonRpcAccount({ method: 'request' }) // [!code ++]
+```
+
+> [See `withJsonRpcAccount`](/docs/actions/wallet/withJsonRpcAccount).

--- a/site/docs/actions/wallet/sendTransaction.md
+++ b/site/docs/actions/wallet/sendTransaction.md
@@ -67,18 +67,12 @@ const hash = await walletClient.sendTransaction({ // [!code focus:99]
 // '0x...'
 ```
 
-```ts {4-6,9} [config.ts (JSON-RPC Account)]
+```ts {3-6} [config.ts (JSON-RPC Account)]
 import { createWalletClient, custom } from 'viem'
 
-// Retrieve Account from an EIP-1193 Provider.
-const [account] = await window.ethereum.request({ 
-  method: 'eth_requestAccounts' 
-})
-
-export const walletClient = createWalletClient({
-  account,
+export const walletClient = await createWalletClient({
   transport: custom(window.ethereum)
-})
+}).withJsonRpcAccount({ method: 'request' })
 ```
 
 ```ts {5} [config.ts (Local Account)]

--- a/site/docs/actions/wallet/signMessage.md
+++ b/site/docs/actions/wallet/signMessage.md
@@ -17,6 +17,7 @@ head:
 Calculates an Ethereum-specific signature in [EIP-191 format](https://eips.ethereum.org/EIPS/eip-191): `keccak256("\x19Ethereum Signed Message:\n" + len(message) + message))`.
 
 With the calculated signature, you can:
+
 - use [`verifyMessage`](/docs/utilities/verifyMessage) to verify the signature,
 - use [`recoverMessageAddress`](/docs/utilities/recoverMessageAddress) to recover the signing address from a signature.
 
@@ -76,18 +77,12 @@ const signature = await walletClient.signMessage({ // [!code focus:99]
 // "0xa461f509887bd19e312c0c58467ce8ff8e300d3c1a90b608a760c5b80318eaf15fe57c96f9175d6cd4daad4663763baa7e78836e067d0163e9a2ccf2ff753f5b1b"
 ```
 
-```ts {4-6,9} [config.ts (JSON-RPC Account)]
+```ts {3-5} [config.ts (JSON-RPC Account)]
 import { createWalletClient, custom } from 'viem'
 
-// Retrieve Account from an EIP-1193 Provider.
-const [account] = await window.ethereum.request({ 
-  method: 'eth_requestAccounts' 
-})
-
-export const walletClient = createWalletClient({
-  account,
+export const walletClient = await createWalletClient({
   transport: custom(window.ethereum)
-})
+}).withJsonRpcAccount({ method: 'request' })
 ```
 
 ```ts {5} [config.ts (Local Account)]

--- a/site/docs/actions/wallet/signTypedData.md
+++ b/site/docs/actions/wallet/signTypedData.md
@@ -137,18 +137,12 @@ export const types = {
 } as const
 ```
 
-```ts {4-6,9} [config.ts (JSON-RPC Account)]
+```ts {3-5} [config.ts (JSON-RPC Account)]
 import { createWalletClient, custom } from 'viem'
 
-// Retrieve Account from an EIP-1193 Provider.
-const [account] = await window.ethereum.request({ 
-  method: 'eth_requestAccounts' 
-})
-
-export const walletClient = createWalletClient({
-  account,
+export const walletClient = await createWalletClient({
   transport: custom(window.ethereum)
-})
+}).withJsonRpcAccount({ method: 'request' })
 ```
 
 ```ts {5} [config.ts (Local Account)]

--- a/site/docs/actions/wallet/withJsonRpcAccount.md
+++ b/site/docs/actions/wallet/withJsonRpcAccount.md
@@ -1,0 +1,52 @@
+---
+head:
+  - - meta
+    - property: og:title
+      content: withJsonRpcAccount
+  - - meta
+    - name: description
+      content: Returns a Client with an attached JSON-RPC Account.
+  - - meta
+    - property: og:description
+      content: Returns a Client with an attached JSON-RPC Account.
+
+---
+
+# withJsonRpcAccount
+
+Returns a Client with an attached JSON-RPC Account asynchronously retrieved via `eth_accounts` or `eth_requestAccounts`.
+
+## Usage
+
+```ts {7}
+import { createWalletClient, http } from 'viem'
+import { mainnnet } from 'viem/chains'
+
+const client = await createWalletClient({ 
+  chain: mainnet,
+  transport: http()
+}).withJsonRpcAccount({ method: 'request' })
+```
+
+## Returns
+
+Client with an attached `account` (JSON-RPC Account).
+
+## Parameters
+
+### method (optional)
+
+- **Type:** `"get" | "request"`
+- **Default:** `"get"`
+
+RPC Method to retrieve the Accounts from the Wallet.
+
+- `"get"`: `eth_accounts`
+- `"request"`: `eth_requestAccounts`
+
+### index (optional)
+
+- **Type:** `number`
+- **Default:** `0`
+
+Index of the Account to use from the retrieved Accounts.

--- a/site/docs/clients/test.md
+++ b/site/docs/clients/test.md
@@ -66,6 +66,48 @@ const hash = await client.sendTransaction({ ... }) // Wallet Action
 const mine = await client.mine({ blocks: 1 }) // Test Action
 ```
 
+### Attaching an Account
+
+#### JSON-RPC Account
+
+You can attach a [JSON-RPC Account](/docs/accounts/jsonRpc) to your Test Client by using the `withJsonRpcAccount` function:
+
+```ts
+import { createTestClient, http, publicActions, walletActions } from 'viem'
+import { foundry } from 'viem/chains'
+
+const client = await createTestClient({ // [!code focus:8]
+  chain: foundry,
+  mode: 'anvil',
+  transport: http(), 
+})
+  .extend(publicActions)
+  .extend(walletActions)
+  .withJsonRpcAccount() // [!code ++]
+
+const hash = await client.sendTransaction({ ... })
+```
+
+#### Local Account
+
+You can attach a Local Account by passing it to the `account` parameter on the Test Client:
+
+```ts
+import { createTestClient, http, publicActions, walletActions } from 'viem'
+import { foundry } from 'viem/chains'
+
+const client = createTestClient({ // [!code focus:8]
+  account: privateKeyToAccount('0x...'), // [!code ++]
+  chain: foundry,
+  mode: 'anvil',
+  transport: http(), 
+})
+  .extend(publicActions)
+  .extend(walletActions)
+
+const hash = await client.sendTransaction({ ... })
+```
+
 ## Parameters
 
 ### mode

--- a/site/docs/clients/wallet.md
+++ b/site/docs/clients/wallet.md
@@ -62,8 +62,8 @@ const client = createWalletClient({
   transport: custom(window.ethereum)
 })
 
-const [address] = await client.getAddresses() // [!code focus:10]
-// or: const [address] = await client.requestAddresses() // [!code focus:10]
+const [address] = await client.requestAddresses() // [!code focus:10]
+// or: const [address] = await client.getAddresses() // [!code focus:10]
 ```
 
 > Note: Some Wallets (like MetaMask) may require you to request access to Account addresses via [`client.requestAddresses`](/docs/actions/wallet/requestAddresses) first.
@@ -81,7 +81,7 @@ const client = createWalletClient({
   transport: custom(window.ethereum)
 })
 
-const [address] = await client.getAddresses()
+const [address] = await client.requestAddresses()
 
 const hash = await client.sendTransaction({ // [!code focus:10]
   account: address,
@@ -92,19 +92,16 @@ const hash = await client.sendTransaction({ // [!code focus:10]
 
 #### Optional: Hoist the Account
 
-If you do not wish to pass an account around to every Action that requires an `account`, you can also hoist the account into the Wallet Client.
+If you do not wish to pass an Account around to every Action that requires an `account`, you can also hoist the JSON RPC Account into the Wallet Client using `withJsonRpcAccount`. This function will asynchronously retrieve the Wallet address from an internal `eth_requestAccounts` call to the Wallet.
 
 ```ts
 import { createWalletClient, http } from 'viem'
 import { mainnnet } from 'viem/chains'
 
-const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
-
-const client = createWalletClient({ // [!code focus:99]
-  account, // [!code ++]
+const client = await createWalletClient({ // [!code focus:99]
   chain: mainnet,
   transport: http()
-})
+}).withJsonRpcAccount({ method: 'request' }) // [!code ++]
 
 const hash = await client.sendTransaction({
   account, // [!code --]
@@ -112,6 +109,8 @@ const hash = await client.sendTransaction({
   value: parseEther('0.001')
 })
 ```
+
+> [See `withJsonRpcAccount`](/docs/actions/wallet/withJsonRpcAccount).
 
 ## Local Accounts (Private Key, Mnemonic, etc)
 

--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -19,7 +19,7 @@ You may notice some of the APIs in viem are a little more verbose than Ethers. W
 
 ## Provider → Client
 
-### getDefaultProvider 
+### getDefaultProvider
 
 #### Ethers
 
@@ -65,7 +65,6 @@ const provider = new providers.JsonRpcProvider('https://rpc.ankr.com/fantom/​'
   id: 250
 })
 ```
-
 
 #### viem
 
@@ -311,17 +310,14 @@ signer.sendTransaction({ ... })
 
 #### viem
 
-```ts {4,7}
+```ts {7}
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
-const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
-
-const client = createWalletClient({
-  account,
+const client = await createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
-})
+}).withJsonRpcAccount()
 
 client.sendTransaction({ ... })
 ```
@@ -417,17 +413,14 @@ signer.signMessage(...)
 
 #### viem
 
-```ts {12-13}
+```ts {9-10}
 import { createWalletClient, custom } from 'viem'
 import { mainnet } from 'viem/chains'
 
-const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
-
-const client = createWalletClient({
-  account,
+const client = await createWalletClient({
   chain: mainnet,
   transport: custom(window.ethereum)
-})
+}).withJsonRpcAccount()
 
 client.sendTransaction({ ... })
 client.signMessage({ ... })
@@ -1711,7 +1704,7 @@ keccak256(toBytes('hello world'))
 
 ### encodeBase64/decodeBase64
 
-viem does not provide Base64 encoding utilities. 
+viem does not provide Base64 encoding utilities.
 
 You can use browser native [`atob`](https://developer.mozilla.org/en-US/docs/Web/API/atob) and [`btoa`](https://developer.mozilla.org/en-US/docs/Web/API/btoa) instead.
 

--- a/src/actions/wallet/withJsonRpcAccount.test.ts
+++ b/src/actions/wallet/withJsonRpcAccount.test.ts
@@ -1,0 +1,96 @@
+import { accounts, localHttpUrl } from '../../_test/constants.js'
+import { createWalletClient } from '../../clients/createWalletClient.js'
+import { http } from '../../clients/transports/http.js'
+import { withJsonRpcAccount } from './withJsonRpcAccount.js'
+import { expect, test } from 'vitest'
+
+test('getAddresses', async () => {
+  const walletClient = createWalletClient({
+    transport: http(localHttpUrl),
+  })
+  const {
+    uid: _1,
+    transport: _2,
+    ...client_1
+  } = await withJsonRpcAccount(walletClient)
+  expect(client_1).toMatchInlineSnapshot(`
+    {
+      "account": {
+        "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "type": "json-rpc",
+      },
+      "addChain": [Function],
+      "batch": undefined,
+      "chain": undefined,
+      "deployContract": [Function],
+      "extend": [Function],
+      "getAddresses": [Function],
+      "getChainId": [Function],
+      "getPermissions": [Function],
+      "key": "wallet",
+      "name": "Wallet Client",
+      "pollingInterval": 4000,
+      "request": [Function],
+      "requestAddresses": [Function],
+      "requestPermissions": [Function],
+      "sendTransaction": [Function],
+      "signMessage": [Function],
+      "signTypedData": [Function],
+      "switchChain": [Function],
+      "type": "walletClient",
+      "watchAsset": [Function],
+      "withJsonRpcAccount": [Function],
+      "writeContract": [Function],
+    }
+  `)
+
+  const client_2 = await withJsonRpcAccount(walletClient, { index: 2 })
+  expect(client_2.account.address.toLowerCase()).toEqual(accounts[2].address)
+})
+
+test('requestAddresses', async () => {
+  const walletClient = createWalletClient({
+    transport: http(localHttpUrl),
+  })
+  const {
+    uid: _1,
+    transport: _2,
+    ...client_1
+  } = await withJsonRpcAccount(walletClient, { method: 'request' })
+  expect(client_1).toMatchInlineSnapshot(`
+    {
+      "account": {
+        "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "type": "json-rpc",
+      },
+      "addChain": [Function],
+      "batch": undefined,
+      "chain": undefined,
+      "deployContract": [Function],
+      "extend": [Function],
+      "getAddresses": [Function],
+      "getChainId": [Function],
+      "getPermissions": [Function],
+      "key": "wallet",
+      "name": "Wallet Client",
+      "pollingInterval": 4000,
+      "request": [Function],
+      "requestAddresses": [Function],
+      "requestPermissions": [Function],
+      "sendTransaction": [Function],
+      "signMessage": [Function],
+      "signTypedData": [Function],
+      "switchChain": [Function],
+      "type": "walletClient",
+      "watchAsset": [Function],
+      "withJsonRpcAccount": [Function],
+      "writeContract": [Function],
+    }
+  `)
+
+  const client_2 = await withJsonRpcAccount(walletClient, {
+    index: 2,
+    method: 'request',
+  })
+  expect(client_2.account.address.toLowerCase()).toEqual(accounts[2].address)
+})

--- a/src/actions/wallet/withJsonRpcAccount.ts
+++ b/src/actions/wallet/withJsonRpcAccount.ts
@@ -1,0 +1,55 @@
+import type { Account } from '../../accounts/types.js'
+import type { Client } from '../../clients/createClient.js'
+import type { Transport } from '../../clients/transports/createTransport.js'
+import type { Chain } from '../../types/chain.js'
+import { parseAccount } from '../../utils/accounts.js'
+import { getAddresses } from './getAddresses.js'
+import { requestAddresses } from './requestAddresses.js'
+
+export type WithJsonRpcAccountParameters = {
+  method?: 'get' | 'request'
+  index?: number
+}
+export type WithJsonRpcAccountReturnType<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TClient extends Client<TTransport, TChain>,
+> = Omit<TClient, 'account'> & {
+  account: Account
+}
+
+/**
+ * Returns a Client with an `account` property set to an address
+ * returned by `eth_accounts` or `eth_requestAccounts`.
+ *
+ * @param client - Client to use
+ * @returns A Client with an attached Account (`account`).
+ *
+ * @example
+ * import { createWalletClient, custom } from 'viem'
+ * import { mainnet } from 'viem/chains'
+ *
+ * let client = await createWalletClient({
+ *   chain: mainnet,
+ *   transport: custom(window.ethereum),
+ * })
+ * client = await withJsonRpcAccount(client)
+ */
+export async function withJsonRpcAccount<
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TClient extends Client<TTransport, TChain>,
+>(
+  client: TClient,
+  args: WithJsonRpcAccountParameters = {},
+): Promise<Omit<TClient, 'account'> & { account: Account }> {
+  const { method = 'get', index = 0 } = args
+  const actions = {
+    get: getAddresses,
+    request: requestAddresses,
+  }
+  const addresses = await actions[method](client)
+  return Object.assign(client, {
+    account: parseAccount(addresses[index]),
+  }) as TClient & { account: Account }
+}

--- a/src/clients/createTestClient.test.ts
+++ b/src/clients/createTestClient.test.ts
@@ -99,6 +99,7 @@ test('creates', () => {
         "type": "mock",
       },
       "type": "testClient",
+      "withJsonRpcAccount": [Function],
     }
   `)
 })
@@ -185,6 +186,7 @@ describe('transports', () => {
           "url": undefined,
         },
         "type": "testClient",
+        "withJsonRpcAccount": [Function],
       }
     `)
   })
@@ -271,6 +273,7 @@ describe('transports', () => {
           "type": "webSocket",
         },
         "type": "testClient",
+        "withJsonRpcAccount": [Function],
       }
     `)
   })
@@ -413,6 +416,7 @@ test('extend', () => {
       "watchContractEvent": [Function],
       "watchEvent": [Function],
       "watchPendingTransactions": [Function],
+      "withJsonRpcAccount": [Function],
       "writeContract": [Function],
     }
   `)

--- a/src/clients/createTestClient.ts
+++ b/src/clients/createTestClient.ts
@@ -3,6 +3,7 @@ import type { ParseAccount } from '../types/account.js'
 import type { Chain } from '../types/chain.js'
 import type { TestRpcSchema } from '../types/eip1193.js'
 import { type Client, type ClientConfig, createClient } from './createClient.js'
+import { type AccountActions, accountActions } from './decorators/account.js'
 import { type TestActions, testActions } from './decorators/test.js'
 import type { Transport } from './transports/createTransport.js'
 import type { Address } from 'abitype'
@@ -36,7 +37,14 @@ export type TestClient<
   TChain,
   TAccount,
   TestRpcSchema<TMode>,
-  TIncludeActions extends true ? TestActions : Record<string, unknown>
+  TIncludeActions extends true
+    ? TestActions &
+        AccountActions<
+          TTransport,
+          TChain,
+          Client<TTransport, TChain, Account, TestRpcSchema<TMode>, TestActions>
+        >
+    : Record<string, unknown>
 > & {
   mode: TMode
 }
@@ -94,4 +102,5 @@ export function createTestClient<
   })
     .extend(() => ({ mode }))
     .extend(testActions({ mode }))
+    .extend(accountActions as any)
 }

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -63,6 +63,7 @@ test('creates', () => {
       },
       "type": "walletClient",
       "watchAsset": [Function],
+      "withJsonRpcAccount": [Function],
       "writeContract": [Function],
     }
   `)
@@ -113,6 +114,7 @@ describe('args: account', () => {
         },
         "type": "walletClient",
         "watchAsset": [Function],
+        "withJsonRpcAccount": [Function],
         "writeContract": [Function],
       }
     `)
@@ -167,6 +169,7 @@ describe('args: account', () => {
         },
         "type": "walletClient",
         "watchAsset": [Function],
+        "withJsonRpcAccount": [Function],
         "writeContract": [Function],
       }
     `)
@@ -212,6 +215,7 @@ describe('args: transport', () => {
         },
         "type": "walletClient",
         "watchAsset": [Function],
+        "withJsonRpcAccount": [Function],
         "writeContract": [Function],
       }
     `)
@@ -256,6 +260,7 @@ describe('args: transport', () => {
         },
         "type": "walletClient",
         "watchAsset": [Function],
+        "withJsonRpcAccount": [Function],
         "writeContract": [Function],
       }
     `)
@@ -325,6 +330,7 @@ describe('args: transport', () => {
         },
         "type": "walletClient",
         "watchAsset": [Function],
+        "withJsonRpcAccount": [Function],
         "writeContract": [Function],
       }
     `)
@@ -466,6 +472,7 @@ test('extend', () => {
       "watchContractEvent": [Function],
       "watchEvent": [Function],
       "watchPendingTransactions": [Function],
+      "withJsonRpcAccount": [Function],
       "writeContract": [Function],
     }
   `)

--- a/src/clients/createWalletClient.ts
+++ b/src/clients/createWalletClient.ts
@@ -6,6 +6,7 @@ import type { Chain } from '../types/chain.js'
 import type { WalletRpcSchema } from '../types/eip1193.js'
 import type { Prettify } from '../types/utils.js'
 import { type Client, type ClientConfig, createClient } from './createClient.js'
+import { type AccountActions, accountActions } from './decorators/account.js'
 import { type WalletActions, walletActions } from './decorators/wallet.js'
 import type { Transport } from './transports/createTransport.js'
 
@@ -31,7 +32,18 @@ export type WalletClient<
     TChain,
     TAccount,
     WalletRpcSchema,
-    WalletActions<TChain, TAccount>
+    WalletActions<TChain, TAccount> &
+      AccountActions<
+        TTransport,
+        TChain,
+        Client<
+          TTransport,
+          TChain,
+          Account,
+          WalletRpcSchema,
+          WalletActions<TChain, Account>
+        >
+      >
   >
 >
 
@@ -95,5 +107,7 @@ export function createWalletClient<
     pollingInterval,
     transport: (opts) => transport({ ...opts, retryCount: 0 }),
     type: 'walletClient',
-  }).extend(walletActions)
+  })
+    .extend(walletActions)
+    .extend(accountActions as any)
 }

--- a/src/clients/decorators/account.test.ts
+++ b/src/clients/decorators/account.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import { walletClient } from '../../_test/utils.js'
+
+import { accountActions } from './account.js'
+
+test('default', async () => {
+  expect(accountActions(walletClient as any)).toMatchInlineSnapshot(`
+    {
+      "withJsonRpcAccount": [Function],
+    }
+  `)
+})
+
+describe('smoke test', () => {
+  test('withJsonRpcAccount', async () => {
+    expect(walletClient.account).toBeUndefined()
+    expect(
+      (await walletClient.withJsonRpcAccount()).account,
+    ).toMatchInlineSnapshot(`
+      {
+        "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "type": "json-rpc",
+      }
+    `)
+  })
+})

--- a/src/clients/decorators/account.ts
+++ b/src/clients/decorators/account.ts
@@ -1,0 +1,50 @@
+import {
+  type WithJsonRpcAccountParameters,
+  type WithJsonRpcAccountReturnType,
+  withJsonRpcAccount,
+} from '../../actions/wallet/withJsonRpcAccount.js'
+import type { Chain } from '../../types/chain.js'
+import type { Client } from '../createClient.js'
+import type { Transport } from '../transports/createTransport.js'
+
+export type AccountActions<
+  TTransport extends Transport = Transport,
+  TChain extends Chain | undefined = Chain | undefined,
+  TClient extends Client<Transport, TChain> = Client<Transport, TChain>,
+> = {
+  /**
+   * Returns a Client with an `account` property set to an address
+   * returned by `eth_getAddresses` or `eth_requestAddresses`.
+   *
+   * @param args - Parameters
+   * @returns A Client with an attached Account (`account`).
+   *
+   * @example
+   * import { createWalletClient, custom } from 'viem'
+   * import { mainnet } from 'viem/chains'
+   *
+   * const client = await createWalletClient({
+   *   chain: mainnet,
+   *   transport: custom(window.ethereum),
+   * }).withJsonRpcAccount()
+   */
+  withJsonRpcAccount: (
+    args?: WithJsonRpcAccountParameters,
+  ) => Promise<WithJsonRpcAccountReturnType<TTransport, TChain, TClient>>
+}
+
+export const accountActions: <
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TClient extends Client<Transport, TChain>,
+>(
+  client: TChain,
+) => AccountActions<TTransport, TChain, TClient> = <
+  TTransport extends Transport,
+  TChain extends Chain | undefined,
+  TClient extends Client<Transport, TChain>,
+>(
+  client: TChain,
+): AccountActions<TTransport, TChain, TClient> => ({
+  withJsonRpcAccount: (args) => withJsonRpcAccount(client as any, args),
+})


### PR DESCRIPTION
Add a `withJsonRpcAccount` Action to the Wallet and Test Client that consumers can use to retrieve the JSON-RPC Account from the target Wallet/Node, and attach it to the Client.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new function `withJsonRpcAccount` to the `viem` library that attaches a JSON-RPC account to a client. It also includes updates to tests, documentation, and related code.

### Detailed summary
- Added `withJsonRpcAccount` function to attach a JSON-RPC account to a client
- Updated tests and documentation to include `withJsonRpcAccount`
- Refactored code related to client creation and account attachment

> The following files were skipped due to too many changes: `src/clients/decorators/account.ts`, `src/actions/wallet/withJsonRpcAccount.ts`, `site/docs/clients/wallet.md`, `src/actions/wallet/withJsonRpcAccount.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->