### PR TITLE
fix: transaction types

### DIFF
--- a/.changeset/quiet-hotels-battle.md
+++ b/.changeset/quiet-hotels-battle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `RpcTransaction` type to not include `typeHex`.

--- a/.changeset/silver-numbers-dream.md
+++ b/.changeset/silver-numbers-dream.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `TransactionRequest` did not narrow based on type.

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -26,6 +26,7 @@ import type {
   IsUndefined,
   Or,
   Prettify,
+  UnionOmit,
 } from '../types/utils.js'
 
 import {
@@ -444,7 +445,7 @@ export function getContract<
             return (
               ...parameters: [
                 args?: readonly unknown[],
-                options?: Omit<
+                options?: UnionOmit<
                   ReadContractParameters,
                   'abi' | 'address' | 'functionName' | 'args'
                 >,
@@ -471,7 +472,7 @@ export function getContract<
             return (
               ...parameters: [
                 args?: readonly unknown[],
-                options?: Omit<
+                options?: UnionOmit<
                   SimulateContractParameters,
                   'abi' | 'address' | 'functionName' | 'args'
                 >,
@@ -565,7 +566,7 @@ export function getContract<
             return (
               ...parameters: [
                 args?: readonly unknown[],
-                options?: Omit<
+                options?: UnionOmit<
                   WriteContractParameters,
                   'abi' | 'address' | 'functionName' | 'args'
                 >,
@@ -599,7 +600,7 @@ export function getContract<
             return (
               ...parameters: [
                 args?: readonly unknown[],
-                options?: Omit<
+                options?: UnionOmit<
                   EstimateContractGasParameters,
                   'abi' | 'address' | 'functionName' | 'args'
                 >,
@@ -616,7 +617,7 @@ export function getContract<
                 account:
                   (options as EstimateContractGasParameters).account ??
                   (walletClient as unknown as WalletClient).account,
-              } as EstimateContractGasParameters)
+              } as any)
             }
           },
         },
@@ -677,7 +678,7 @@ type GetReadFunction<
     : AbiFunction,
   Args = AbiParametersToPrimitiveTypes<TAbiFunction['inputs']>,
   Options = Prettify<
-    Omit<
+    UnionOmit<
       ReadContractParameters<TAbi, TFunctionName>,
       'abi' | 'address' | 'args' | 'functionName'
     >
@@ -705,7 +706,7 @@ type GetEstimateFunction<
     : AbiFunction,
   Args = AbiParametersToPrimitiveTypes<TAbiFunction['inputs']>,
   Options = Prettify<
-    Omit<
+    UnionOmit<
       EstimateContractGasParameters<TAbi, TFunctionName, TChain, TAccount>,
       'abi' | 'address' | 'args' | 'functionName'
     >
@@ -751,7 +752,7 @@ type GetSimulateFunction<
   ? <
       TChainOverride extends Chain | undefined,
       Options extends Prettify<
-        Omit<
+        UnionOmit<
           SimulateContractParameters<
             TAbi,
             TFunctionName,
@@ -771,7 +772,7 @@ type GetSimulateFunction<
   : <
       TChainOverride extends Chain | undefined,
       Options extends Prettify<
-        Omit<
+        UnionOmit<
           SimulateContractParameters<
             TAbi,
             TFunctionName,
@@ -803,7 +804,7 @@ type GetWriteFunction<
   ? <
       TChainOverride extends Chain | undefined,
       Options extends Prettify<
-        Omit<
+        UnionOmit<
           WriteContractParameters<
             TAbi,
             TFunctionName,
@@ -829,7 +830,7 @@ type GetWriteFunction<
   : <
       TChainOverride extends Chain | undefined,
       Options extends Prettify<
-        Omit<
+        UnionOmit<
           WriteContractParameters<
             TAbi,
             TFunctionName,

--- a/src/actions/public/call.test-d.ts
+++ b/src/actions/public/call.test-d.ts
@@ -1,0 +1,90 @@
+import { test } from 'vitest'
+
+import { publicClient } from '../../_test/utils.js'
+
+import { call } from './call.js'
+
+test('legacy', () => {
+  call(publicClient, {
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+  // @ts-expect-error
+  call(publicClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+})
+
+test('eip1559', () => {
+  call(publicClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip1559',
+  })
+  // @ts-expect-error
+  call(publicClient, {
+    gasPrice: 0n,
+    type: 'eip1559',
+  })
+})
+
+test('eip2930', () => {
+  call(publicClient, {
+    accessList: [],
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  call(publicClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+  // @ts-expect-error
+  call(publicClient, {
+    accessList: [],
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+})

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -17,6 +17,7 @@ import type { Chain } from '../../types/chain.js'
 import type { Hex } from '../../types/misc.js'
 import type { RpcTransactionRequest } from '../../types/rpc.js'
 import type { TransactionRequest } from '../../types/transaction.js'
+import type { UnionOmit } from '../../types/utils.js'
 import { decodeFunctionResult } from '../../utils/abi/decodeFunctionResult.js'
 import { encodeFunctionData } from '../../utils/abi/encodeFunctionData.js'
 import { getChainContractAddress } from '../../utils/chain.js'
@@ -29,6 +30,7 @@ import {
 } from '../../utils/formatters/transactionRequest.js'
 import { createBatchScheduler } from '../../utils/promise/createBatchScheduler.js'
 import { assertRequest } from '../../utils/transaction/assertRequest.js'
+import type { AssertRequestParameters } from '../../utils/transaction/assertRequest.js'
 
 export type FormattedCall<
   TChain extends Chain | undefined = Chain | undefined,
@@ -36,7 +38,7 @@ export type FormattedCall<
 
 export type CallParameters<
   TChain extends Chain | undefined = Chain | undefined,
-> = Omit<FormattedCall<TChain>, 'from'> & {
+> = UnionOmit<FormattedCall<TChain>, 'from'> & {
   account?: Account | Address
   batch?: boolean
 } & (
@@ -105,7 +107,7 @@ export async function call<TChain extends Chain | undefined>(
   const account = account_ ? parseAccount(account_) : undefined
 
   try {
-    assertRequest(args)
+    assertRequest(args as AssertRequestParameters)
 
     const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
     const block = blockNumberHex || blockTag

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -7,6 +7,7 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { BaseError } from '../../errors/base.js'
 import type { Chain } from '../../types/chain.js'
 import type { ContractFunctionConfig, GetValue } from '../../types/contract.js'
+import type { UnionOmit } from '../../types/utils.js'
 import {
   type EncodeFunctionDataParameters,
   encodeFunctionData,
@@ -20,7 +21,7 @@ export type EstimateContractGasParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = undefined,
 > = ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
-  Omit<EstimateGasParameters<TChain, TAccount>, 'data' | 'to' | 'value'> &
+  UnionOmit<EstimateGasParameters<TChain, TAccount>, 'data' | 'to' | 'value'> &
   GetValue<
     TAbi,
     TFunctionName,

--- a/src/actions/public/estimateGas.test-d.ts
+++ b/src/actions/public/estimateGas.test-d.ts
@@ -1,0 +1,102 @@
+import { test } from 'vitest'
+
+import { publicClient } from '../../_test/utils.js'
+
+import { estimateGas } from './estimateGas.js'
+
+test('legacy', () => {
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+})
+
+test('eip1559', () => {
+  estimateGas(publicClient, {
+    account: '0x',
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip1559',
+  })
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    gasPrice: 0n,
+    type: 'eip1559',
+  })
+})
+
+test('eip2930', () => {
+  estimateGas(publicClient, {
+    account: '0x',
+    accessList: [],
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+  // @ts-expect-error
+  estimateGas(publicClient, {
+    account: '0x',
+    accessList: [],
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+})

--- a/src/actions/public/estimateGas.ts
+++ b/src/actions/public/estimateGas.ts
@@ -8,6 +8,7 @@ import type { GetAccountParameter } from '../../types/account.js'
 import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type { TransactionRequest } from '../../types/transaction.js'
+import type { UnionOmit } from '../../types/utils.js'
 import { numberToHex } from '../../utils/encoding/toHex.js'
 import { getEstimateGasError } from '../../utils/errors/getEstimateGasError.js'
 import { extract } from '../../utils/formatters/extract.js'
@@ -15,7 +16,10 @@ import {
   type FormattedTransactionRequest,
   formatTransactionRequest,
 } from '../../utils/formatters/transactionRequest.js'
-import { assertRequest } from '../../utils/transaction/assertRequest.js'
+import {
+  type AssertRequestParameters,
+  assertRequest,
+} from '../../utils/transaction/assertRequest.js'
 import { prepareRequest } from '../../utils/transaction/prepareRequest.js'
 
 export type FormattedEstimateGas<
@@ -25,7 +29,7 @@ export type FormattedEstimateGas<
 export type EstimateGasParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = undefined,
-> = Omit<FormattedEstimateGas<TChain>, 'from'> &
+> = UnionOmit<FormattedEstimateGas<TChain>, 'from'> &
   GetAccountParameter<TAccount> &
   (
     | {
@@ -103,7 +107,7 @@ export async function estimateGas<
     const blockNumberHex = blockNumber ? numberToHex(blockNumber) : undefined
     const block = blockNumberHex || blockTag
 
-    assertRequest(args)
+    assertRequest(args as AssertRequestParameters)
 
     const format =
       client.chain?.formatters?.transactionRequest?.format ||

--- a/src/actions/public/simulateContract.test-d.ts
+++ b/src/actions/public/simulateContract.test-d.ts
@@ -1,48 +1,25 @@
 import { test } from 'vitest'
 
 import { wagmiContractConfig } from '../../_test/abis.js'
-import { accounts } from '../../_test/constants.js'
-import {
-  publicClient,
-  walletClient,
-  walletClientWithAccount,
-} from '../../_test/utils.js'
-import { estimateContractGas } from './estimateContractGas.js'
+import { publicClient } from '../../_test/utils.js'
+
+import { simulateContract } from './simulateContract.js'
 
 const args = {
   ...wagmiContractConfig,
+  account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
   functionName: 'mint',
   args: [69420n],
 } as const
 
-test('publicClient', () => {
-  estimateContractGas(publicClient, {
-    ...args,
-    account: accounts[0].address,
-  })
-})
-
-test('wallet client without account', () => {
-  estimateContractGas(walletClient, {
-    ...args,
-    account: accounts[0].address,
-  })
-})
-
-test('wallet client with account', () => {
-  estimateContractGas(walletClientWithAccount, {
-    ...args,
-  })
-})
-
 test('legacy', () => {
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -50,7 +27,7 @@ test('legacy', () => {
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -58,7 +35,7 @@ test('legacy', () => {
     type: 'legacy',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
@@ -67,14 +44,14 @@ test('legacy', () => {
 })
 
 test('eip1559', () => {
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -82,7 +59,7 @@ test('eip1559', () => {
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -90,7 +67,7 @@ test('eip1559', () => {
     type: 'eip1559',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     gasPrice: 0n,
     type: 'eip1559',
@@ -98,14 +75,14 @@ test('eip1559', () => {
 })
 
 test('eip2930', () => {
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     accessList: [],
     gasPrice: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     accessList: [],
     gasPrice: 0n,
@@ -114,7 +91,7 @@ test('eip2930', () => {
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     accessList: [],
     gasPrice: 0n,
@@ -123,7 +100,7 @@ test('eip2930', () => {
     type: 'eip2930',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  simulateContract(publicClient, {
     ...args,
     accessList: [],
     maxFeePerGas: 0n,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -11,6 +11,7 @@ import type {
   GetValue,
 } from '../../types/contract.js'
 import type { Hex } from '../../types/misc.js'
+import type { UnionOmit } from '../../types/utils.js'
 import {
   type DecodeFunctionResultParameters,
   decodeFunctionResult,
@@ -34,7 +35,7 @@ export type SimulateContractParameters<
   /** Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). */
   dataSuffix?: Hex
 } & ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
-  Omit<
+  UnionOmit<
     CallParameters<TChainOverride extends Chain ? TChainOverride : TChain>,
     'batch' | 'to' | 'data' | 'value'
   > &
@@ -53,7 +54,7 @@ export type SimulateContractReturnType<
   TChainOverride extends Chain | undefined = undefined,
 > = {
   result: ContractFunctionResult<TAbi, TFunctionName>
-  request: Omit<
+  request: UnionOmit<
     WriteContractParameters<
       TAbi,
       TFunctionName,

--- a/src/actions/wallet/deployContract.test-d.ts
+++ b/src/actions/wallet/deployContract.test-d.ts
@@ -1,48 +1,24 @@
 import { test } from 'vitest'
 
 import { wagmiContractConfig } from '../../_test/abis.js'
-import { accounts } from '../../_test/constants.js'
-import {
-  publicClient,
-  walletClient,
-  walletClientWithAccount,
-} from '../../_test/utils.js'
-import { estimateContractGas } from './estimateContractGas.js'
+import { walletClient } from '../../_test/utils.js'
+
+import { deployContract } from './deployContract.js'
 
 const args = {
   ...wagmiContractConfig,
-  functionName: 'mint',
-  args: [69420n],
+  account: '0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC',
+  bytecode: '0x',
 } as const
 
-test('publicClient', () => {
-  estimateContractGas(publicClient, {
-    ...args,
-    account: accounts[0].address,
-  })
-})
-
-test('wallet client without account', () => {
-  estimateContractGas(walletClient, {
-    ...args,
-    account: accounts[0].address,
-  })
-})
-
-test('wallet client with account', () => {
-  estimateContractGas(walletClientWithAccount, {
-    ...args,
-  })
-})
-
 test('legacy', () => {
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -50,7 +26,7 @@ test('legacy', () => {
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -58,7 +34,7 @@ test('legacy', () => {
     type: 'legacy',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
@@ -67,14 +43,14 @@ test('legacy', () => {
 })
 
 test('eip1559', () => {
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -82,7 +58,7 @@ test('eip1559', () => {
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
     maxFeePerGas: 0n,
@@ -90,7 +66,7 @@ test('eip1559', () => {
     type: 'eip1559',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
     gasPrice: 0n,
     type: 'eip1559',
@@ -98,34 +74,30 @@ test('eip1559', () => {
 })
 
 test('eip2930', () => {
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
-    accessList: [],
     gasPrice: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
-    accessList: [],
     gasPrice: 0n,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
   })
 
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
-    accessList: [],
     gasPrice: 0n,
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
     type: 'eip2930',
   })
   // @ts-expect-error
-  estimateContractGas(walletClientWithAccount, {
+  deployContract(walletClient, {
     ...args,
-    accessList: [],
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
     type: 'eip2930',

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -6,6 +6,7 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { Chain, GetChain } from '../../types/chain.js'
 import type { GetConstructorArgs } from '../../types/contract.js'
 import type { Hex } from '../../types/misc.js'
+import type { UnionOmit } from '../../types/utils.js'
 import { encodeDeployData } from '../../utils/abi/encodeDeployData.js'
 
 import {
@@ -19,7 +20,7 @@ export type DeployContractParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = undefined,
-> = Omit<
+> = UnionOmit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
   'accessList' | 'chain' | 'to' | 'data' | 'value'
 > & {

--- a/src/actions/wallet/sendTransaction.test-d.ts
+++ b/src/actions/wallet/sendTransaction.test-d.ts
@@ -46,3 +46,88 @@ test('with and without `account`', () => {
     // ^?
   })
 })
+
+test('legacy', () => {
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+})
+
+test('eip1559', () => {
+  sendTransaction(walletClient, {
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip1559',
+  })
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    gasPrice: 0n,
+    type: 'eip1559',
+  })
+})
+
+test('eip2930', () => {
+  sendTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+  // @ts-expect-error
+  sendTransaction(walletClient, {
+    accessList: [],
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+})

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -11,7 +11,7 @@ import type {
   TransactionRequest,
   TransactionSerializable,
 } from '../../types/transaction.js'
-import type { IsUndefined } from '../../types/utils.js'
+import type { IsUndefined, UnionOmit } from '../../types/utils.js'
 import { assertCurrentChain } from '../../utils/chain.js'
 import { getTransactionError } from '../../utils/errors/getTransactionError.js'
 import { extract } from '../../utils/formatters/extract.js'
@@ -27,7 +27,7 @@ export type SendTransactionParameters<
   TChain extends Chain | undefined = Chain | undefined,
   TAccount extends Account | undefined = Account | undefined,
   TChainOverride extends Chain | undefined = Chain,
-> = Omit<
+> = UnionOmit<
   FormattedTransactionRequest<
     IsUndefined<TChain> extends true ? TChainOverride : TChain
   >,

--- a/src/actions/wallet/writeContract.test-d.ts
+++ b/src/actions/wallet/writeContract.test-d.ts
@@ -1,7 +1,9 @@
 import { seaportAbi } from 'abitype/test'
 import { assertType, expectTypeOf, test } from 'vitest'
 
-import type { WriteContractParameters } from './writeContract.js'
+import { wagmiContractConfig } from '../../_test/abis.js'
+import { walletClientWithAccount } from '../../_test/utils.js'
+import { type WriteContractParameters, writeContract } from './writeContract.js'
 
 test('WriteContractParameters', async () => {
   type Result = WriteContractParameters<typeof seaportAbi, 'cancel'>
@@ -60,5 +62,108 @@ test('WriteContractParameters', async () => {
         },
       ],
     ],
+  })
+})
+
+const args = {
+  ...wagmiContractConfig,
+  functionName: 'mint',
+  args: [69420n],
+} as const
+
+test('legacy', () => {
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'legacy',
+  })
+})
+
+test('eip1559', () => {
+  writeContract(walletClientWithAccount, {
+    ...args,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip1559',
+  })
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    gasPrice: 0n,
+    type: 'eip1559',
+  })
+})
+
+test('eip2930', () => {
+  writeContract(walletClientWithAccount, {
+    ...args,
+    accessList: [],
+    gasPrice: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+  })
+
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    accessList: [],
+    gasPrice: 0n,
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
+  })
+  // @ts-expect-error
+  writeContract(walletClientWithAccount, {
+    ...args,
+    accessList: [],
+    maxFeePerGas: 0n,
+    maxPriorityFeePerGas: 0n,
+    type: 'eip2930',
   })
 })

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -6,6 +6,7 @@ import type { Transport } from '../../clients/transports/createTransport.js'
 import type { Chain, GetChain } from '../../types/chain.js'
 import type { ContractFunctionConfig, GetValue } from '../../types/contract.js'
 import type { Hex } from '../../types/misc.js'
+import type { UnionOmit } from '../../types/utils.js'
 import {
   type EncodeFunctionDataParameters,
   encodeFunctionData,
@@ -24,7 +25,7 @@ export type WriteContractParameters<
   TAccount extends Account | undefined = undefined,
   TChainOverride extends Chain | undefined = undefined,
 > = ContractFunctionConfig<TAbi, TFunctionName, 'payable' | 'nonpayable'> &
-  Omit<
+  UnionOmit<
     SendTransactionParameters<TChain, TAccount, TChainOverride>,
     'chain' | 'to' | 'data' | 'value'
   > &

--- a/src/chains/formatters/celo.test-d.ts
+++ b/src/chains/formatters/celo.test-d.ts
@@ -198,7 +198,7 @@ describe('smoke', () => {
       gatewayFeeRecipient: '0x',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `gasPrice` is not defined
     sendTransaction(client, {
       feeCurrency: '0x',
       gatewayFee: 0n,
@@ -208,7 +208,7 @@ describe('smoke', () => {
       maxPriorityFeePerGas: 0n,
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `gasPrice` is not defined
     sendTransaction(client, {
       feeCurrency: '0x',
       gatewayFee: 0n,
@@ -217,7 +217,7 @@ describe('smoke', () => {
       type: 'eip1559',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `type` cannot be "legacy"
     sendTransaction(client, {
       feeCurrency: '0x',
       gatewayFee: 0n,
@@ -226,7 +226,7 @@ describe('smoke', () => {
       type: 'legacy',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `type` cannot be "eip2930"
     sendTransaction(client, {
       feeCurrency: '0x',
       gatewayFee: 0n,
@@ -249,7 +249,7 @@ describe('smoke', () => {
       gatewayFeeRecipient: '0x',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `gasPrice` is not defined
     sendTransaction(client, {
       chain: celo,
       feeCurrency: '0x',
@@ -260,7 +260,7 @@ describe('smoke', () => {
       maxPriorityFeePerGas: 0n,
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `gasPrice` is not defined
     sendTransaction(client, {
       chain: celo,
       feeCurrency: '0x',
@@ -270,7 +270,7 @@ describe('smoke', () => {
       type: 'eip1559',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `type` cannot be "legacy"
     sendTransaction(client, {
       chain: celo,
       feeCurrency: '0x',
@@ -280,7 +280,7 @@ describe('smoke', () => {
       type: 'legacy',
     })
 
-    // @ts-expect-error
+    // @ts-expect-error `type` cannot be "eip2930"
     sendTransaction(client, {
       chain: celo,
       feeCurrency: '0x',

--- a/src/chains/formatters/celo.test-d.ts
+++ b/src/chains/formatters/celo.test-d.ts
@@ -4,6 +4,7 @@ import { getBlock } from '../../actions/public/getBlock.js'
 import { getTransaction } from '../../actions/public/getTransaction.js'
 import { getTransactionReceipt } from '../../actions/public/getTransactionReceipt.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
+import { createWalletClient } from '../../clients/createWalletClient.js'
 import { http } from '../../clients/transports/http.js'
 import type {
   RpcBlock,
@@ -14,6 +15,7 @@ import type {
   Transaction,
   TransactionRequest,
 } from '../../types/transaction.js'
+import { sendTransaction } from '../../wallet.js'
 import { celo } from '../index.js'
 import { celoFormatters } from './celo.js'
 
@@ -181,5 +183,111 @@ describe('smoke', () => {
     expectTypeOf(transaction.gatewayFeeRecipient).toEqualTypeOf<
       `0x${string}` | null
     >()
+  })
+
+  test('transactionRequest', async () => {
+    const client = createWalletClient({
+      account: '0x',
+      chain: celo,
+      transport: http(),
+    })
+
+    sendTransaction(client, {
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      gasPrice: 0n,
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      gasPrice: 0n,
+      type: 'eip1559',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      maxFeePerGas: 0n,
+      type: 'legacy',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      maxFeePerGas: 0n,
+      type: 'eip2930',
+    })
+  })
+
+  test('transactionRequest (chain on action)', async () => {
+    const client = createWalletClient({
+      account: '0x',
+      transport: http(),
+    })
+
+    sendTransaction(client, {
+      chain: celo,
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      chain: celo,
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      gasPrice: 0n,
+      maxFeePerGas: 0n,
+      maxPriorityFeePerGas: 0n,
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      chain: celo,
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      gasPrice: 0n,
+      type: 'eip1559',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      chain: celo,
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      maxFeePerGas: 0n,
+      type: 'legacy',
+    })
+
+    // @ts-expect-error
+    sendTransaction(client, {
+      chain: celo,
+      feeCurrency: '0x',
+      gatewayFee: 0n,
+      gatewayFeeRecipient: '0x',
+      maxFeePerGas: 0n,
+      type: 'eip2930',
+    })
   })
 })

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -6,8 +6,11 @@ import type {
   TransactionEIP2930,
   TransactionLegacy,
   TransactionReceipt,
-  TransactionRequest,
+  TransactionRequestEIP1559,
+  TransactionRequestEIP2930,
+  TransactionRequestLegacy,
 } from './transaction.js'
+import type { UnionOmit } from './utils.js'
 
 export type Index = `0x${string}`
 export type Quantity = `0x${string}`
@@ -27,8 +30,13 @@ export type RpcTransactionReceipt = TransactionReceipt<
   Status,
   TransactionType
 >
-export type RpcTransactionRequest = TransactionRequest<Quantity, Index>
-export type RpcTransaction =
+export type RpcTransactionRequest =
+  | TransactionRequestLegacy<Quantity, Index, '0x0'>
+  | TransactionRequestEIP2930<Quantity, Index, '0x1'>
+  | TransactionRequestEIP1559<Quantity, Index, '0x2'>
+export type RpcTransaction = UnionOmit<
   | TransactionLegacy<Quantity, Index, '0x0'>
   | TransactionEIP2930<Quantity, Index, '0x1'>
-  | TransactionEIP1559<Quantity, Index, '0x2'>
+  | TransactionEIP1559<Quantity, Index, '0x2'>,
+  'typeHex'
+>

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -129,23 +129,29 @@ export type TransactionRequestBase<TQuantity = bigint, TIndex = number> = {
 export type TransactionRequestLegacy<
   TQuantity = bigint,
   TIndex = number,
+  TTransactionType = 'legacy',
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
     accessList?: never
+    type?: TTransactionType
   }
 export type TransactionRequestEIP2930<
   TQuantity = bigint,
   TIndex = number,
+  TTransactionType = 'eip2930',
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesLegacy<TQuantity>> & {
     accessList?: AccessList
+    type?: TTransactionType
   }
 export type TransactionRequestEIP1559<
   TQuantity = bigint,
   TIndex = number,
+  TTransactionType = 'eip1559',
 > = TransactionRequestBase<TQuantity, TIndex> &
   Partial<FeeValuesEIP1559<TQuantity>> & {
     accessList?: AccessList
+    type?: TTransactionType
   }
 export type TransactionRequest<TQuantity = bigint, TIndex = number> =
   | TransactionRequestLegacy<TQuantity, TIndex>

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -165,6 +165,16 @@ export type OptionalNullable<T> = {
 export type NoUndefined<T> = T extends undefined ? never : T
 
 /**
+ * @description Construct a type with the properties of union type T except for those in type K.
+ * @example
+ * type Result = UnionOmit<{ a: string, b: number } | { a: string, b: undefined, c: number }, 'a'>
+ * => { b: number } | { b: undefined, c: number }
+ */
+export type UnionOmit<T, K extends keyof any> = T extends any
+  ? Omit<T, K>
+  : never
+
+/**
  * @description Creates a type that is a partial of T, but with the required keys K.
  *
  * @example

--- a/src/utils/errors/getCallError.ts
+++ b/src/utils/errors/getCallError.ts
@@ -3,7 +3,11 @@ import type { BaseError } from '../../errors/base.js'
 import { CallExecutionError } from '../../errors/contract.js'
 import type { Chain } from '../../types/chain.js'
 
-import { containsNodeError, getNodeError } from './getNodeError.js'
+import {
+  type GetNodeErrorParameters,
+  containsNodeError,
+  getNodeError,
+} from './getNodeError.js'
 
 export function getCallError(
   err: BaseError,
@@ -16,7 +20,8 @@ export function getCallError(
   },
 ) {
   let cause = err
-  if (containsNodeError(err)) cause = getNodeError(err, args)
+  if (containsNodeError(err))
+    cause = getNodeError(err, args as GetNodeErrorParameters)
   return new CallExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/errors/getEstimateGasError.ts
+++ b/src/utils/errors/getEstimateGasError.ts
@@ -4,7 +4,11 @@ import type { BaseError } from '../../errors/base.js'
 import { EstimateGasExecutionError } from '../../errors/estimateGas.js'
 import type { Chain } from '../../types/chain.js'
 
-import { containsNodeError, getNodeError } from './getNodeError.js'
+import {
+  type GetNodeErrorParameters,
+  containsNodeError,
+  getNodeError,
+} from './getNodeError.js'
 
 export function getEstimateGasError(
   err: BaseError,
@@ -18,7 +22,8 @@ export function getEstimateGasError(
   },
 ) {
   let cause = err
-  if (containsNodeError(err)) cause = getNodeError(err, args)
+  if (containsNodeError(err))
+    cause = getNodeError(err, args as GetNodeErrorParameters)
   return new EstimateGasExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -28,10 +28,9 @@ export function containsNodeError(err: BaseError) {
   )
 }
 
-export function getNodeError(
-  err: BaseError,
-  args: Partial<SendTransactionParameters<any>>,
-) {
+export type GetNodeErrorParameters = Partial<SendTransactionParameters<any>>
+
+export function getNodeError(err: BaseError, args: GetNodeErrorParameters) {
   const message = err.details.toLowerCase()
   if (FeeCapTooHighError.nodeMessage.test(message))
     return new FeeCapTooHighError({

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -4,21 +4,28 @@ import type { BaseError } from '../../errors/base.js'
 import { TransactionExecutionError } from '../../errors/transaction.js'
 import type { Chain } from '../../types/chain.js'
 
-import { containsNodeError, getNodeError } from './getNodeError.js'
+import {
+  type GetNodeErrorParameters,
+  containsNodeError,
+  getNodeError,
+} from './getNodeError.js'
+
+export type GetTransactionErrorParameters = Omit<
+  SendTransactionParameters,
+  'account' | 'chain'
+> & {
+  account: Account
+  chain?: Chain
+  docsPath?: string
+}
 
 export function getTransactionError(
   err: BaseError,
-  {
-    docsPath,
-    ...args
-  }: Omit<SendTransactionParameters, 'account' | 'chain'> & {
-    account: Account
-    chain?: Chain
-    docsPath?: string
-  },
+  { docsPath, ...args }: GetTransactionErrorParameters,
 ) {
   let cause = err
-  if (containsNodeError(err)) cause = getNodeError(err, args)
+  if (containsNodeError(err))
+    cause = getNodeError(err, args as GetNodeErrorParameters)
   return new TransactionExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/transaction/assertRequest.test.ts
+++ b/src/utils/transaction/assertRequest.test.ts
@@ -59,6 +59,7 @@ test('tip higher than fee cap', () => {
 
 test('fee conflict', () => {
   expect(() =>
+    // @ts-expect-error
     assertRequest({
       gasPrice: parseGwei('8'),
       maxFeePerGas: parseGwei('10'),
@@ -72,6 +73,7 @@ test('fee conflict', () => {
   `)
 
   expect(() =>
+    // @ts-expect-error
     assertRequest({
       gasPrice: parseGwei('8'),
       maxFeePerGas: parseGwei('10'),
@@ -84,6 +86,7 @@ test('fee conflict', () => {
   `)
 
   expect(() =>
+    // @ts-expect-error
     assertRequest({
       gasPrice: parseGwei('8'),
       maxPriorityFeePerGas: parseGwei('11'),

--- a/src/utils/transaction/assertRequest.ts
+++ b/src/utils/transaction/assertRequest.ts
@@ -6,7 +6,9 @@ import { FeeConflictError } from '../../errors/transaction.js'
 import type { Chain } from '../../types/chain.js'
 import { isAddress } from '../address/isAddress.js'
 
-export function assertRequest(args: Partial<SendTransactionParameters<Chain>>) {
+export type AssertRequestParameters = Partial<SendTransactionParameters<Chain>>
+
+export function assertRequest(args: AssertRequestParameters) {
   const {
     account: account_,
     gasPrice,

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -17,7 +17,7 @@ import { BaseError } from '../../errors/base.js'
 import type { GetAccountParameter } from '../../types/account.js'
 import type { Chain } from '../../types/chain.js'
 
-import { assertRequest } from './assertRequest.js'
+import { type AssertRequestParameters, assertRequest } from './assertRequest.js'
 
 export type PrepareRequestParameters<
   TAccount extends Account | undefined = undefined,
@@ -112,7 +112,7 @@ export async function prepareRequest<
       account: { address: account.address, type: 'json-rpc' },
     } as EstimateGasParameters)
 
-  assertRequest(request)
+  assertRequest(request as AssertRequestParameters)
 
   return request as PrepareRequestReturnType<TAccount, TParameters>
 }


### PR DESCRIPTION
- Fixes #803. Can look into a fix for laxxing the `type` to accept `0x{string}` in a follow-up PR.
- Fixes a regressions where `TransactionRequest` was no longer narrowing on `type` & added type tests for them.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing and improving various transaction-related functions. 

### Detailed summary
- Fixed `RpcTransaction` type to exclude `typeHex` property.
- Fixed issue with `TransactionRequest` not narrowing based on type.
- Updated `assertRequest` function to use a type alias for parameters.
- Updated `getNodeError` function to use a type alias for parameters.
- Updated `getCallError` function to use a type alias for parameters.
- Updated `prepareRequest` function to use a type alias for parameters.
- Updated `getEstimateGasError` function to use a type alias for parameters.
- Updated `getTransactionError` function to use a type alias for parameters.
- Updated `WriteContractParameters` type to use `UnionOmit` utility type.
- Updated `DeployContractParameters` type to use `UnionOmit` utility type.
- Updated `EstimateContractGasParameters` type to use `UnionOmit` utility type.
- Updated `SendTransactionParameters` type to use `UnionOmit` utility type.
- Updated `TransactionRequest` type to include `TTransactionType` property.
- Updated `RpcTransaction` type to use `UnionOmit` utility type.
- Updated `SimulateContractParameters` type to use `UnionOmit` utility type.
- Updated `FormattedCall` type to use `UnionOmit` utility type.
- Updated `CallParameters` type to use `UnionOmit` utility type.

> The following files were skipped due to too many changes: `src/actions/public/call.ts`, `src/actions/public/call.test-d.ts`, `src/actions/public/estimateGas.ts`, `src/actions/wallet/sendTransaction.test-d.ts`, `src/actions/public/estimateGas.test-d.ts`, `src/actions/wallet/deployContract.test-d.ts`, `src/actions/public/simulateContract.test-d.ts`, `src/actions/wallet/writeContract.test-d.ts`, `src/actions/getContract.ts`, `src/actions/public/estimateContractGas.test-d.ts`, `src/chains/formatters/celo.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->