### PR TITLE
doc: fix broken link

### DIFF
--- a/site/docs/utilities/toRlp.md
+++ b/site/docs/utilities/toRlp.md
@@ -14,7 +14,7 @@ head:
 
 # toRlp
 
-Encodes a hex value or byte array into a [Recursive-Length Prefix (RLP)](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/enc) encoded value.
+Encodes a hex value or byte array into a [Recursive-Length Prefix (RLP)](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/) encoded value.
 
 ## Import
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the link in the `toRlp` utility function's documentation to the correct URL for RLP encoding. 

### Detailed summary
- Updated the link in the `toRlp` utility function's documentation to the correct URL for RLP encoding.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->