### PR TITLE
refactor: remove Promise type for sign.ts

### DIFF
--- a/src/accounts/utils/sign.ts
+++ b/src/accounts/utils/sign.ts
@@ -17,10 +17,10 @@ export type SignReturnType = Signature
  *
  * @returns The signature.
  */
-export async function sign({
+export function sign({
   hash,
   privateKey,
-}: SignParameters): Promise<SignReturnType> {
+}: SignParameters): SignReturnType {
   const { r, s, recovery } = secp256k1.sign(hash.slice(2), privateKey.slice(2))
   return {
     r: toHex(r),


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the `sign` function in `src/accounts/utils/sign.ts` by changing the return type and removing the `async` keyword. 

### Detailed summary
- Changed the return type of the `sign` function from `Promise<SignReturnType>` to `SignReturnType`.
- Removed the `async` keyword from the `sign` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->