### PR TITLE
refactor: EIP1193 eventmap

### DIFF
--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -25,7 +25,7 @@ import { http } from '../clients/transports/http.js'
 import { webSocket } from '../clients/transports/webSocket.js'
 import { RpcRequestError } from '../errors/request.js'
 import type { Chain } from '../types/chain.js'
-import { ProviderRpcError } from '../types/eip1193.js'
+import { type EIP1193Provider, ProviderRpcError } from '../types/eip1193.js'
 import type { Hex } from '../types/misc.js'
 import { namehash } from '../utils/ens/namehash.js'
 import { rpc } from '../utils/rpc.js'
@@ -63,8 +63,8 @@ export const anvilChain = {
   },
 } as const satisfies Chain
 
-const provider = {
-  on: (message: string, listener: (...args: any[]) => null) => {
+const provider: EIP1193Provider = {
+  on: (message, listener) => {
     if (message === 'accountsChanged') {
       listener([accounts[0].address] as any)
     }

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -52,22 +52,22 @@ export type ProviderMessage = {
 }
 
 export type EIP1193EventMap = {
-  connect: (connectInfo: ProviderConnectInfo) => void
-  disconnect: (error: ProviderRpcError) => void
-  chainChanged: (chainId: string) => void
-  accountsChanged: (accounts: Address[]) => void
-  message: (message: ProviderMessage) => void
+  accountsChanged(accounts: Address[]): void
+  chainChanged(chainId: string): void
+  connect(connectInfo: ProviderConnectInfo): void
+  disconnect(error: ProviderRpcError): void
+  message(message: ProviderMessage): void
 }
-export type EIP1193Events = {
-  on: <E extends keyof EIP1193EventMap>(
-    event: E,
-    listener: EIP1193EventMap[E],
-  ) => void
 
-  removeListener: <E extends keyof EIP1193EventMap>(
-    event: E,
-    listener: EIP1193EventMap[E],
-  ) => void
+export type EIP1193Events = {
+  on<TEvent extends keyof EIP1193EventMap>(
+    event: TEvent,
+    listener: EIP1193EventMap[TEvent],
+  ): void
+  removeListener<TEvent extends keyof EIP1193EventMap>(
+    event: TEvent,
+    listener: EIP1193EventMap[TEvent],
+  ): void
 }
 
 //////////////////////////////////////////////////

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -51,36 +51,23 @@ export type ProviderMessage = {
   data: unknown
 }
 
+export type EIP1193EventMap = {
+  connect: (connectInfo: ProviderConnectInfo) => void
+  disconnect: (error: ProviderRpcError) => void
+  chainChanged: (chainId: string) => void
+  accountsChanged: (accounts: Address[]) => void
+  message: (message: ProviderMessage) => void
+}
 export type EIP1193Events = {
-  on(
-    event: 'connect',
-    listener: (connectInfo: ProviderConnectInfo) => void,
-  ): void
-  on(event: 'disconnect', listener: (error: ProviderRpcError) => void): void
-  on(event: 'chainChanged', listener: (chainId: string) => void): void
-  on(event: 'accountsChanged', listener: (accounts: string[]) => void): void
-  on(event: 'message', listener: (message: ProviderMessage) => void): void
+  on: <E extends keyof EIP1193EventMap>(
+    event: E,
+    listener: EIP1193EventMap[E],
+  ) => void
 
-  removeListener(
-    event: 'connect',
-    listener: (connectInfo: ProviderConnectInfo) => void,
-  ): void
-  removeListener(
-    event: 'disconnect',
-    listener: (error: ProviderRpcError) => void,
-  ): void
-  removeListener(
-    event: 'chainChanged',
-    listener: (chainId: string) => void,
-  ): void
-  removeListener(
-    event: 'accountsChanged',
-    listener: (accounts: Address[]) => void,
-  ): void
-  removeListener(
-    event: 'message',
-    listener: (message: ProviderMessage) => void,
-  ): void
+  removeListener: <E extends keyof EIP1193EventMap>(
+    event: E,
+    listener: EIP1193EventMap[E],
+  ) => void
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding type annotations to the `provider` object in the `utils.ts` file. 

### Detailed summary
- Added type annotation `EIP1193Provider` to the `provider` object in `utils.ts`.
- Updated import statement in `utils.ts` to import `EIP1193Provider` from `../types/eip1193.js`.
- Updated `EIP1193Events` type in `eip1193.ts` to use `EIP1193EventMap` for event definitions.
- Updated `on` and `removeListener` methods in `EIP1193Events` type to use generic type arguments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->