### PR TITLE
Support value in deployContract function

### DIFF
--- a/.changeset/new-pigs-count.md
+++ b/.changeset/new-pigs-count.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-This will add value to the parameters of deployContract to allow passing value when creating a payable contract constructor.
+Added ability to pass `value` to `deployContract`.

--- a/.changeset/new-pigs-count.md
+++ b/.changeset/new-pigs-count.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+This will add value to the parameters of deployContract to allow passing value when creating a payable contract constructor.

--- a/src/_test/abis.ts
+++ b/src/_test/abis.ts
@@ -4,11 +4,12 @@ export const payableContractConfig = {
   abi: [
     {
       inputs: [],
-      stateMutability: "payable",
-      type: "constructor",
+      stateMutability: 'payable',
+      type: 'constructor',
     },
   ],
-  bytecode: '0x608060405260358060116000396000f3006080604052600080fd00a165627a7a72305820f86ff341f0dff29df244305f8aa88abaf10e3a0719fa6ea1dcdd01b8b7d750970029'
+  bytecode:
+    '0x608060405260358060116000396000f3006080604052600080fd00a165627a7a72305820f86ff341f0dff29df244305f8aa88abaf10e3a0719fa6ea1dcdd01b8b7d750970029',
 } as const
 
 export const baycContractConfig = {

--- a/src/_test/abis.ts
+++ b/src/_test/abis.ts
@@ -1,5 +1,16 @@
 import { smartAccountAbi } from '../constants/abis.js'
 
+export const payableContractConfig = {
+  abi: [
+    {
+      inputs: [],
+      stateMutability: "payable",
+      type: "constructor",
+    },
+  ],
+  bytecode: '0x608060405260358060116000396000f3006080604052600080fd00a165627a7a72305820f86ff341f0dff29df244305f8aa88abaf10e3a0719fa6ea1dcdd01b8b7d750970029'
+} as const
+
 export const baycContractConfig = {
   address: '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
   abi: [

--- a/src/actions/wallet/deployContract.test.ts
+++ b/src/actions/wallet/deployContract.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { baycContractConfig } from '../../_test/abis.js'
+import { baycContractConfig, payableContractConfig  } from '../../_test/abis.js'
 import { accounts } from '../../_test/constants.js'
 import {
   testClient,
@@ -10,6 +10,7 @@ import {
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
+import { getBalance } from '../public/getBalance.js'
 
 import { deployContract } from './deployContract.js'
 
@@ -52,4 +53,24 @@ test('no funds', async () => {
     address: accounts[0].address,
     value: parseEther('10000'),
   })
+})
+
+test('send value to contract', async () => {
+  await setBalance(testClient, {
+    address: accounts[0].address,
+    value: parseEther('2'),
+  })
+  
+  const hash = await deployContract(walletClient, {
+    ...payableContractConfig,
+    account: accounts[0].address,
+    value: parseEther('1')
+  })
+  expect(hash).toBeDefined()
+
+  await mine(testClient, { blocks: 1 })
+
+  expect(
+    await getBalance(testClient, { address: accounts[0].address }),
+  ).toBeLessThan(parseEther('1'))
 })

--- a/src/actions/wallet/deployContract.test.ts
+++ b/src/actions/wallet/deployContract.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest'
 
-import { baycContractConfig, payableContractConfig  } from '../../_test/abis.js'
+import { baycContractConfig, payableContractConfig } from '../../_test/abis.js'
 import { accounts } from '../../_test/constants.js'
 import {
   testClient,
@@ -8,9 +8,9 @@ import {
   walletClientWithAccount,
 } from '../../_test/utils.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
+import { getBalance } from '../public/getBalance.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { getBalance } from '../public/getBalance.js'
 
 import { deployContract } from './deployContract.js'
 
@@ -60,11 +60,11 @@ test('send value to contract', async () => {
     address: accounts[0].address,
     value: parseEther('2'),
   })
-  
+
   const hash = await deployContract(walletClient, {
     ...payableContractConfig,
     account: accounts[0].address,
-    value: parseEther('1')
+    value: parseEther('1'),
   })
   expect(hash).toBeDefined()
 

--- a/src/actions/wallet/deployContract.ts
+++ b/src/actions/wallet/deployContract.ts
@@ -22,7 +22,7 @@ export type DeployContractParameters<
   TChainOverride extends Chain | undefined = undefined,
 > = UnionOmit<
   SendTransactionParameters<TChain, TAccount, TChainOverride>,
-  'accessList' | 'chain' | 'to' | 'data' | 'value'
+  'accessList' | 'chain' | 'to' | 'data'
 > & {
   abi: Narrow<TAbi>
   bytecode: Hex


### PR DESCRIPTION
This allows having a value in the parameters of deployContract function.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Add ability to send value to a contract when deploying it.

### Detailed summary:
- Added the ability to pass a `value` parameter to the `deployContract` function in the `wallet/deployContract.ts` file.
- Updated the `SendTransactionParameters` type in the `deployContract.ts` file to include the `value` parameter.
- Added a new test in the `deployContract.test.ts` file to test sending value to a contract.
- Imported the `payableContractConfig` object in the `deployContract.test.ts` file.
- Imported the `getBalance` function in the `deployContract.test.ts` file.
- Updated the test to set the balance of the test client's account.
- Updated the test to deploy the contract with a specified value.
- Added an assertion to check that the balance of the test client's account is less than the specified value after deploying the contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->