### PR TITLE
feat: narrow return types for actions that include `blockTag` or `includeTransactions`

### DIFF
--- a/.changeset/bright-jobs-boil.md
+++ b/.changeset/bright-jobs-boil.md
@@ -1,0 +1,41 @@
+---
+"viem": minor
+---
+
+Narrowed `getBlock`, `watchBlocks`, `getFilterChanges`, `getFilterLogs` & `getLogs` return types for when `blockTag` or `includeTransactions` is provided.
+
+- When `blockTag !== 'pending'`, the return type will now include some non-nullish properties if it were dependent on pending blocks. Example: For `getBlock`, the `block.number` type is now non-nullish since `blockTag !== 'pending'`.
+- On the other hand, when `blockTag: 'pending'`, some properties will be nullish. Example: For `getBlock`, the `block.number` type is now `null` since `blockTag === 'pending'`.
+- When `includeTransactions` is provided, the return type of will narrow the `transactions` property type. Example: `block.transactions` will be `Transaction[]` when `includeTransactions: true` instead of `Hash[] | Transaction[]`.
+
+TLDR;
+
+```ts
+// Before
+const block = publicClient.getBlock({ includeTransactions: true })
+block.transactions
+//    ^? Hash[] | Transaction[]
+block.transactions[0].blockNumber
+//                    ^? bigint | null
+
+// After
+const block = publicClient.getBlock({ includeTransactions: true })
+block.transactions
+//    ^? Transaction[]
+block.transactions[0].blockNumber
+//                    ^? bigint
+
+// Before
+const block = publicClient.getBlock({ blockTag: 'pending', includeTransactions: true })
+block.number
+//    ^? number | null
+block.transactions[0].blockNumber
+//                    ^? bigint | null
+
+// After
+const block = publicClient.getBlock({ blockTag: 'pending', includeTransactions: true })
+block.number
+//    ^? null
+block.transactions[0].blockNumber
+//                    ^? null
+```

--- a/.changeset/brown-sheep-visit.md
+++ b/.changeset/brown-sheep-visit.md
@@ -1,0 +1,19 @@
+---
+"viem": minor
+---
+
+**Type Change**: `TPending` has been added to slot 2 of the `Log` generic.
+
+```diff
+type Log<
+  TQuantity = bigint,
+  TIndex = number,
++ TPending extends boolean = boolean,
+  TAbiEvent extends AbiEvent | undefined = undefined,
+  TStrict extends boolean | undefined = undefined,
+  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
+  TEventName extends string | undefined = TAbiEvent extends AbiEvent
+    ? TAbiEvent['name']
+    : undefined,
+>
+```

--- a/.changeset/brown-sheep-visit.md
+++ b/.changeset/brown-sheep-visit.md
@@ -2,7 +2,7 @@
 "viem": minor
 ---
 
-**Type Change**: `TPending` has been added to slot 2 of the `Log` generic.
+**Type Change**: `TPending` has been added to slot 2 of the `Log` generics.
 
 ```diff
 type Log<

--- a/.changeset/wicked-bananas-cover.md
+++ b/.changeset/wicked-bananas-cover.md
@@ -2,7 +2,7 @@
 "viem": minor
 ---
 
-**Type Change**: `TIncludeTransactions` & `TBlockTag` has been added to slot 1 & 2 of the `Block` generic.
+**Type Change**: `TIncludeTransactions` & `TBlockTag` has been added to slot 1 & 2 of the `Block` generics.
 
 ```diff
 type Block<

--- a/.changeset/wicked-bananas-cover.md
+++ b/.changeset/wicked-bananas-cover.md
@@ -1,0 +1,18 @@
+---
+"viem": minor
+---
+
+**Type Change**: `TIncludeTransactions` & `TBlockTag` has been added to slot 1 & 2 of the `Block` generic.
+
+```diff
+type Block<
+  TQuantity = bigint,
++ TIncludeTransactions extends boolean = boolean,
++ TBlockTag extends BlockTag = BlockTag,
+  TTransaction = Transaction<
+    bigint,
+    number,
+    TBlockTag extends 'pending' ? true : false
+  >,
+>
+```

--- a/src/actions/public/createContractEventFilter.test-d.ts
+++ b/src/actions/public/createContractEventFilter.test-d.ts
@@ -1,0 +1,26 @@
+import { usdcContractConfig } from '../../_test/abis.js'
+import { publicClient } from '../../_test/utils.js'
+import { createContractEventFilter } from './createContractEventFilter.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('fromBlock/toBlock', async () => {
+  const filter = await createContractEventFilter(publicClient, {
+    abi: usdcContractConfig.abi,
+  })
+  expectTypeOf(filter.fromBlock).toBeUndefined()
+  expectTypeOf(filter.toBlock).toBeUndefined()
+
+  const filter_fromBlock = await createContractEventFilter(publicClient, {
+    abi: usdcContractConfig.abi,
+    fromBlock: 69n,
+  })
+  expectTypeOf(filter_fromBlock.fromBlock).toMatchTypeOf<69n | undefined>()
+  expectTypeOf(filter_fromBlock.toBlock).toBeUndefined()
+
+  const filter_toBlock = await createContractEventFilter(publicClient, {
+    abi: usdcContractConfig.abi,
+    toBlock: 69n,
+  })
+  expectTypeOf(filter_toBlock.toBlock).toMatchTypeOf<69n | undefined>()
+  expectTypeOf(filter_toBlock.fromBlock).toBeUndefined()
+})

--- a/src/actions/public/createEventFilter.test-d.ts
+++ b/src/actions/public/createEventFilter.test-d.ts
@@ -1,0 +1,21 @@
+import { publicClient } from '../../_test/utils.js'
+import { createEventFilter } from './createEventFilter.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('fromBlock/toBlock', async () => {
+  const filter = await createEventFilter(publicClient)
+  expectTypeOf(filter.fromBlock).toBeUndefined()
+  expectTypeOf(filter.toBlock).toBeUndefined()
+
+  const filter_fromBlock = await createEventFilter(publicClient, {
+    fromBlock: 69n,
+  })
+  expectTypeOf(filter_fromBlock.fromBlock).toMatchTypeOf<69n | undefined>()
+  expectTypeOf(filter_fromBlock.toBlock).toBeUndefined()
+
+  const filter_toBlock = await createEventFilter(publicClient, {
+    toBlock: 69n,
+  })
+  expectTypeOf(filter_toBlock.toBlock).toMatchTypeOf<69n | undefined>()
+  expectTypeOf(filter_toBlock.fromBlock).toBeUndefined()
+})

--- a/src/actions/public/getBlock.test-d.ts
+++ b/src/actions/public/getBlock.test-d.ts
@@ -1,0 +1,40 @@
+import { publicClient } from '../../_test/utils.js'
+import type { Hash, Hex } from '../../types/misc.js'
+import type { Transaction } from '../../types/transaction.js'
+import { getBlock } from './getBlock.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('includeTransactions = false', async () => {
+  const block_1 = await getBlock(publicClient)
+  expectTypeOf(block_1.transactions).toEqualTypeOf<Hash[]>()
+
+  const block_2 = await getBlock(publicClient, { includeTransactions: false })
+  expectTypeOf(block_2.transactions).toEqualTypeOf<Hash[]>()
+})
+
+test('includeTransactions = true', async () => {
+  const block = await getBlock(publicClient, { includeTransactions: true })
+  expectTypeOf(block.transactions).toEqualTypeOf<
+    Transaction<bigint, number, false>[]
+  >()
+})
+
+test('blockTag = "latest" & includeTransactions = true', async () => {
+  const block = await getBlock(publicClient, { includeTransactions: true })
+  expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<Hex>()
+  expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<number>()
+})
+
+test('blockTag = "pending" & includeTransactions = true', async () => {
+  const block = await getBlock(publicClient, {
+    blockTag: 'pending',
+    includeTransactions: true,
+  })
+  expectTypeOf(block.transactions).toEqualTypeOf<
+    Transaction<bigint, number, true>[]
+  >()
+  expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<null>()
+  expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<null>()
+  expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<null>()
+})

--- a/src/actions/public/getBlock.test-d.ts
+++ b/src/actions/public/getBlock.test-d.ts
@@ -1,8 +1,11 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
 import { publicClient } from '../../_test/utils.js'
+import { optimism } from '../../chains/index.js'
+import { createPublicClient, http } from '../../index.js'
 import type { Hash, Hex } from '../../types/misc.js'
 import type { Transaction } from '../../types/transaction.js'
 import { getBlock } from './getBlock.js'
-import { expectTypeOf, test } from 'vitest'
 
 test('includeTransactions = false', async () => {
   const block_1 = await getBlock(publicClient)
@@ -21,6 +24,10 @@ test('includeTransactions = true', async () => {
 
 test('blockTag = "latest" & includeTransactions = true', async () => {
   const block = await getBlock(publicClient, { includeTransactions: true })
+  expectTypeOf(block.hash).toEqualTypeOf<Hex>()
+  expectTypeOf(block.logsBloom).toEqualTypeOf<Hex>()
+  expectTypeOf(block.nonce).toEqualTypeOf<Hex>()
+  expectTypeOf(block.number).toEqualTypeOf<bigint>()
   expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<Hex>()
   expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<bigint>()
   expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<number>()
@@ -31,10 +38,46 @@ test('blockTag = "pending" & includeTransactions = true', async () => {
     blockTag: 'pending',
     includeTransactions: true,
   })
+  expectTypeOf(block.hash).toEqualTypeOf<null>()
+  expectTypeOf(block.logsBloom).toEqualTypeOf<null>()
+  expectTypeOf(block.nonce).toEqualTypeOf<null>()
+  expectTypeOf(block.number).toEqualTypeOf<null>()
   expectTypeOf(block.transactions).toEqualTypeOf<
     Transaction<bigint, number, true>[]
   >()
   expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<null>()
   expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<null>()
   expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<null>()
+})
+
+describe('chain w/ formatter', () => {
+  const client = createPublicClient({
+    chain: optimism,
+    transport: http(),
+  })
+
+  test('blockTag = "latest" & includeTransactions = true', async () => {
+    const block = await getBlock(client, { includeTransactions: true })
+    expectTypeOf(block.hash).toEqualTypeOf<Hex>()
+    expectTypeOf(block.logsBloom).toEqualTypeOf<Hex>()
+    expectTypeOf(block.nonce).toEqualTypeOf<Hex>()
+    expectTypeOf(block.number).toEqualTypeOf<bigint>()
+    expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('blockTag = "pending" & includeTransactions = true', async () => {
+    const block = await getBlock(client, {
+      blockTag: 'pending',
+      includeTransactions: true,
+    })
+    expectTypeOf(block.hash).toEqualTypeOf<null>()
+    expectTypeOf(block.logsBloom).toEqualTypeOf<null>()
+    expectTypeOf(block.nonce).toEqualTypeOf<null>()
+    expectTypeOf(block.number).toEqualTypeOf<null>()
+    expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<null>()
+    expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(block.transactions[0].transactionIndex).toEqualTypeOf<null>()
+  })
 })

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -12,9 +12,12 @@ import {
   formatBlock,
 } from '../../utils/formatters/block.js'
 
-export type GetBlockParameters = {
+export type GetBlockParameters<
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
+> = {
   /** Whether or not to include transaction data in the response. */
-  includeTransactions?: boolean
+  includeTransactions?: TIncludeTransactions
 } & (
   | {
       /** Hash of the block. */
@@ -35,13 +38,15 @@ export type GetBlockParameters = {
        * The block tag.
        * @default 'latest'
        */
-      blockTag?: BlockTag
+      blockTag?: TBlockTag
     }
 )
 
 export type GetBlockReturnType<
   TChain extends Chain | undefined = Chain | undefined,
-> = FormattedBlock<TChain>
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
+> = FormattedBlock<TChain, TIncludeTransactions, TBlockTag>
 
 /**
  * Returns information about a block at a block number, hash, or tag.
@@ -70,15 +75,20 @@ export type GetBlockReturnType<
 export async function getBlock<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
 >(
   client: Client<Transport, TChain, TAccount>,
   {
     blockHash,
     blockNumber,
-    blockTag = 'latest',
-    includeTransactions = false,
-  }: GetBlockParameters = {},
-): Promise<GetBlockReturnType<TChain>> {
+    blockTag: blockTag_,
+    includeTransactions: includeTransactions_,
+  }: GetBlockParameters<TBlockTag, TIncludeTransactions> = {},
+): Promise<GetBlockReturnType<TChain, TBlockTag, TIncludeTransactions>> {
+  const blockTag = blockTag_ ?? 'latest'
+  const includeTransactions = includeTransactions_ ?? false
+
   const blockNumberHex =
     blockNumber !== undefined ? numberToHex(blockNumber) : undefined
 

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -13,8 +13,8 @@ import {
 } from '../../utils/formatters/block.js'
 
 export type GetBlockParameters<
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 > = {
   /** Whether or not to include transaction data in the response. */
   includeTransactions?: TIncludeTransactions
@@ -44,8 +44,8 @@ export type GetBlockParameters<
 
 export type GetBlockReturnType<
   TChain extends Chain | undefined = Chain | undefined,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 > = FormattedBlock<TChain, TIncludeTransactions, TBlockTag>
 
 /**
@@ -75,8 +75,8 @@ export type GetBlockReturnType<
 export async function getBlock<
   TChain extends Chain | undefined,
   TAccount extends Account | undefined,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 >(
   client: Client<Transport, TChain, TAccount>,
   {
@@ -84,8 +84,8 @@ export async function getBlock<
     blockNumber,
     blockTag: blockTag_,
     includeTransactions: includeTransactions_,
-  }: GetBlockParameters<TBlockTag, TIncludeTransactions> = {},
-): Promise<GetBlockReturnType<TChain, TBlockTag, TIncludeTransactions>> {
+  }: GetBlockParameters<TIncludeTransactions, TBlockTag> = {},
+): Promise<GetBlockReturnType<TChain, TIncludeTransactions, TBlockTag>> {
   const blockTag = blockTag_ ?? 'latest'
   const includeTransactions = includeTransactions_ ?? false
 

--- a/src/actions/public/getBlock.ts
+++ b/src/actions/public/getBlock.ts
@@ -38,7 +38,7 @@ export type GetBlockParameters<
        * The block tag.
        * @default 'latest'
        */
-      blockTag?: TBlockTag
+      blockTag?: TBlockTag | BlockTag
     }
 )
 

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -4,6 +4,7 @@ import { describe, expectTypeOf, test } from 'vitest'
 import { usdcContractConfig } from '../../_test/abis.js'
 import { publicClient } from '../../_test/utils.js'
 import type { Log } from '../../types/log.js'
+import type { Hash, Hex } from '../../types/misc.js'
 import { createContractEventFilter } from './createContractEventFilter.js'
 import { createEventFilter } from './createEventFilter.js'
 import { getFilterChanges } from './getFilterChanges.js'
@@ -19,6 +20,63 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0]).not.toHaveProperty('eventName')
     expectTypeOf(logs[0]).not.toHaveProperty('args')
+  })
+
+  test('non-pending logs', async () => {
+    const filter = await createEventFilter(publicClient)
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(logs[0].blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(logs[0].logIndex).toEqualTypeOf<number>()
+    expectTypeOf(logs[0].transactionHash).toEqualTypeOf<Hash>()
+    expectTypeOf(logs[0].transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('pending logs', async () => {
+    const filter_fromPending = await createEventFilter(publicClient, {
+      fromBlock: 'pending',
+    })
+    const logs_fromPending = await getFilterChanges(publicClient, {
+      filter: filter_fromPending,
+    })
+    expectTypeOf(logs_fromPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_fromPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_fromPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(
+      logs_fromPending[0].transactionHash,
+    ).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_fromPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_toPending = await createEventFilter(publicClient, {
+      toBlock: 'pending',
+    })
+    const logs_toPending = await getFilterChanges(publicClient, {
+      filter: filter_toPending,
+    })
+    expectTypeOf(logs_toPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_toPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_toPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(logs_toPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_toPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_bothPending = await createEventFilter(publicClient, {
+      fromBlock: 'pending',
+      toBlock: 'pending',
+    })
+    const logs_bothPending = await getFilterChanges(publicClient, {
+      filter: filter_bothPending,
+    })
+    expectTypeOf(logs_bothPending[0].blockHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].logIndex).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionIndex).toEqualTypeOf<null>()
   })
 
   test('args: event: defined inline', async () => {
@@ -300,7 +358,7 @@ describe('createContractEventFilter', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, false, typeof abi>[]
+      Log<bigint, number, false, undefined, false, typeof abi>[]
     >()
     expectTypeOf(logs[0].topics).toEqualTypeOf<
       | [`0x${string}`, `0x${string}`, `0x${string}`]
@@ -328,6 +386,68 @@ describe('createContractEventFilter', () => {
           bar?: bigint
         }
     >()
+  })
+
+  test('non-pending logs', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(logs[0].blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(logs[0].logIndex).toEqualTypeOf<number>()
+    expectTypeOf(logs[0].transactionHash).toEqualTypeOf<Hash>()
+    expectTypeOf(logs[0].transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('pending logs', async () => {
+    const filter_fromPending = await createContractEventFilter(publicClient, {
+      abi,
+      fromBlock: 'pending',
+    })
+    const logs_fromPending = await getFilterChanges(publicClient, {
+      filter: filter_fromPending,
+    })
+    expectTypeOf(logs_fromPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_fromPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_fromPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(
+      logs_fromPending[0].transactionHash,
+    ).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_fromPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_toPending = await createContractEventFilter(publicClient, {
+      abi,
+      toBlock: 'pending',
+    })
+    const logs_toPending = await getFilterChanges(publicClient, {
+      filter: filter_toPending,
+    })
+    expectTypeOf(logs_toPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_toPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_toPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(logs_toPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_toPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_bothPending = await createContractEventFilter(publicClient, {
+      abi,
+      fromBlock: 'pending',
+      toBlock: 'pending',
+    })
+    const logs_bothPending = await getFilterChanges(publicClient, {
+      filter: filter_bothPending,
+    })
+    expectTypeOf(logs_bothPending[0].blockHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].logIndex).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionIndex).toEqualTypeOf<null>()
   })
 
   test('args: eventName', async () => {

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -210,7 +210,14 @@ describe('contract events', () => {
     })
 
     assertType<
-      Log<bigint, number, undefined, false, typeof usdcContractConfig.abi>[]
+      Log<
+        bigint,
+        number,
+        boolean,
+        undefined,
+        false,
+        typeof usdcContractConfig.abi
+      >[]
     >(logs)
     expect(logs.length).toBe(3)
     expect(logs[0].args).toEqual({
@@ -264,6 +271,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -298,6 +306,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -321,6 +330,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         true,
         typeof usdcContractConfig.abi,
@@ -364,6 +374,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -413,6 +424,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -468,6 +480,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -517,6 +530,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -689,7 +703,7 @@ describe('events', () => {
     let logs = await getFilterChanges(publicClient, { filter })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, typeof event.default>[]
+      Log<bigint, number, false, typeof event.default>[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
@@ -741,7 +755,7 @@ describe('events', () => {
     })
 
     let logs = await getFilterChanges(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default>[]>(logs)
     expect(logs.length).toBe(1056)
     expect(logs[0].args).toEqual({
       from: '0x00000000003b3cc22aF3aE1EAc0440BcEe416B40',
@@ -764,7 +778,7 @@ describe('events', () => {
 
     let logs = await getFilterChanges(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
 
     expect(logs.length).toBe(784)
 
@@ -794,7 +808,9 @@ describe('events', () => {
 
     let logs = await getFilterChanges(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, false>[]>(
+      logs,
+    )
 
     expect(logs.length).toBe(1056)
 
@@ -824,7 +840,7 @@ describe('events', () => {
     })
 
     let logs = await getFilterChanges(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
 
     expect(logs.length).toBe(784)
 
@@ -851,7 +867,9 @@ describe('events', () => {
     })
 
     let logs = await getFilterChanges(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, false>[]>(
+      logs,
+    )
 
     expect(logs.length).toBe(1056)
 

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -3,6 +3,7 @@ import { describe, expectTypeOf, test } from 'vitest'
 import { usdcContractConfig } from '../../_test/abis.js'
 import { publicClient } from '../../_test/utils.js'
 import type { Log } from '../../types/log.js'
+import type { Hash, Hex } from '../../types/misc.js'
 import { createContractEventFilter } from './createContractEventFilter.js'
 import { createEventFilter } from './createEventFilter.js'
 import { getFilterLogs } from './getFilterLogs.js'
@@ -19,6 +20,63 @@ describe('createEventFilter', () => {
     >()
     expectTypeOf(logs[0]).not.toHaveProperty('eventName')
     expectTypeOf(logs[0]).not.toHaveProperty('args')
+  })
+
+  test('non-pending logs', async () => {
+    const filter = await createEventFilter(publicClient)
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(logs[0].blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(logs[0].logIndex).toEqualTypeOf<number>()
+    expectTypeOf(logs[0].transactionHash).toEqualTypeOf<Hash>()
+    expectTypeOf(logs[0].transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('pending logs', async () => {
+    const filter_fromPending = await createEventFilter(publicClient, {
+      fromBlock: 'pending',
+    })
+    const logs_fromPending = await getFilterLogs(publicClient, {
+      filter: filter_fromPending,
+    })
+    expectTypeOf(logs_fromPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_fromPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_fromPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(
+      logs_fromPending[0].transactionHash,
+    ).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_fromPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_toPending = await createEventFilter(publicClient, {
+      toBlock: 'pending',
+    })
+    const logs_toPending = await getFilterLogs(publicClient, {
+      filter: filter_toPending,
+    })
+    expectTypeOf(logs_toPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_toPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_toPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(logs_toPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_toPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_bothPending = await createEventFilter(publicClient, {
+      fromBlock: 'pending',
+      toBlock: 'pending',
+    })
+    const logs_bothPending = await getFilterLogs(publicClient, {
+      filter: filter_bothPending,
+    })
+    expectTypeOf(logs_bothPending[0].blockHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].logIndex).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionIndex).toEqualTypeOf<null>()
   })
 
   test('args: event: defined inline', async () => {
@@ -300,7 +358,7 @@ describe('createContractEventFilter', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, false, typeof abi>[]
+      Log<bigint, number, false, undefined, false, typeof abi>[]
     >()
     expectTypeOf(logs[0].topics).toEqualTypeOf<
       | [`0x${string}`, `0x${string}`, `0x${string}`]
@@ -328,6 +386,68 @@ describe('createContractEventFilter', () => {
           bar?: bigint
         }
     >()
+  })
+
+  test('non-pending logs', async () => {
+    const filter = await createContractEventFilter(publicClient, {
+      abi,
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(logs[0].blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(logs[0].logIndex).toEqualTypeOf<number>()
+    expectTypeOf(logs[0].transactionHash).toEqualTypeOf<Hash>()
+    expectTypeOf(logs[0].transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('pending logs', async () => {
+    const filter_fromPending = await createContractEventFilter(publicClient, {
+      abi,
+      fromBlock: 'pending',
+    })
+    const logs_fromPending = await getFilterLogs(publicClient, {
+      filter: filter_fromPending,
+    })
+    expectTypeOf(logs_fromPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_fromPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_fromPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(
+      logs_fromPending[0].transactionHash,
+    ).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_fromPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_toPending = await createContractEventFilter(publicClient, {
+      abi,
+      toBlock: 'pending',
+    })
+    const logs_toPending = await getFilterLogs(publicClient, {
+      filter: filter_toPending,
+    })
+    expectTypeOf(logs_toPending[0].blockHash).toEqualTypeOf<Hex | null>()
+    expectTypeOf(logs_toPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+    expectTypeOf(logs_toPending[0].logIndex).toEqualTypeOf<number | null>()
+    expectTypeOf(logs_toPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+    expectTypeOf(logs_toPending[0].transactionIndex).toEqualTypeOf<
+      number | null
+    >()
+
+    const filter_bothPending = await createContractEventFilter(publicClient, {
+      abi,
+      fromBlock: 'pending',
+      toBlock: 'pending',
+    })
+    const logs_bothPending = await getFilterLogs(publicClient, {
+      filter: filter_bothPending,
+    })
+    expectTypeOf(logs_bothPending[0].blockHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].logIndex).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionHash).toEqualTypeOf<null>()
+    expectTypeOf(logs_bothPending[0].transactionIndex).toEqualTypeOf<null>()
   })
 
   test('args: eventName', async () => {

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -155,7 +155,14 @@ describe('contract events', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, undefined, false, typeof usdcContractConfig.abi>[]
+      Log<
+        bigint,
+        number,
+        false,
+        undefined,
+        false,
+        typeof usdcContractConfig.abi
+      >[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<
@@ -223,6 +230,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -257,6 +265,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -280,6 +289,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         true,
         typeof usdcContractConfig.abi,
@@ -323,6 +333,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -372,6 +383,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -427,6 +439,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -476,6 +489,7 @@ describe('contract events', () => {
       Log<
         bigint,
         number,
+        boolean,
         undefined,
         false,
         typeof usdcContractConfig.abi,
@@ -631,7 +645,7 @@ describe('raw events', () => {
     await mine(testClient, { blocks: 1 })
 
     const logs = await getFilterLogs(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default>[]>(logs)
     expect(logs.length).toBe(2)
     expect(logs[0].args).toEqual({
       from: getAddress(address.vitalik),
@@ -655,7 +669,7 @@ describe('raw events', () => {
     })
 
     const logs = await getFilterLogs(publicClient, { filter })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default>[]>(logs)
     expect(logs.length).toBe(1056)
   })
 
@@ -669,7 +683,7 @@ describe('raw events', () => {
 
     const logs = await getFilterLogs(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
 
     expect(logs.length).toBe(784)
 
@@ -696,7 +710,9 @@ describe('raw events', () => {
 
     const logs = await getFilterLogs(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, false>[]>(
+      logs,
+    )
 
     expect(logs.length).toBe(1056)
 
@@ -724,7 +740,7 @@ describe('raw events', () => {
 
     const logs = await getFilterLogs(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
 
     expect(logs.length).toBe(784)
 
@@ -749,7 +765,9 @@ describe('raw events', () => {
 
     const logs = await getFilterLogs(publicClient, { filter })
 
-    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, false>[]>(
+      logs,
+    )
 
     expect(logs.length).toBe(1056)
 

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -6,6 +6,7 @@ import {
   DecodeLogDataMismatch,
   DecodeLogTopicsMismatch,
 } from '../../errors/abi.js'
+import type { BlockNumber, BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type { Filter } from '../../types/filter.js'
 import type { Log } from '../../types/log.js'
@@ -16,19 +17,26 @@ export type GetFilterLogsParameters<
   TAbi extends Abi | readonly unknown[] = Abi,
   TEventName extends string | undefined = string,
   TStrict extends boolean | undefined = undefined,
+  TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+  TToBlock extends BlockNumber | BlockTag | undefined = undefined,
 > = {
-  filter: Filter<'event', TAbi, TEventName, any, TStrict>
+  filter: Filter<'event', TAbi, TEventName, any, TStrict, TFromBlock, TToBlock>
 }
 export type GetFilterLogsReturnType<
   TAbi extends Abi | readonly unknown[] = Abi,
   TEventName extends string | undefined = string,
   TStrict extends boolean | undefined = undefined,
+  TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+  TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   _AbiEvent extends AbiEvent | undefined = TAbi extends Abi
     ? TEventName extends string
       ? ExtractAbiEvent<TAbi, TEventName>
       : undefined
     : undefined,
-> = Log<bigint, number, _AbiEvent, TStrict, TAbi, TEventName>[]
+  _Pending extends boolean =
+    | (TFromBlock extends 'pending' ? true : false)
+    | (TToBlock extends 'pending' ? true : false),
+> = Log<bigint, number, _Pending, _AbiEvent, TStrict, TAbi, TEventName>[]
 
 /**
  * Returns a list of event logs since the filter was created.
@@ -62,10 +70,16 @@ export async function getFilterLogs<
   TAbi extends Abi | readonly unknown[],
   TEventName extends string | undefined,
   TStrict extends boolean | undefined = undefined,
+  TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+  TToBlock extends BlockNumber | BlockTag | undefined = undefined,
 >(
   _client: Client<Transport, TChain>,
-  { filter }: GetFilterLogsParameters<TAbi, TEventName, TStrict>,
-): Promise<GetFilterLogsReturnType<TAbi, TEventName, TStrict>> {
+  {
+    filter,
+  }: GetFilterLogsParameters<TAbi, TEventName, TStrict, TFromBlock, TToBlock>,
+): Promise<
+  GetFilterLogsReturnType<TAbi, TEventName, TStrict, TFromBlock, TToBlock>
+> {
   const strict = filter.strict ?? false
 
   const logs = await filter.request({
@@ -105,6 +119,8 @@ export async function getFilterLogs<
     .filter(Boolean) as unknown as GetFilterLogsReturnType<
     TAbi,
     TEventName,
-    TStrict
+    TStrict,
+    TFromBlock,
+    TToBlock
   >
 }

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -3,6 +3,7 @@ import { expectTypeOf, test } from 'vitest'
 
 import { publicClient } from '../../_test/utils.js'
 
+import type { Hash, Hex } from '../../types/misc.js'
 import { getLogs } from './getLogs.js'
 
 test('event: const assertion', async () => {
@@ -225,4 +226,45 @@ test('strict: unnamed', async () => {
   expectTypeOf(logs[0]['args']).toEqualTypeOf<
     readonly [`0x${string}`, `0x${string}`, bigint, string, string]
   >()
+})
+
+test('non-pending logs', async () => {
+  const logs = await getLogs(publicClient)
+  expectTypeOf(logs[0].blockHash).toEqualTypeOf<Hex>()
+  expectTypeOf(logs[0].blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(logs[0].logIndex).toEqualTypeOf<number>()
+  expectTypeOf(logs[0].transactionHash).toEqualTypeOf<Hash>()
+  expectTypeOf(logs[0].transactionIndex).toEqualTypeOf<number>()
+})
+
+test('pending logs', async () => {
+  const logs_fromPending = await getLogs(publicClient, { fromBlock: 'pending' })
+  expectTypeOf(logs_fromPending[0].blockHash).toEqualTypeOf<Hex | null>()
+  expectTypeOf(logs_fromPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+  expectTypeOf(logs_fromPending[0].logIndex).toEqualTypeOf<number | null>()
+  expectTypeOf(logs_fromPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+  expectTypeOf(logs_fromPending[0].transactionIndex).toEqualTypeOf<
+    number | null
+  >()
+
+  const logs_toPending = await getLogs(publicClient, {
+    toBlock: 'pending',
+  })
+  expectTypeOf(logs_toPending[0].blockHash).toEqualTypeOf<Hex | null>()
+  expectTypeOf(logs_toPending[0].blockNumber).toEqualTypeOf<bigint | null>()
+  expectTypeOf(logs_toPending[0].logIndex).toEqualTypeOf<number | null>()
+  expectTypeOf(logs_toPending[0].transactionHash).toEqualTypeOf<Hash | null>()
+  expectTypeOf(logs_toPending[0].transactionIndex).toEqualTypeOf<
+    number | null
+  >()
+
+  const logs_bothPending = await getLogs(publicClient, {
+    fromBlock: 'pending',
+    toBlock: 'pending',
+  })
+  expectTypeOf(logs_bothPending[0].blockHash).toEqualTypeOf<null>()
+  expectTypeOf(logs_bothPending[0].blockNumber).toEqualTypeOf<null>()
+  expectTypeOf(logs_bothPending[0].logIndex).toEqualTypeOf<null>()
+  expectTypeOf(logs_bothPending[0].transactionHash).toEqualTypeOf<null>()
+  expectTypeOf(logs_bothPending[0].transactionIndex).toEqualTypeOf<null>()
 })

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -161,7 +161,7 @@ describe('events', () => {
     })
 
     expectTypeOf(logs).toEqualTypeOf<
-      Log<bigint, number, typeof event.default>[]
+      Log<bigint, number, false, typeof event.default>[]
     >()
     expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer'>()
     expectTypeOf(logs[0].args).toEqualTypeOf<{
@@ -191,7 +191,7 @@ describe('events', () => {
       fromBlock: forkBlockNumber - 5n,
       toBlock: forkBlockNumber,
     })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default>[]>(logs)
     expect(logs.length).toBe(1056)
     expect(logs[0].eventName).toEqual('Transfer')
     expect(logs[0].args).toEqual({
@@ -209,7 +209,7 @@ describe('events', () => {
       event: event.default,
       blockHash: block.hash!,
     })
-    assertType<Log<bigint, number, typeof event.default>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default>[]>(logs)
     expect(logs.length).toBe(118)
     expect(logs[0].eventName).toEqual('Transfer')
     expect(logs[0].args).toEqual({
@@ -227,7 +227,7 @@ describe('events', () => {
       strict: true,
     })
 
-    assertType<Log<bigint, number, typeof event.default, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
     expect(logs.length).toBe(784)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<{
@@ -252,7 +252,9 @@ describe('events', () => {
       toBlock: forkBlockNumber,
     })
 
-    assertType<Log<bigint, number, typeof event.default, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.default, false>[]>(
+      logs,
+    )
     expect(logs.length).toBe(1056)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<{
@@ -278,7 +280,7 @@ describe('events', () => {
       strict: true,
     })
 
-    assertType<Log<bigint, number, typeof event.unnamed, true>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
     expect(logs.length).toBe(784)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<
@@ -301,7 +303,9 @@ describe('events', () => {
       toBlock: forkBlockNumber,
     })
 
-    assertType<Log<bigint, number, typeof event.unnamed, false>[]>(logs)
+    assertType<Log<bigint, number, boolean, typeof event.unnamed, false>[]>(
+      logs,
+    )
     expect(logs.length).toBe(1056)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<

--- a/src/actions/public/getTransaction.test-d.ts
+++ b/src/actions/public/getTransaction.test-d.ts
@@ -1,0 +1,23 @@
+import { publicClient } from '../../_test/utils.js'
+import type { Hex } from '../../types/misc.js'
+import { getTransaction } from './getTransaction.js'
+import { expectTypeOf, test } from 'vitest'
+
+test('blockTag = "latest"', async () => {
+  const transaction = await getTransaction(publicClient, {
+    hash: '0x',
+  })
+  expectTypeOf(transaction.blockHash).toEqualTypeOf<Hex>()
+  expectTypeOf(transaction.blockNumber).toEqualTypeOf<bigint>()
+  expectTypeOf(transaction.transactionIndex).toEqualTypeOf<number>()
+})
+
+test('blockTag = "pending"', async () => {
+  const transaction = await getTransaction(publicClient, {
+    blockTag: 'pending',
+    index: 0,
+  })
+  expectTypeOf(transaction.blockHash).toEqualTypeOf<null>()
+  expectTypeOf(transaction.blockNumber).toEqualTypeOf<null>()
+  expectTypeOf(transaction.transactionIndex).toEqualTypeOf<null>()
+})

--- a/src/actions/public/getTransaction.test-d.ts
+++ b/src/actions/public/getTransaction.test-d.ts
@@ -1,7 +1,11 @@
+import { describe, expectTypeOf, test } from 'vitest'
+
 import { publicClient } from '../../_test/utils.js'
+import { optimism } from '../../chains/index.js'
+import { createPublicClient } from '../../clients/createPublicClient.js'
+import { http } from '../../clients/transports/http.js'
 import type { Hex } from '../../types/misc.js'
 import { getTransaction } from './getTransaction.js'
-import { expectTypeOf, test } from 'vitest'
 
 test('blockTag = "latest"', async () => {
   const transaction = await getTransaction(publicClient, {
@@ -20,4 +24,30 @@ test('blockTag = "pending"', async () => {
   expectTypeOf(transaction.blockHash).toEqualTypeOf<null>()
   expectTypeOf(transaction.blockNumber).toEqualTypeOf<null>()
   expectTypeOf(transaction.transactionIndex).toEqualTypeOf<null>()
+})
+
+describe('chain w/ formatter', () => {
+  const client = createPublicClient({
+    chain: optimism,
+    transport: http(),
+  })
+
+  test('blockTag = "latest"', async () => {
+    const transaction = await getTransaction(client, {
+      hash: '0x',
+    })
+    expectTypeOf(transaction.blockHash).toEqualTypeOf<Hex>()
+    expectTypeOf(transaction.blockNumber).toEqualTypeOf<bigint>()
+    expectTypeOf(transaction.transactionIndex).toEqualTypeOf<number>()
+  })
+
+  test('blockTag = "pending"', async () => {
+    const transaction = await getTransaction(client, {
+      blockTag: 'pending',
+      index: 0,
+    })
+    expectTypeOf(transaction.blockHash).toEqualTypeOf<null>()
+    expectTypeOf(transaction.blockNumber).toEqualTypeOf<null>()
+    expectTypeOf(transaction.transactionIndex).toEqualTypeOf<null>()
+  })
 })

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -11,7 +11,7 @@ import {
   formatTransaction,
 } from '../../utils/formatters/transaction.js'
 
-export type GetTransactionParameters =
+export type GetTransactionParameters<TBlockTag extends BlockTag = 'latest'> =
   | {
       /** The block hash */
       blockHash: Hash
@@ -34,7 +34,7 @@ export type GetTransactionParameters =
       blockHash?: never
       blockNumber?: never
       /** The block tag. */
-      blockTag: BlockTag
+      blockTag: TBlockTag
       hash?: never
       /** The index of the transaction on the block. */
       index: number
@@ -48,8 +48,10 @@ export type GetTransactionParameters =
       index?: number
     }
 
-export type GetTransactionReturnType<TChain extends Chain | undefined = Chain> =
-  FormattedTransaction<TChain>
+export type GetTransactionReturnType<
+  TChain extends Chain | undefined = Chain,
+  TBlockTag extends BlockTag = 'latest',
+> = FormattedTransaction<TChain, TBlockTag>
 
 /**
  * Returns information about a [Transaction](https://viem.sh/docs/glossary/terms.html#transaction) given a hash or block identifier.
@@ -75,16 +77,21 @@ export type GetTransactionReturnType<TChain extends Chain | undefined = Chain> =
  *   hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
  * })
  */
-export async function getTransaction<TChain extends Chain | undefined>(
+export async function getTransaction<
+  TChain extends Chain | undefined,
+  TBlockTag extends BlockTag = 'latest',
+>(
   client: Client<Transport, TChain>,
   {
     blockHash,
     blockNumber,
-    blockTag = 'latest',
+    blockTag: blockTag_,
     hash,
     index,
-  }: GetTransactionParameters,
-): Promise<GetTransactionReturnType<TChain>> {
+  }: GetTransactionParameters<TBlockTag>,
+): Promise<GetTransactionReturnType<TChain, TBlockTag>> {
+  const blockTag = blockTag_ || 'latest'
+
   const blockNumberHex =
     blockNumber !== undefined ? numberToHex(blockNumber) : undefined
 

--- a/src/actions/public/getTransaction.ts
+++ b/src/actions/public/getTransaction.ts
@@ -34,7 +34,7 @@ export type GetTransactionParameters<TBlockTag extends BlockTag = 'latest'> =
       blockHash?: never
       blockNumber?: never
       /** The block tag. */
-      blockTag: TBlockTag
+      blockTag: TBlockTag | BlockTag
       hash?: never
       /** The index of the transaction on the block. */
       index: number

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -7,7 +7,7 @@ import {
   walletClient,
   webSocketClient,
 } from '../../_test/utils.js'
-import { celo, localhost } from '../../chains/index.js'
+import { type Chain, celo, localhost } from '../../chains/index.js'
 import {
   type PublicClient,
   createPublicClient,
@@ -33,7 +33,7 @@ describe('poll', () => {
     const prevBlocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {
       onBlock: (block, prevBlock) => {
-        blocks.push(block)
+        block.number
         prevBlock && block !== prevBlock && prevBlocks.push(prevBlock)
       },
       poll: true,
@@ -459,7 +459,10 @@ describe('poll', () => {
         .mockResolvedValueOnce({ number: null } as Block)
         .mockResolvedValueOnce({ number: null } as Block)
 
-      const blocks: [OnBlockParameter, OnBlockParameter | undefined][] = []
+      const blocks: [
+        OnBlockParameter<Chain, 'pending'>,
+        OnBlockParameter<Chain, 'pending'> | undefined,
+      ][] = []
       const unwatch = watchBlocks(publicClient, {
         pollingInterval: 100,
         poll: true,

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -33,7 +33,7 @@ describe('poll', () => {
     const prevBlocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {
       onBlock: (block, prevBlock) => {
-        block.number
+        blocks.push(block)
         prevBlock && block !== prevBlock && prevBlocks.push(prevBlock)
       },
       poll: true,

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -460,8 +460,8 @@ describe('poll', () => {
         .mockResolvedValueOnce({ number: null } as Block)
 
       const blocks: [
-        OnBlockParameter<Chain, 'pending'>,
-        OnBlockParameter<Chain, 'pending'> | undefined,
+        OnBlockParameter<Chain, boolean, 'pending'>,
+        OnBlockParameter<Chain, boolean, 'pending'> | undefined,
       ][] = []
       const unwatch = watchBlocks(publicClient, {
         pollingInterval: 100,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -10,23 +10,35 @@ import { stringify } from '../../utils/stringify.js'
 
 import { type GetBlockReturnType, getBlock } from './getBlock.js'
 
-export type OnBlockParameter<TChain extends Chain | undefined = Chain> =
-  GetBlockReturnType<TChain>
+export type OnBlockParameter<
+  TChain extends Chain | undefined = Chain,
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
+> = GetBlockReturnType<TChain, TBlockTag, TIncludeTransactions>
 
-export type OnBlock<TChain extends Chain | undefined = Chain> = (
-  block: OnBlockParameter<TChain>,
-  prevBlock: OnBlockParameter<TChain> | undefined,
+export type OnBlock<
+  TChain extends Chain | undefined = Chain,
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
+> = (
+  block: OnBlockParameter<TChain, TBlockTag, TIncludeTransactions>,
+  prevBlock:
+    | OnBlockParameter<TChain, TBlockTag, TIncludeTransactions>
+    | undefined,
 ) => void
 
-type PollOptions = {
+type PollOptions<
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
+> = {
   /** The block tag. Defaults to "latest". */
-  blockTag?: BlockTag
+  blockTag?: TBlockTag | BlockTag
   /** Whether or not to emit the missed blocks to the callback. */
   emitMissed?: boolean
   /** Whether or not to emit the block to the callback when the subscription opens. */
   emitOnBegin?: boolean
   /** Whether or not to include transaction data in the response. */
-  includeTransactions?: boolean
+  includeTransactions?: TIncludeTransactions
   /** Polling frequency (in ms). Defaults to the client's pollingInterval config. */
   pollingInterval?: number
 }
@@ -34,9 +46,11 @@ type PollOptions = {
 export type WatchBlocksParameters<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain,
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
 > = {
   /** The callback to call when a new block is received. */
-  onBlock: OnBlock<TChain>
+  onBlock: OnBlock<TChain, TBlockTag, TIncludeTransactions>
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
 } & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
@@ -50,8 +64,8 @@ export type WatchBlocksParameters<
           poll?: false
           pollingInterval?: never
         }
-      | (PollOptions & { poll?: true })
-  : PollOptions & { poll?: true })
+      | (PollOptions<TBlockTag, TIncludeTransactions> & { poll?: true })
+  : PollOptions<TBlockTag, TIncludeTransactions> & { poll?: true })
 
 export type WatchBlocksReturnType = () => void
 
@@ -83,6 +97,8 @@ export type WatchBlocksReturnType = () => void
 export function watchBlocks<
   TTransport extends Transport,
   TChain extends Chain | undefined,
+  TBlockTag extends BlockTag = 'latest',
+  TIncludeTransactions extends boolean = false,
 >(
   client: Client<TTransport, TChain>,
   {
@@ -91,13 +107,14 @@ export function watchBlocks<
     emitOnBegin = false,
     onBlock,
     onError,
-    includeTransactions = false,
+    includeTransactions: includeTransactions_,
     poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: WatchBlocksParameters<TTransport, TChain>,
+  }: WatchBlocksParameters<TTransport, TChain, TBlockTag, TIncludeTransactions>,
 ): WatchBlocksReturnType {
   const enablePolling =
     typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
+  const includeTransactions = includeTransactions_ ?? false
 
   let prevBlock: GetBlockReturnType<TChain> | undefined
 
@@ -132,7 +149,7 @@ export function watchBlocks<
                     blockNumber: i,
                     includeTransactions,
                   })
-                  emit.onBlock(block, prevBlock)
+                  emit.onBlock(block as any, prevBlock as any)
                   prevBlock = block
                 }
               }
@@ -147,8 +164,8 @@ export function watchBlocks<
               // We don't want to emit blocks in the past.
               (block.number && block.number > prevBlock.number)
             ) {
-              emit.onBlock(block, prevBlock)
-              prevBlock = block
+              emit.onBlock(block as any, prevBlock as any)
+              prevBlock = block as any
             }
           } catch (err) {
             emit.onError?.(err as Error)
@@ -174,7 +191,7 @@ export function watchBlocks<
             const format =
               client.chain?.formatters?.block?.format || formatBlock
             const block = format(data.result)
-            onBlock(block, prevBlock)
+            onBlock(block, prevBlock as any)
             prevBlock = block
           },
           onError(error: Error) {

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -12,24 +12,24 @@ import { type GetBlockReturnType, getBlock } from './getBlock.js'
 
 export type OnBlockParameter<
   TChain extends Chain | undefined = Chain,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
-> = GetBlockReturnType<TChain, TBlockTag, TIncludeTransactions>
+  TBlockTag extends BlockTag = 'latest',
+> = GetBlockReturnType<TChain, TIncludeTransactions, TBlockTag>
 
 export type OnBlock<
   TChain extends Chain | undefined = Chain,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 > = (
-  block: OnBlockParameter<TChain, TBlockTag, TIncludeTransactions>,
+  block: OnBlockParameter<TChain, TIncludeTransactions, TBlockTag>,
   prevBlock:
-    | OnBlockParameter<TChain, TBlockTag, TIncludeTransactions>
+    | OnBlockParameter<TChain, TIncludeTransactions, TBlockTag>
     | undefined,
 ) => void
 
 type PollOptions<
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 > = {
   /** The block tag. Defaults to "latest". */
   blockTag?: TBlockTag | BlockTag
@@ -46,11 +46,11 @@ type PollOptions<
 export type WatchBlocksParameters<
   TTransport extends Transport = Transport,
   TChain extends Chain | undefined = Chain,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 > = {
   /** The callback to call when a new block is received. */
-  onBlock: OnBlock<TChain, TBlockTag, TIncludeTransactions>
+  onBlock: OnBlock<TChain, TIncludeTransactions, TBlockTag>
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
 } & (GetTransportConfig<TTransport>['type'] extends 'webSocket'
@@ -64,8 +64,8 @@ export type WatchBlocksParameters<
           poll?: false
           pollingInterval?: never
         }
-      | (PollOptions<TBlockTag, TIncludeTransactions> & { poll?: true })
-  : PollOptions<TBlockTag, TIncludeTransactions> & { poll?: true })
+      | (PollOptions<TIncludeTransactions, TBlockTag> & { poll?: true })
+  : PollOptions<TIncludeTransactions, TBlockTag> & { poll?: true })
 
 export type WatchBlocksReturnType = () => void
 
@@ -97,8 +97,8 @@ export type WatchBlocksReturnType = () => void
 export function watchBlocks<
   TTransport extends Transport,
   TChain extends Chain | undefined,
-  TBlockTag extends BlockTag = 'latest',
   TIncludeTransactions extends boolean = false,
+  TBlockTag extends BlockTag = 'latest',
 >(
   client: Client<TTransport, TChain>,
   {
@@ -110,7 +110,7 @@ export function watchBlocks<
     includeTransactions: includeTransactions_,
     poll: poll_,
     pollingInterval = client.pollingInterval,
-  }: WatchBlocksParameters<TTransport, TChain, TBlockTag, TIncludeTransactions>,
+  }: WatchBlocksParameters<TTransport, TChain, TIncludeTransactions, TBlockTag>,
 ): WatchBlocksReturnType {
   const enablePolling =
     typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -116,7 +116,9 @@ export function watchBlocks<
     typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
   const includeTransactions = includeTransactions_ ?? false
 
-  let prevBlock: GetBlockReturnType<TChain> | undefined
+  let prevBlock:
+    | GetBlockReturnType<TChain, false | TIncludeTransactions, 'latest'>
+    | undefined
 
   const pollBlocks = () => {
     const observerId = stringify([

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -1,4 +1,4 @@
-import type { Abi, Address, ExtractAbiEvent, Narrow } from 'abitype'
+import type { Abi, AbiEvent, Address, ExtractAbiEvent, Narrow } from 'abitype'
 
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
@@ -20,7 +20,7 @@ import {
 } from './createContractEventFilter.js'
 import { getBlockNumber } from './getBlockNumber.js'
 import { getFilterChanges } from './getFilterChanges.js'
-import { type GetLogsParameters, getLogs } from './getLogs.js'
+import { getLogs } from './getLogs.js'
 import { uninstallFilter } from './uninstallFilter.js'
 
 export type WatchContractEventOnLogsParameter<
@@ -28,7 +28,7 @@ export type WatchContractEventOnLogsParameter<
   TEventName extends string = string,
   TStrict extends boolean | undefined = undefined,
 > = TAbi extends Abi
-  ? Log<bigint, number, ExtractAbiEvent<TAbi, TEventName>, TStrict>[]
+  ? Log<bigint, number, false, ExtractAbiEvent<TAbi, TEventName>, TStrict>[]
   : Log[]
 export type WatchContractEventOnLogsFn<
   TAbi extends Abi | readonly unknown[] = readonly unknown[],
@@ -173,8 +173,8 @@ export function watchContractEvent<
                 event: getAbiItem({
                   abi,
                   name: eventName,
-                } as unknown as GetAbiItemParameters),
-              } as unknown as GetLogsParameters)
+                } as unknown as GetAbiItemParameters) as AbiEvent,
+              })
             } else {
               logs = []
             }

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -26,7 +26,7 @@ export type WatchEventOnLogsParameter<
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
-> = Log<bigint, number, TAbiEvent, TStrict, [TAbiEvent], TEventName>[]
+> = Log<bigint, number, false, TAbiEvent, TStrict, [TAbiEvent], TEventName>[]
 export type WatchEventOnLogsFn<
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,

--- a/src/chains/formatters/celo.test-d.ts
+++ b/src/chains/formatters/celo.test-d.ts
@@ -12,10 +12,7 @@ import type {
   RpcTransaction,
   RpcTransactionReceipt,
 } from '../../types/rpc.js'
-import type {
-  Transaction,
-  TransactionRequest,
-} from '../../types/transaction.js'
+import type { TransactionRequest } from '../../types/transaction.js'
 import { sendTransaction } from '../../wallet.js'
 import { celo } from '../index.js'
 import { formattersCelo } from './celo.js'
@@ -146,13 +143,15 @@ describe('smoke', () => {
       blockNumber: 16645775n,
       includeTransactions: true,
     })
-    expectTypeOf(block_includeTransactions.transactions).toEqualTypeOf<
-      | (Transaction & {
-          feeCurrency: `0x${string}` | null
-          gatewayFee: bigint | null
-          gatewayFeeRecipient: `0x${string}` | null
-        })[]
-    >()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].feeCurrency,
+    ).toEqualTypeOf<`0x${string}` | null>()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].gatewayFee,
+    ).toEqualTypeOf<bigint | null>()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].gatewayFeeRecipient,
+    ).toEqualTypeOf<`0x${string}` | null>()
   })
 
   test('transaction', async () => {

--- a/src/chains/formatters/celo.test-d.ts
+++ b/src/chains/formatters/celo.test-d.ts
@@ -6,6 +6,7 @@ import { getTransactionReceipt } from '../../actions/public/getTransactionReceip
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { createWalletClient } from '../../clients/createWalletClient.js'
 import { http } from '../../clients/transports/http.js'
+import type { Hash } from '../../types/misc.js'
 import type {
   RpcBlock,
   RpcTransaction,
@@ -128,7 +129,6 @@ describe('smoke', () => {
     })
     const block = await getBlock(client, {
       blockNumber: 16645775n,
-      includeTransactions: true,
     })
 
     expectTypeOf(block.difficulty).toEqualTypeOf<never>()
@@ -140,8 +140,13 @@ describe('smoke', () => {
       committed: `0x${string}`
       revealed: `0x${string}`
     }>()
-    expectTypeOf(block.transactions).toEqualTypeOf<
-      | `0x${string}`[]
+    expectTypeOf(block.transactions).toEqualTypeOf<Hash[]>()
+
+    const block_includeTransactions = await getBlock(client, {
+      blockNumber: 16645775n,
+      includeTransactions: true,
+    })
+    expectTypeOf(block_includeTransactions.transactions).toEqualTypeOf<
       | (Transaction & {
           feeCurrency: `0x${string}` | null
           gatewayFee: bigint | null

--- a/src/chains/formatters/optimism.test-d.ts
+++ b/src/chains/formatters/optimism.test-d.ts
@@ -4,6 +4,7 @@ import { getBlock } from '../../actions/public/getBlock.js'
 import { getTransaction } from '../../actions/public/getTransaction.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
+import type { Hash } from '../../types/misc.js'
 import type { RpcBlock, RpcTransaction } from '../../types/rpc.js'
 import type { Transaction } from '../../types/transaction.js'
 import { optimism } from '../index.js'
@@ -39,13 +40,18 @@ describe('smoke', () => {
       chain: optimism,
       transport: http(),
     })
+
     const block = await getBlock(client, {
+      blockNumber: 16645775n,
+    })
+    expectTypeOf(block.transactions).toEqualTypeOf<Hash[]>()
+
+    const block_includeTransactions = await getBlock(client, {
       blockNumber: 16645775n,
       includeTransactions: true,
     })
-
-    expectTypeOf(block.transactions).toEqualTypeOf<
-      `0x${string}`[] | (Transaction | DepositTransaction)[]
+    expectTypeOf(block_includeTransactions.transactions).toEqualTypeOf<
+      (Transaction | DepositTransaction)[]
     >()
   })
 

--- a/src/chains/formatters/optimism.test-d.ts
+++ b/src/chains/formatters/optimism.test-d.ts
@@ -6,13 +6,8 @@ import { createPublicClient } from '../../clients/createPublicClient.js'
 import { http } from '../../clients/transports/http.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock, RpcTransaction } from '../../types/rpc.js'
-import type { Transaction } from '../../types/transaction.js'
 import { optimism } from '../index.js'
-import {
-  type DepositTransaction,
-  type RpcDepositTransaction,
-  formattersOptimism,
-} from './optimism.js'
+import { type RpcDepositTransaction, formattersOptimism } from './optimism.js'
 
 describe('block', () => {
   expectTypeOf(formattersOptimism.block.format).parameter(0).toEqualTypeOf<
@@ -50,9 +45,17 @@ describe('smoke', () => {
       blockNumber: 16645775n,
       includeTransactions: true,
     })
-    expectTypeOf(block_includeTransactions.transactions).toEqualTypeOf<
-      (Transaction | DepositTransaction)[]
-    >()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].sourceHash,
+    ).toEqualTypeOf<`0x${string}` | undefined>()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].type === 'deposit' &&
+        block_includeTransactions.transactions[0].sourceHash,
+    ).toEqualTypeOf<false | `0x${string}`>()
+    expectTypeOf(
+      block_includeTransactions.transactions[0].type === 'eip1559' &&
+        block_includeTransactions.transactions[0].sourceHash,
+    ).toEqualTypeOf<false | undefined>()
   })
 
   test('transaction', async () => {

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -197,6 +197,7 @@ import {
   watchPendingTransactions,
 } from '../../actions/public/watchPendingTransactions.js'
 import type { Account } from '../../types/account.js'
+import type { BlockNumber, BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type {
   ContractFunctionConfig,
@@ -281,10 +282,26 @@ export type PublicActions<
     TEventName extends string | undefined,
     TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName> | undefined,
     TStrict extends boolean | undefined = undefined,
+    TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+    TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args: CreateContractEventFilterParameters<TAbi, TEventName, TArgs, TStrict>,
+    args: CreateContractEventFilterParameters<
+      TAbi,
+      TEventName,
+      TArgs,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >,
   ) => Promise<
-    CreateContractEventFilterReturnType<TAbi, TEventName, TArgs, TStrict>
+    CreateContractEventFilterReturnType<
+      TAbi,
+      TEventName,
+      TArgs,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >
   >
   /**
    * Creates a [`Filter`](https://viem.sh/docs/glossary/types.html#filter) to listen for new events that can be used with [`getFilterChanges`](https://viem.sh/docs/actions/public/getFilterChanges.html).
@@ -310,6 +327,8 @@ export type PublicActions<
   createEventFilter: <
     TAbiEvent extends AbiEvent | undefined,
     TStrict extends boolean | undefined = undefined,
+    TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+    TToBlock extends BlockNumber | BlockTag | undefined = undefined,
     _Abi extends Abi | readonly unknown[] = [TAbiEvent],
     _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
     _Args extends
@@ -319,12 +338,22 @@ export type PublicActions<
     args?: CreateEventFilterParameters<
       TAbiEvent,
       TStrict,
+      TFromBlock,
+      TToBlock,
       _Abi,
       _EventName,
       _Args
     >,
   ) => Promise<
-    CreateEventFilterReturnType<TAbiEvent, TStrict, _Abi, _EventName, _Args>
+    CreateEventFilterReturnType<
+      TAbiEvent,
+      TStrict,
+      TFromBlock,
+      TToBlock,
+      _Abi,
+      _EventName,
+      _Args
+    >
   >
   /**
    * Creates a Filter to listen for new pending transaction hashes that can be used with [`getFilterChanges`](https://viem.sh/docs/actions/public/getFilterChanges.html).
@@ -890,9 +919,11 @@ export type PublicActions<
   getLogs: <
     TAbiEvent extends AbiEvent | undefined,
     TStrict extends boolean | undefined = undefined,
+    TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+    TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args?: GetLogsParameters<TAbiEvent, TStrict>,
-  ) => Promise<GetLogsReturnType<TAbiEvent, TStrict>>
+    args?: GetLogsParameters<TAbiEvent, TStrict, TFromBlock, TToBlock>,
+  ) => Promise<GetLogsReturnType<TAbiEvent, TStrict, TFromBlock, TToBlock>>
   /**
    * Returns the value from a storage slot at a given address.
    *
@@ -1265,8 +1296,16 @@ export type PublicActions<
    *   onBlock: (block) => console.log(block),
    * })
    */
-  watchBlocks: (
-    args: WatchBlocksParameters<TTransport, TChain>,
+  watchBlocks: <
+    TBlockTag extends BlockTag = 'latest',
+    TIncludeTransactions extends boolean = false,
+  >(
+    args: WatchBlocksParameters<
+      TTransport,
+      TChain,
+      TBlockTag,
+      TIncludeTransactions
+    >,
   ) => WatchBlocksReturnType
   /**
    * Watches and returns emitted contract event logs.
@@ -1406,7 +1445,7 @@ export function publicActions<
     getFilterChanges: (args) => getFilterChanges(client, args),
     getFilterLogs: (args) => getFilterLogs(client, args),
     getGasPrice: () => getGasPrice(client),
-    getLogs: (args) => getLogs(client, args),
+    getLogs: (args) => getLogs(client, args as any),
     getStorageAt: (args) => getStorageAt(client, args),
     getTransaction: (args) => getTransaction(client, args),
     getTransactionConfirmations: (args) =>

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -1297,14 +1297,14 @@ export type PublicActions<
    * })
    */
   watchBlocks: <
-    TBlockTag extends BlockTag = 'latest',
     TIncludeTransactions extends boolean = false,
+    TBlockTag extends BlockTag = 'latest',
   >(
     args: WatchBlocksParameters<
       TTransport,
       TChain,
-      TBlockTag,
-      TIncludeTransactions
+      TIncludeTransactions,
+      TBlockTag
     >,
   ) => WatchBlocksReturnType
   /**

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -491,7 +491,12 @@ export type PublicActions<
    * })
    * const block = await client.getBlock()
    */
-  getBlock: (args?: GetBlockParameters) => Promise<GetBlockReturnType<TChain>>
+  getBlock: <
+    TIncludeTransactions extends boolean = false,
+    TBlockTag extends BlockTag = 'latest',
+  >(
+    args?: GetBlockParameters<TIncludeTransactions, TBlockTag>,
+  ) => Promise<GetBlockReturnType<TChain, TIncludeTransactions, TBlockTag>>
   /**
    * Returns the number of the most recent block seen.
    *
@@ -839,10 +844,26 @@ export type PublicActions<
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
+    TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+    TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args: GetFilterChangesParameters<TFilterType, TAbi, TEventName, TStrict>,
+    args: GetFilterChangesParameters<
+      TFilterType,
+      TAbi,
+      TEventName,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >,
   ) => Promise<
-    GetFilterChangesReturnType<TFilterType, TAbi, TEventName, TStrict>
+    GetFilterChangesReturnType<
+      TFilterType,
+      TAbi,
+      TEventName,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >
   >
   /**
    * Returns a list of event logs since the filter was created.
@@ -874,9 +895,19 @@ export type PublicActions<
     TAbi extends Abi | readonly unknown[],
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
+    TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+    TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args: GetFilterLogsParameters<TAbi, TEventName, TStrict>,
-  ) => Promise<GetFilterLogsReturnType<TAbi, TEventName, TStrict>>
+    args: GetFilterLogsParameters<
+      TAbi,
+      TEventName,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >,
+  ) => Promise<
+    GetFilterLogsReturnType<TAbi, TEventName, TStrict, TFromBlock, TToBlock>
+  >
   /**
    * Returns the current price of gas (in wei).
    *
@@ -972,9 +1003,9 @@ export type PublicActions<
    *   hash: '0x4ca7ee652d57678f26e887c149ab0735f41de37bcad58c9f6d3ed5824f15b74d',
    * })
    */
-  getTransaction: (
-    args: GetTransactionParameters,
-  ) => Promise<GetTransactionReturnType<TChain>>
+  getTransaction: <TBlockTag extends BlockTag = 'latest'>(
+    args: GetTransactionParameters<TBlockTag>,
+  ) => Promise<GetTransactionReturnType<TChain, TBlockTag>>
   /**
    * Returns the number of blocks passed (confirmations) since the transaction was processed on a block.
    *

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -3,7 +3,15 @@ import type { Address } from 'abitype'
 import type { Hash, Hex } from './misc.js'
 import type { Transaction } from './transaction.js'
 
-export type Block<TQuantity = bigint, TTransaction = Transaction> = {
+export type Block<
+  TQuantity = bigint,
+  TBlockTag extends BlockTag = BlockTag,
+  TTransaction = Transaction<
+    bigint,
+    number,
+    TBlockTag extends 'pending' ? true : false
+  >,
+> = {
   /** Base fee per gas */
   baseFeePerGas: TQuantity | null
   /** Difficulty for this block */
@@ -15,17 +23,17 @@ export type Block<TQuantity = bigint, TTransaction = Transaction> = {
   /** Total used gas by all transactions in this block */
   gasUsed: TQuantity
   /** Block hash or `null` if pending */
-  hash: Hash | null
+  hash: TBlockTag extends 'pending' ? null : Hash
   /** Logs bloom filter or `null` if pending */
-  logsBloom: Hex | null
+  logsBloom: TBlockTag extends 'pending' ? null : Hex
   /** Address that received this block’s mining rewards */
   miner: Address
   /** Unique identifier for the block. */
   mixHash: Hash
   /** Proof-of-work hash or `null` if pending */
-  nonce: Hex | null
+  nonce: TBlockTag extends 'pending' ? null : Hex
   /** Block number or `null` if pending */
-  number: TQuantity | null
+  number: TBlockTag extends 'pending' ? null : TQuantity
   /** Parent block hash */
   parentHash: Hash
   /** Root of the this block’s receipts trie */
@@ -67,7 +75,12 @@ export type BlockNumber<TQuantity = bigint> = TQuantity
 
 export type BlockTag = 'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'
 
-export type Uncle<TQuantity = bigint, TTransaction = Transaction> = Block<
-  TQuantity,
-  TTransaction
->
+export type Uncle<
+  TQuantity = bigint,
+  TBlockTag extends BlockTag = BlockTag,
+  TTransaction = Transaction<
+    bigint,
+    number,
+    TBlockTag extends 'pending' ? true : false
+  >,
+> = Block<TQuantity, TBlockTag, TTransaction>

--- a/src/types/block.ts
+++ b/src/types/block.ts
@@ -5,6 +5,7 @@ import type { Transaction } from './transaction.js'
 
 export type Block<
   TQuantity = bigint,
+  TIncludeTransactions extends boolean = boolean,
   TBlockTag extends BlockTag = BlockTag,
   TTransaction = Transaction<
     bigint,
@@ -50,7 +51,7 @@ export type Block<
   /** Total difficulty of the chain until this block */
   totalDifficulty: TQuantity | null
   /** List of transaction objects or hashes */
-  transactions: Hash[] | TTransaction[]
+  transactions: TIncludeTransactions extends true ? TTransaction[] : Hash[]
   /** Root of this block’s transaction trie */
   transactionsRoot: Hash
   /** List of uncle hashes */
@@ -77,10 +78,11 @@ export type BlockTag = 'latest' | 'earliest' | 'pending' | 'safe' | 'finalized'
 
 export type Uncle<
   TQuantity = bigint,
+  TIncludeTransactions extends boolean = boolean,
   TBlockTag extends BlockTag = BlockTag,
   TTransaction = Transaction<
     bigint,
     number,
     TBlockTag extends 'pending' ? true : false
   >,
-> = Block<TQuantity, TBlockTag, TTransaction>
+> = Block<TQuantity, TIncludeTransactions, TBlockTag, TTransaction>

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -1,5 +1,6 @@
 import type { Abi } from 'abitype'
 
+import type { BlockNumber, BlockTag } from './block.js'
 import type { MaybeExtractEventArgsFromAbi } from './contract.js'
 import type { EIP1193RequestFn, PublicRpcSchema } from './eip1193.js'
 import type { Hex } from './misc.js'
@@ -22,36 +23,41 @@ export type Filter<
     | MaybeExtractEventArgsFromAbi<TAbi, TEventName>
     | undefined = MaybeExtractEventArgsFromAbi<TAbi, TEventName>,
   TStrict extends boolean | undefined = undefined,
+  TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
+  TToBlock extends BlockNumber | BlockTag | undefined = undefined,
 > = {
   id: Hex
   request: EIP1193RequestFn<FilterRpcSchema>
   type: TFilterType
 } & (TFilterType extends 'event'
-  ? TAbi extends Abi
-    ? undefined extends TEventName
-      ? {
-          abi: TAbi
+  ? {
+      fromBlock?: TFromBlock
+      toBlock?: TToBlock
+    } & (TAbi extends Abi
+      ? undefined extends TEventName
+        ? {
+            abi: TAbi
+            args?: never
+            eventName?: never
+            strict: TStrict
+          }
+        : TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName>
+        ? {
+            abi: TAbi
+            args: TArgs
+            eventName: TEventName
+            strict: TStrict
+          }
+        : {
+            abi: TAbi
+            args?: never
+            eventName: TEventName
+            strict: TStrict
+          }
+      : {
+          abi?: never
           args?: never
           eventName?: never
-          strict: TStrict
-        }
-      : TArgs extends MaybeExtractEventArgsFromAbi<TAbi, TEventName>
-      ? {
-          abi: TAbi
-          args: TArgs
-          eventName: TEventName
-          strict: TStrict
-        }
-      : {
-          abi: TAbi
-          args?: never
-          eventName: TEventName
-          strict: TStrict
-        }
-    : {
-        abi?: never
-        args?: never
-        eventName?: never
-        strict?: never
-      }
+          strict?: never
+        })
   : {})

--- a/src/types/formatter.ts
+++ b/src/types/formatter.ts
@@ -12,6 +12,15 @@ export type Formatters = {
   transactionRequest?: Formatter<'transactionRequest'>
 }
 
+export type ExtractFormatterExclude<
+  TChain extends Chain | undefined,
+  TType extends keyof Formatters,
+> = TChain extends Chain<infer _Formatters extends Formatters>
+  ? _Formatters[TType] extends { exclude: infer Exclude }
+    ? Extract<Exclude, string[]>[number]
+    : ''
+  : ''
+
 export type ExtractFormatterParameters<
   TChain extends Chain | undefined,
   TType extends keyof Formatters,

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -15,6 +15,7 @@ import type { Hash, Hex } from './misc.js'
 export type Log<
   TQuantity = bigint,
   TIndex = number,
+  TPending extends boolean = false,
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TAbi extends Abi | readonly unknown[] = [TAbiEvent],
@@ -25,17 +26,17 @@ export type Log<
   /** The address from which this log originated */
   address: Address
   /** Hash of block containing this log or `null` if pending */
-  blockHash: Hash | null
+  blockHash: TPending extends true ? null : Hash
   /** Number of block containing this log or `null` if pending */
-  blockNumber: TQuantity | null
+  blockNumber: TPending extends true ? null : TQuantity
   /** Contains the non-indexed arguments of the log */
   data: Hex
   /** Index of this log within its block or `null` if pending */
-  logIndex: TIndex | null
+  logIndex: TPending extends true ? null : TIndex
   /** Hash of the transaction that created this log or `null` if pending */
-  transactionHash: Hash | null
+  transactionHash: TPending extends true ? null : Hash
   /** Index of the transaction that created this log or `null` if pending */
-  transactionIndex: TIndex | null
+  transactionIndex: TPending extends true ? null : TIndex
   /** `true` if this filter has been destroyed and is invalid */
   removed: boolean
 } & GetInferredLogValues<TAbiEvent, TAbi, TEventName, TStrict>

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -15,7 +15,7 @@ import type { Hash, Hex } from './misc.js'
 export type Log<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TAbi extends Abi | readonly unknown[] = [TAbiEvent],

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -23,8 +23,12 @@ export type Quantity = `0x${string}`
 export type Status = '0x0' | '0x1'
 export type TransactionType = '0x0' | '0x1' | '0x2' | (string & {})
 
-export type RpcBlock<TBlockTag extends BlockTag = BlockTag> = Block<
+export type RpcBlock<
+  TBlockTag extends BlockTag = BlockTag,
+  TIncludeTransactions extends boolean = boolean,
+> = Block<
   Quantity,
+  TIncludeTransactions,
   TBlockTag,
   RpcTransaction<TBlockTag extends 'pending' ? true : false>
 >

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -1,4 +1,10 @@
-import type { Block, BlockIdentifier, BlockNumber, Uncle } from './block.js'
+import type {
+  Block,
+  BlockIdentifier,
+  BlockNumber,
+  BlockTag,
+  Uncle,
+} from './block.js'
 import type { FeeHistory, FeeValues } from './fee.js'
 import type { Log } from './log.js'
 import type {
@@ -17,7 +23,11 @@ export type Quantity = `0x${string}`
 export type Status = '0x0' | '0x1'
 export type TransactionType = '0x0' | '0x1' | '0x2' | (string & {})
 
-export type RpcBlock = Block<Quantity, RpcTransaction>
+export type RpcBlock<TBlockTag extends BlockTag = BlockTag> = Block<
+  Quantity,
+  TBlockTag,
+  RpcTransaction<TBlockTag extends 'pending' ? true : false>
+>
 export type RpcBlockNumber = BlockNumber<Quantity>
 export type RpcBlockIdentifier = BlockIdentifier<Quantity>
 export type RpcUncle = Uncle<Quantity>
@@ -34,9 +44,9 @@ export type RpcTransactionRequest =
   | TransactionRequestLegacy<Quantity, Index, '0x0'>
   | TransactionRequestEIP2930<Quantity, Index, '0x1'>
   | TransactionRequestEIP1559<Quantity, Index, '0x2'>
-export type RpcTransaction = UnionOmit<
-  | TransactionLegacy<Quantity, Index, '0x0'>
-  | TransactionEIP2930<Quantity, Index, '0x1'>
-  | TransactionEIP1559<Quantity, Index, '0x2'>,
+export type RpcTransaction<TPending extends boolean = boolean> = UnionOmit<
+  | TransactionLegacy<Quantity, Index, TPending, '0x0'>
+  | TransactionEIP2930<Quantity, Index, TPending, '0x1'>
+  | TransactionEIP1559<Quantity, Index, TPending, '0x2'>,
   'typeHex'
 >

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -47,11 +47,15 @@ export type TransactionReceipt<
   type: TType
 }
 
-export type TransactionBase<TQuantity = bigint, TIndex = number> = {
+export type TransactionBase<
+  TQuantity = bigint,
+  TIndex = number,
+  TPending extends boolean = false,
+> = {
   /** Hash of block containing this transaction or `null` if pending */
-  blockHash: Hash | null
+  blockHash: TPending extends true ? null : Hash
   /** Number of block containing this transaction or `null` if pending */
-  blockNumber: TQuantity | null
+  blockNumber: TPending extends true ? null : TQuantity
   /** Transaction sender */
   from: Address
   /** Gas provided for transaction execution */
@@ -69,7 +73,7 @@ export type TransactionBase<TQuantity = bigint, TIndex = number> = {
   /** Transaction recipient or `null` if deploying a contract */
   to: Address | null
   /** Index of this transaction in the block or `null` if pending */
-  transactionIndex: TIndex | null
+  transactionIndex: TPending extends true ? null : TIndex
   /** The type represented as hex. */
   typeHex: Hex | null
   /** ECDSA recovery ID */
@@ -80,8 +84,9 @@ export type TransactionBase<TQuantity = bigint, TIndex = number> = {
 export type TransactionLegacy<
   TQuantity = bigint,
   TIndex = number,
+  TPending extends boolean = false,
   TType = 'legacy',
-> = TransactionBase<TQuantity, TIndex> &
+> = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesLegacy<TQuantity> & {
     accessList?: never
     chainId?: TIndex
@@ -90,8 +95,9 @@ export type TransactionLegacy<
 export type TransactionEIP2930<
   TQuantity = bigint,
   TIndex = number,
+  TPending extends boolean = false,
   TType = 'eip2930',
-> = TransactionBase<TQuantity, TIndex> &
+> = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesLegacy<TQuantity> & {
     accessList: AccessList
     chainId: TIndex
@@ -100,17 +106,22 @@ export type TransactionEIP2930<
 export type TransactionEIP1559<
   TQuantity = bigint,
   TIndex = number,
+  TPending extends boolean = false,
   TType = 'eip1559',
-> = TransactionBase<TQuantity, TIndex> &
+> = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesEIP1559<TQuantity> & {
     accessList: AccessList
     chainId: TIndex
     type: TType
   }
-export type Transaction<TQuantity = bigint, TIndex = number> =
-  | TransactionLegacy<TQuantity, TIndex>
-  | TransactionEIP2930<TQuantity, TIndex>
-  | TransactionEIP1559<TQuantity, TIndex>
+export type Transaction<
+  TQuantity = bigint,
+  TIndex = number,
+  TPending extends boolean = false,
+> =
+  | TransactionLegacy<TQuantity, TIndex, TPending>
+  | TransactionEIP2930<TQuantity, TIndex, TPending>
+  | TransactionEIP1559<TQuantity, TIndex, TPending>
 
 export type TransactionRequestBase<TQuantity = bigint, TIndex = number> = {
   /** Contract code or a hashed method call with encoded args */

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -50,7 +50,7 @@ export type TransactionReceipt<
 export type TransactionBase<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
 > = {
   /** Hash of block containing this transaction or `null` if pending */
   blockHash: TPending extends true ? null : Hash
@@ -84,7 +84,7 @@ export type TransactionBase<
 export type TransactionLegacy<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
   TType = 'legacy',
 > = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesLegacy<TQuantity> & {
@@ -95,7 +95,7 @@ export type TransactionLegacy<
 export type TransactionEIP2930<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
   TType = 'eip2930',
 > = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesLegacy<TQuantity> & {
@@ -106,7 +106,7 @@ export type TransactionEIP2930<
 export type TransactionEIP1559<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
   TType = 'eip1559',
 > = TransactionBase<TQuantity, TIndex, TPending> &
   FeeValuesEIP1559<TQuantity> & {
@@ -117,7 +117,7 @@ export type TransactionEIP1559<
 export type Transaction<
   TQuantity = bigint,
   TIndex = number,
-  TPending extends boolean = false,
+  TPending extends boolean = boolean,
 > =
   | TransactionLegacy<TQuantity, TIndex, TPending>
   | TransactionEIP2930<TQuantity, TIndex, TPending>

--- a/src/utils/formatters/block.ts
+++ b/src/utils/formatters/block.ts
@@ -1,6 +1,9 @@
 import type { Block, BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
-import type { ExtractFormatterReturnType } from '../../types/formatter.js'
+import type {
+  ExtractFormatterExclude,
+  ExtractFormatterReturnType,
+} from '../../types/formatter.js'
 import type { Hash } from '../../types/misc.js'
 import type { RpcBlock } from '../../types/rpc.js'
 import type { Prettify } from '../../types/utils.js'
@@ -19,13 +22,8 @@ export type FormattedBlock<
     'block',
     Block<bigint, TIncludeTransactions>
   >,
-  _ExcludedPendingDependencies extends string = {
-    [Key in BlockPendingDependencies]: Key extends keyof _FormatterReturnType
-      ? _FormatterReturnType[Key] extends never
-        ? Key
-        : never
-      : never
-  }[BlockPendingDependencies],
+  _ExcludedPendingDependencies extends string = BlockPendingDependencies &
+    ExtractFormatterExclude<TChain, 'block'>,
   _Formatted = Omit<_FormatterReturnType, BlockPendingDependencies> & {
     [K in _ExcludedPendingDependencies]: never
   } & Pick<

--- a/src/utils/formatters/block.ts
+++ b/src/utils/formatters/block.ts
@@ -19,15 +19,15 @@ export type FormattedBlock<
     'block',
     Block<bigint, TIncludeTransactions>
   >,
-  _ExcludedDependencies extends string = {
+  _ExcludedPendingDependencies extends string = {
     [Key in BlockPendingDependencies]: Key extends keyof _FormatterReturnType
       ? _FormatterReturnType[Key] extends never
         ? Key
         : never
       : never
   }[BlockPendingDependencies],
-  _ExtractedFormat = Omit<_FormatterReturnType, BlockPendingDependencies> & {
-    [K in _ExcludedDependencies]: never
+  _Formatted = Omit<_FormatterReturnType, BlockPendingDependencies> & {
+    [K in _ExcludedPendingDependencies]: never
   } & Pick<
       Block<bigint, TIncludeTransactions, TBlockTag>,
       BlockPendingDependencies
@@ -35,7 +35,7 @@ export type FormattedBlock<
   _Transactions = TIncludeTransactions extends true
     ? Prettify<FormattedTransaction<TChain, TBlockTag>>[]
     : Hash[],
-> = Omit<_ExtractedFormat, 'transactions'> & {
+> = Omit<_Formatted, 'transactions'> & {
   transactions: _Transactions
 }
 

--- a/src/utils/formatters/block.ts
+++ b/src/utils/formatters/block.ts
@@ -14,7 +14,7 @@ export type FormattedBlock<
   _ExtractedFormat = ExtractFormatterReturnType<
     TChain,
     'block',
-    Block<bigint, TBlockTag>
+    Block<bigint, TIncludeTransactions, TBlockTag>
   >,
   _Transactions = TIncludeTransactions extends true
     ? _ExtractedFormat extends { transactions: infer Transactions }

--- a/src/utils/formatters/formatter.ts
+++ b/src/utils/formatters/formatter.ts
@@ -16,6 +16,7 @@ export function defineFormatter<TType extends string, TParameters, TReturnType>(
     format: (_: TOverrideParameters) => TOverrideReturnType
   }) => {
     return {
+      exclude,
       format: (args: TParameters & TOverrideParameters) => {
         const formatted = format(args)
         if (exclude) {

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -20,7 +20,7 @@ export type FormattedTransaction<
     'transaction',
     Transaction
   >,
-  _ExcludedDependencies extends string = {
+  _ExcludedPendingDependencies extends string = {
     [Key in
       TransactionPendingDependencies]: Key extends keyof _FormatterReturnType
       ? _FormatterReturnType[Key] extends never
@@ -29,7 +29,7 @@ export type FormattedTransaction<
       : never
   }[TransactionPendingDependencies],
 > = UnionOmit<_FormatterReturnType, TransactionPendingDependencies> & {
-  [K in _ExcludedDependencies]: never
+  [K in _ExcludedPendingDependencies]: never
 } & Pick<
     Transaction<bigint, number, TBlockTag extends 'pending' ? true : false>,
     TransactionPendingDependencies

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -1,3 +1,4 @@
+import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type { ExtractFormatterReturnType } from '../../types/formatter.js'
 import type { RpcTransaction } from '../../types/rpc.js'
@@ -7,7 +8,12 @@ import { defineFormatter } from './formatter.js'
 
 export type FormattedTransaction<
   TChain extends Chain | undefined = Chain | undefined,
-> = ExtractFormatterReturnType<TChain, 'transaction', Transaction>
+  TBlockTag extends BlockTag = BlockTag,
+> = ExtractFormatterReturnType<
+  TChain,
+  'transaction',
+  Transaction<bigint, number, TBlockTag extends 'pending' ? true : false>
+>
 
 export const transactionType = {
   '0x0': 'legacy',

--- a/src/utils/formatters/transaction.ts
+++ b/src/utils/formatters/transaction.ts
@@ -1,6 +1,9 @@
 import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
-import type { ExtractFormatterReturnType } from '../../types/formatter.js'
+import type {
+  ExtractFormatterExclude,
+  ExtractFormatterReturnType,
+} from '../../types/formatter.js'
 import type { RpcTransaction } from '../../types/rpc.js'
 import type { Transaction } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
@@ -20,14 +23,8 @@ export type FormattedTransaction<
     'transaction',
     Transaction
   >,
-  _ExcludedPendingDependencies extends string = {
-    [Key in
-      TransactionPendingDependencies]: Key extends keyof _FormatterReturnType
-      ? _FormatterReturnType[Key] extends never
-        ? Key
-        : never
-      : never
-  }[TransactionPendingDependencies],
+  _ExcludedPendingDependencies extends string = TransactionPendingDependencies &
+    ExtractFormatterExclude<TChain, 'transaction'>,
 > = UnionOmit<_FormatterReturnType, TransactionPendingDependencies> & {
   [K in _ExcludedPendingDependencies]: never
 } & Pick<


### PR DESCRIPTION
Narrowed `getBlock`, `watchBlocks`, `getFilterChanges`, `getFilterLogs` & `getLogs` return types for when `blockTag` or `includeTransactions` is provided.

- When `blockTag !== 'pending'`, the return type will now include some non-nullish properties if it were dependent on pending blocks. Example: For `getBlock`, the `block.number` type is now non-nullish since `blockTag !== 'pending'`.
- On the other hand, when `blockTag: 'pending'`, some properties will be nullish. Example: For `getBlock`, the `block.number` type is now `null` since `blockTag === 'pending'`.
- When `includeTransactions` is provided, the return type of will narrow the `transactions` property type. Example: `block.transactions` will be `Transaction[]` when `includeTransactions: true` instead of `Hash[] | Transaction[]`.

TLDR;

```ts
// Before
const block = publicClient.getBlock({ includeTransactions: true })
block.transactions
//    ^? Hash[] | Transaction[]
block.transactions[0].blockNumber
//                    ^? bigint | null

// After
const block = publicClient.getBlock({ includeTransactions: true })
block.transactions
//    ^? Transaction[]
block.transactions[0].blockNumber
//                    ^? bigint

// Before
const block = publicClient.getBlock({ blockTag: 'pending', includeTransactions: true })
block.number
//    ^? number | null
block.transactions[0].blockNumber
//                    ^? bigint | null

// After
const block = publicClient.getBlock({ blockTag: 'pending', includeTransactions: true })
block.number
//    ^? null
block.transactions[0].blockNumber
//                    ^? null
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding new types and updating existing types in various files. 

### Detailed summary
- Added `TIncludeTransactions` and `TBlockTag` to the `Block` generics in `wicked-bananas-cover.md`
- Added `TPending` to the `Log` generics in `brown-sheep-visit.md`
- Updated types in `watchEvent.ts`, `watchBlocks.test.ts`, `createEventFilter.test-d.ts`, `createContractEventFilter.test-d.ts`, `log.ts`, `watchContractEvent.ts`, `transaction.ts`, `rpc.ts`, and `filter.ts`

> The following files were skipped due to too many changes: `src/chains/formatters/celo.test-d.ts`, `src/chains/formatters/optimism.test-d.ts`, `.changeset/bright-jobs-boil.md`, `src/utils/formatters/block.ts`, `src/actions/public/getBlock.ts`, `src/actions/public/getTransaction.ts`, `src/actions/public/getTransaction.test-d.ts`, `src/actions/public/getLogs.test.ts`, `src/actions/public/getLogs.test-d.ts`, `src/types/block.ts`, `src/actions/public/getFilterLogs.ts`, `src/actions/public/getLogs.ts`, `src/actions/public/getFilterChanges.ts`, `src/types/transaction.ts`, `src/actions/public/createContractEventFilter.ts`, `src/actions/public/getFilterChanges.test.ts`, `src/actions/public/getFilterLogs.test.ts`, `src/actions/public/getBlock.test-d.ts`, `src/actions/public/createEventFilter.ts`, `src/actions/public/watchBlocks.ts`, `src/actions/public/getFilterLogs.test-d.ts`, `src/actions/public/getFilterChanges.test-d.ts`, `src/clients/decorators/public.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->