### PR TITLE
docs: fix TransactionReceipt docs and comments

### DIFF
--- a/site/docs/actions/public/getTransactionConfirmations.md
+++ b/site/docs/actions/public/getTransactionConfirmations.md
@@ -77,7 +77,7 @@ The number of blocks passed since the transaction was processed. If confirmation
 
 ### transactionReceipt
 
-- **Type:** [`TransactionReceipt`](/docs/glossary/types#transaction-receipt)
+- **Type:** [`TransactionReceipt`](/docs/glossary/types#transactionreceipt)
 
 The transaction receipt.
 

--- a/site/docs/actions/public/getTransactionReceipt.md
+++ b/site/docs/actions/public/getTransactionReceipt.md
@@ -14,7 +14,7 @@ head:
 
 # getTransactionReceipt
 
-Returns the [Transaction Receipt](/docs/glossary/terms#transactionreceipt) given a [Transaction](/docs/glossary/terms#transaction) hash.
+Returns the [Transaction Receipt](/docs/glossary/terms#transaction-receipt) given a [Transaction](/docs/glossary/terms#transaction) hash.
 
 ## Usage
 
@@ -51,7 +51,7 @@ export const publicClient = createPublicClient({
 
 ## Returns
 
-[`TransactionReceipt`](/docs/glossary/types#transaction-receipt)
+[`TransactionReceipt`](/docs/glossary/types#transactionreceipt)
 
 The transaction receipt.
 

--- a/site/docs/actions/public/waitForTransactionReceipt.md
+++ b/site/docs/actions/public/waitForTransactionReceipt.md
@@ -53,7 +53,7 @@ export const publicClient = createPublicClient({
 
 ## Returns
 
-[`TransactionReceipt`](/docs/glossary/types#transaction-receipt)
+[`TransactionReceipt`](/docs/glossary/types#transactionreceipt)
 
 The transaction receipt.
 

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -35,7 +35,7 @@ export type TransactionReceipt<
   logs: Log<TQuantity, TIndex>[]
   /** Logs bloom filter */
   logsBloom: Hex
-  /** `1` if this transaction was successful or `0` if it failed */
+  /** `success` if this transaction was successful or `reverted` if it failed */
   status: TStatus
   /** Transaction recipient or `null` if deploying a contract */
   to: Address | null


### PR DESCRIPTION
See [Issue](https://github.com/wagmi-dev/viem/issues/849) for full description. Please let me know if there's any other required information to contribute.

1. Fixing comment on expected values for TransactionReceipt.status
2. Fixing TransactionReceipt-related documentation links

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the references to `TransactionReceipt` in the code and documentation. 

### Detailed summary
- Renamed `TransactionReceipt` to `TransactionReceipt` in `waitForTransactionReceipt.md`.
- Renamed `TransactionReceipt` to `TransactionReceipt` in `getTransactionConfirmations.md`.
- Updated the comment in `transaction.ts` to reflect the change from `success` to `reverted`.
- Renamed `Transaction Receipt` to `Transaction Receipt` in `getTransactionReceipt.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->