### PR TITLE
Allow EIP-1559 transactions on chains with baseFeePerGas of 0

### DIFF
--- a/.changeset/loud-poems-burn.md
+++ b/.changeset/loud-poems-burn.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Allow using EIP-1559 transactions on chains with 0 base fee.

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -72,7 +72,7 @@ export async function prepareRequest<
       blockTag: 'pending',
     })
 
-  if (block.baseFeePerGas) {
+  if (block.baseFeePerGas !== null) {
     if (typeof gasPrice !== 'undefined')
       throw new BaseError('Chain does not support legacy `gasPrice`.')
 


### PR DESCRIPTION
Currently a baseFeePerGas of 0 fails truthy check and results in `Chain does not support EIP-1559 fees.` error.

This was highlighted when trying to refactor Lattice/MUD project to use Viem instead of Ethers because they use a local Anvil node with with 0 base fee for ease of development.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on allowing the use of EIP-1559 transactions on chains with a base fee of 0.

### Detailed summary
- Added support for using EIP-1559 transactions on chains with 0 base fee.
- Updated the condition to check for a non-null value of `baseFeePerGas` in the `prepareRequest.ts` file.
- Added an error check to ensure that the chain does not support legacy `gasPrice`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->