### PR TITLE
fix: return `dataSuffix` in `simulateTransaction`

### DIFF
--- a/.changeset/quick-tips-compete.md
+++ b/.changeset/quick-tips-compete.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `dataSuffix` was not being provided to the `request` returned from `simulateTransaction`.

--- a/src/actions/getContract.test.ts
+++ b/src/actions/getContract.test.ts
@@ -149,6 +149,7 @@ test('simulate', async () => {
         "account": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
         "address": "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
         "args": [],
+        "dataSuffix": undefined,
         "functionName": "mint",
       },
       "result": undefined,

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -160,7 +160,7 @@ describe('wagmi', () => {
 
 test('args: dataSuffix', async () => {
   const spy = vi.spyOn(call, 'call')
-  await simulateContract(publicClient, {
+  const { request } = await simulateContract(publicClient, {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
@@ -172,6 +172,7 @@ test('args: dataSuffix', async () => {
     data: '0x1249c58b12345678',
     to: wagmiContractConfig.address,
   })
+  expect(request.dataSuffix).toEqual('0x12345678')
 })
 
 describe('BAYC', () => {

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -145,6 +145,7 @@ export async function simulateContract<
         abi,
         address,
         args,
+        dataSuffix,
         functionName,
         ...callRequest,
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing an issue related to the `dataSuffix` parameter in the `simulateTransaction` function. 

### Detailed summary
- Added `dataSuffix` parameter to the `simulateContract` function in `simulateContract.ts`
- Fixed an issue where `dataSuffix` was not being provided to the `request` returned from `simulateTransaction` in `quick-tips-compete.md`
- Added a test case for `dataSuffix` in `simulateContract.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->