### PR TITLE
docs: fix typos & missing commas

### DIFF
--- a/site/docs/contract/decodeEventLog.md
+++ b/site/docs/contract/decodeEventLog.md
@@ -96,7 +96,7 @@ For example, the following will throw an error as there is a mismatch in non-`in
 decodeEventLog({
   abi: parseAbi(['event Transfer(address indexed, address, uint256)']),
   // `data` should be 64 bytes, but is only 32 bytes.
-  data: '0x0000000000000000000000000000000000000000000000000000000000000001'
+  data: '0x0000000000000000000000000000000000000000000000000000000000000001',
   topics: [
     '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
@@ -110,7 +110,7 @@ It is possible for `decodeEventLog` to try and partially decode the Log, this ca
 ```ts {2-4}
 decodeEventLog({
   abi: parseAbi(['event Transfer(address indexed, address, uint256)']),
-  data: '0x0000000000000000000000000000000000000000000000000000000000000001'
+  data: '0x0000000000000000000000000000000000000000000000000000000000000001',
   topics: [
     '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',

--- a/site/docs/contract/decodeFunctionData.md
+++ b/site/docs/contract/decodeFunctionData.md
@@ -26,7 +26,7 @@ import { decodeFunctionData } from 'viem'
 
 ## Usage
 
-Below is a very basic example of how to encode a function to calldata.
+Below is a very basic example of how to decode a function to calldata.
 
 ::: code-group
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting the usage instructions and examples in the `decodeFunctionData.md` and `decodeEventLog.md` files.

### Detailed summary:
- Corrected the usage example in `decodeFunctionData.md` to show how to decode a function to calldata.
- Fixed a typo in the `decodeEventLog.md` file.
- Added a missing comma in the `decodeEventLog.md` file.
- Updated the usage example in `decodeEventLog.md` to include the correct data and topics.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->