### PR TITLE
docs: make arg match its description

### DIFF
--- a/site/docs/contract/decodeEventLog.md
+++ b/site/docs/contract/decodeEventLog.md
@@ -115,7 +115,7 @@ decodeEventLog({
     '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
     '0x000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266',
   ],
-  strict: true // [!code ++]
+  strict: false // [!code ++]
 })
 /**
  * {


### PR DESCRIPTION
The descriptions says we should pass `false`, but the example passes `true`.

<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on changing the value of the `strict` property from `true` to `false` in the code. 

### Detailed summary
- Changed the value of the `strict` property from `true` to `false`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->