### PR TITLE
fix: `BaseError@walk` to return `null` when predicate fn not matches

### DIFF
--- a/.changeset/young-spiders-taste.md
+++ b/.changeset/young-spiders-taste.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix `BaseError@walk` to return `null` if callback is provided, but no error matches it

--- a/.changeset/young-spiders-taste.md
+++ b/.changeset/young-spiders-taste.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-fix `BaseError@walk` to return `null` if callback is provided, but no error matches it
+Fixed `BaseError.walk` to return `null` if the predicate callback is not satisfied.

--- a/src/errors/base.test.ts
+++ b/src/errors/base.test.ts
@@ -153,3 +153,13 @@ test('walk: predicate fn', () => {
     Version: viem@1.0.2]
   `)
 })
+
+test('walk: predicate fn (no match)', () => {
+  class FooError extends BaseError {}
+  class BarError extends BaseError {}
+
+  const err = new BaseError('test1', {
+    cause: new Error('test2', { cause: new BarError('test3') }),
+  })
+  expect(err.walk((err) => err instanceof FooError)).toBeNull()
+})

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -67,6 +67,7 @@ export class BaseError extends Error {
 
 function walk(err: unknown, fn?: (err: unknown) => boolean): unknown {
   if (fn?.(err)) return err
-  if ((err as Error).cause) return walk((err as Error).cause, fn)
-  return err
+  if (err && typeof err === 'object' && 'cause' in err)
+    return walk(err.cause, fn)
+  return fn ? null : err
 }


### PR DESCRIPTION
As [discussed here](https://github.com/wagmi-dev/viem/pull/497#issuecomment-1629106968), the current implementation of `BaseError@walk(fn?)` has a bug when `fn` is provided and no error matches it

Current behavior: the deepest error will be returned
Expected behavior: `null` should be returned

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing the `BaseError.walk` function to return `null` if the predicate callback is not satisfied.

### Detailed summary:
- Fixed `BaseError.walk` to return `null` if the predicate callback is not satisfied.
- Updated the implementation of `walk` in `src/errors/base.ts`.
- Added a new test case for `walk` in `src/errors/base.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->