### PR TITLE
docs: simulateContract/Handling Custom Errors - simplify search of `revertError`

### DIFF
--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -201,11 +201,12 @@ try {
     account,
   })
 } catch (err) {
-  const revertError = err instanceof BaseError
-    && err.walk(err => err instanceof ContractFunctionRevertedError)
-  if (revertError instanceof ContractFunctionRevertedError) {
-    const errorName = revertError.data?.errorName ?? "";
-    // do something with `errorName`
+  if (err instanceof BaseError) {
+    const revertError = err.walk(err => err instanceof ContractFunctionRevertedError)
+    if (revertError instanceof ContractFunctionRevertedError) {
+      const errorName = revertError.data?.errorName ?? ''
+      // do something with `errorName`
+    }
   }
 }
 

--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -201,20 +201,11 @@ try {
     account,
   })
 } catch (err) {
-  if (err instanceof BaseError) {
-    // Option 1: checking the instance of the error
-    if (err.cause instanceof ContractFunctionRevertedError) {
-      const cause: ContractFunctionRevertedError = err.cause;
-      const errorName = cause.data?.errorName ?? "";
-      // do something with `errorName`
-    }
-  
-    // Option 2: using `walk` method from `BaseError`
-    const revertError = err.walk(err => err instanceof ContractFunctionRevertedError)
-    if (revertError) {
-      const errorName = revertError.data?.errorName ?? "";
-      // do something with `errorName`
-    }
+  const revertError = err instanceof BaseError
+    && err.walk(err => err instanceof ContractFunctionRevertedError)
+  if (revertError instanceof ContractFunctionRevertedError) {
+    const errorName = revertError.data?.errorName ?? "";
+    // do something with `errorName`
   }
 }
 

--- a/src/utils/errors/getContractError.ts
+++ b/src/utils/errors/getContractError.ts
@@ -33,7 +33,7 @@ export function getContractError(
     err instanceof RawContractError
       ? err
       : err instanceof BaseError
-      ? err.walk((err) => 'data' in (err as Error))
+      ? err.walk((err) => 'data' in (err as Error)) || {}
       : {}
   ) as RawContractError
 


### PR DESCRIPTION
Remove redundant code from the example of finding `revertError`

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to refactor error handling in `simulateContract.md` file.
- It replaces the option 1 of checking the instance of the error with option 2 using the `walk` method from `BaseError`.
- It updates the code to check if `revertError` is an instance of `ContractFunctionRevertedError` before accessing its `data` property.
- The code for handling `errorName` remains the same.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->