### PR TITLE
chore: export missing types

### DIFF
--- a/.changeset/thick-jobs-end.md
+++ b/.changeset/thick-jobs-end.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+canary changes

--- a/.changeset/thick-jobs-end.md
+++ b/.changeset/thick-jobs-end.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-canary changes
+Exported missing types

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -21,9 +21,7 @@ export type ClientConfig<
     | undefined,
 > = {
   /** The Account to use for the Client. This will be used for Actions that require an account as an argument. */
-  account?: accountOrAddress extends Account | Address
-    ? accountOrAddress | Account | Address // `accountOrAddress` defined, add for inference
-    : Account | Address | undefined // `accountOrAddress` undefined, show possible types for autocomplete
+  account?: accountOrAddress | Account | Address | undefined
   /** Flags for batch settings. */
   batch?:
     | {
@@ -32,9 +30,7 @@ export type ClientConfig<
       }
     | undefined
   /** Chain for the client. */
-  chain?: chain extends Chain
-    ? chain // `chain` defined, add for inference
-    : Chain | undefined // `chain` undefined, show possible types for autocomplete
+  chain?: Chain | undefined | chain
   /** A key for the client. */
   key?: string | undefined
   /** A name for the client. */
@@ -58,23 +54,9 @@ export type Client<
   account extends Account | undefined = Account | undefined,
   rpcSchema extends RpcSchema | undefined = undefined,
   extended extends Extended | undefined = Extended | undefined,
-> = Prettify<
-  Prettify<Client_Base<transport, chain, account, rpcSchema>> & {
-    extend: <const client extends Extended>(
-      fn: (
-        client: Client<transport, chain, account, rpcSchema, extended>,
-      ) => client,
-    ) => Prettify<
-      Client<
-        transport,
-        chain,
-        account,
-        rpcSchema,
-        Prettify<client> & (extended extends Extended ? extended : unknown)
-      >
-    >
-  } & (extended extends Extended ? extended : unknown)
->
+> = Client_Base<transport, chain, account, rpcSchema> &
+  (extended extends Extended ? extended : unknown) &
+  ExtendFn<transport, chain, account, rpcSchema, extended>
 
 type Client_Base<
   transport extends Transport = Transport,
@@ -106,10 +88,30 @@ type Client_Base<
   uid: string
 }
 
+type ExtendFn<
+  transport extends Transport = Transport,
+  chain extends Chain | undefined = Chain | undefined,
+  account extends Account | undefined = Account | undefined,
+  rpcSchema extends RpcSchema | undefined = undefined,
+  extended extends Extended | undefined = Extended | undefined,
+> = {
+  extend: <const client extends Extended>(
+    fn: (
+      client: Client<transport, chain, account, rpcSchema, extended>,
+    ) => client,
+  ) => Client<
+    transport,
+    chain,
+    account,
+    rpcSchema,
+    Prettify<client> & (extended extends Extended ? extended : unknown)
+  >
+}
+
 type Extended = Prettify<
-  // disallow redefining base properties
-  { [K in keyof Client_Base]?: undefined } & {
-    [key: string]: unknown
+  { [key: string]: unknown } & {
+    // disallow redefining base properties
+    [K in keyof Client_Base]?: undefined
   }
 >
 
@@ -129,12 +131,14 @@ export function createClient<
   accountOrAddress extends Account | Address | undefined = undefined,
 >(
   parameters: ClientConfig<transport, chain, accountOrAddress>,
-): Client<
-  transport,
-  chain,
-  accountOrAddress extends Address
-    ? Prettify<JsonRpcAccount<accountOrAddress>>
-    : accountOrAddress
+): Prettify<
+  Client<
+    transport,
+    chain,
+    accountOrAddress extends Address
+      ? Prettify<JsonRpcAccount<accountOrAddress>>
+      : accountOrAddress
+  >
 >
 
 export function createClient(parameters: ClientConfig): Client {

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -55,8 +55,19 @@ export type Client<
   rpcSchema extends RpcSchema | undefined = undefined,
   extended extends Extended | undefined = Extended | undefined,
 > = Client_Base<transport, chain, account, rpcSchema> &
-  (extended extends Extended ? extended : unknown) &
-  ExtendFn<transport, chain, account, rpcSchema, extended>
+  (extended extends Extended ? extended : unknown) & {
+    extend: <const client extends Extended>(
+      fn: (
+        client: Client<transport, chain, account, rpcSchema, extended>,
+      ) => client,
+    ) => Client<
+      transport,
+      chain,
+      account,
+      rpcSchema,
+      Prettify<client> & (extended extends Extended ? extended : unknown)
+    >
+  }
 
 type Client_Base<
   transport extends Transport = Transport,
@@ -88,30 +99,10 @@ type Client_Base<
   uid: string
 }
 
-type ExtendFn<
-  transport extends Transport = Transport,
-  chain extends Chain | undefined = Chain | undefined,
-  account extends Account | undefined = Account | undefined,
-  rpcSchema extends RpcSchema | undefined = undefined,
-  extended extends Extended | undefined = Extended | undefined,
-> = {
-  extend: <const client extends Extended>(
-    fn: (
-      client: Client<transport, chain, account, rpcSchema, extended>,
-    ) => client,
-  ) => Client<
-    transport,
-    chain,
-    account,
-    rpcSchema,
-    Prettify<client> & (extended extends Extended ? extended : unknown)
-  >
-}
-
 type Extended = Prettify<
-  { [key: string]: unknown } & {
-    // disallow redefining base properties
-    [K in keyof Client_Base]?: undefined
+  // disallow redefining base properties
+  { [K in keyof Client_Base]?: undefined } & {
+    [key: string]: unknown
   }
 >
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export type {
   DeployContractReturnType,
 } from './actions/wallet/deployContract.js'
 export type { DropTransactionParameters } from './actions/test/dropTransaction.js'
+export type { GetAutomineReturnType } from './actions/test/getAutomine.js'
 export type {
   EstimateContractGasParameters,
   EstimateContractGasReturnType,
@@ -181,6 +182,9 @@ export type {
   RequestPermissionsReturnType,
   RequestPermissionsParameters,
 } from './actions/wallet/requestPermissions.js'
+export type { GetTxpoolContentReturnType } from './actions/test/getTxpoolContent.js'
+export type { GetTxpoolStatusReturnType } from './actions/test/getTxpoolStatus.js'
+export type { InspectTxpoolReturnType } from './actions/test/inspectTxpool.js'
 export type { ResetParameters } from './actions/test/reset.js'
 export type { RevertParameters } from './actions/test/revert.js'
 export type {

--- a/src/test.ts
+++ b/src/test.ts
@@ -2,9 +2,18 @@ export {
   dropTransaction,
   type DropTransactionParameters,
 } from './actions/test/dropTransaction.js'
-export { getAutomine } from './actions/test/getAutomine.js'
-export { getTxpoolContent } from './actions/test/getTxpoolContent.js'
-export { getTxpoolStatus } from './actions/test/getTxpoolStatus.js'
+export {
+  getAutomine,
+  type GetAutomineReturnType,
+} from './actions/test/getAutomine.js'
+export {
+  getTxpoolContent,
+  type GetTxpoolContentReturnType,
+} from './actions/test/getTxpoolContent.js'
+export {
+  getTxpoolStatus,
+  type GetTxpoolStatusReturnType,
+} from './actions/test/getTxpoolStatus.js'
 export {
   impersonateAccount,
   type ImpersonateAccountParameters,
@@ -13,7 +22,10 @@ export {
   increaseTime,
   type IncreaseTimeParameters,
 } from './actions/test/increaseTime.js'
-export { inspectTxpool } from './actions/test/inspectTxpool.js'
+export {
+  inspectTxpool,
+  type InspectTxpoolReturnType,
+} from './actions/test/inspectTxpool.js'
 export { mine, type MineParameters } from './actions/test/mine.js'
 export { removeBlockTimestampInterval } from './actions/test/removeBlockTimestampInterval.js'
 export { reset, type ResetParameters } from './actions/test/reset.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Exported missing types for `GetAutomineReturnType`, `GetTxpoolContentReturnType`, `GetTxpoolStatusReturnType`, and `InspectTxpoolReturnType`.
- Updated exports in `src/test.ts` to include the exported types.
- Updated the `ClientConfig` type in `src/clients/createClient.ts` to include additional possible types for `account` and `chain` properties.
- Updated the return type of the `createClient` function in `src/clients/createClient.ts` to include the prettified types for `accountOrAddress`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->