### PR TITLE
Fix code focus in `to` param docs

### DIFF
--- a/site/docs/actions/wallet/sendTransaction.md
+++ b/site/docs/actions/wallet/sendTransaction.md
@@ -125,8 +125,8 @@ The transaction recipient or contract address.
 
 ```ts
 const hash = await walletClient.sendTransaction({
-  account, // [!code focus]
-  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+  account,
+  to: '0x70997970c51812dc3a010c7d01b50e0d17dc79c8', // [!code focus]
   value: 1000000000000000000n,
   nonce: 69
 })


### PR DESCRIPTION
Ensure the [!code focus] is applied to the `to` param for the `to` param section of the docs.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in the `sendTransaction` method of the walletClient. 

### Detailed summary
- Fixed a typo in the `sendTransaction` method where the `account` parameter was incorrectly named.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->