### PR TITLE
Fix parse units large number

### DIFF
--- a/.changeset/dirty-lobsters-beg.md
+++ b/.changeset/dirty-lobsters-beg.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed parseUnits to properly handle large numbers when decimals = 0

--- a/.changeset/dirty-lobsters-beg.md
+++ b/.changeset/dirty-lobsters-beg.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Fixed parseUnits to properly handle large numbers when decimals = 0
+Fixed an issue where `parseUnits` would throw `Cannot convert to a BigInt` for large numbers with a fraction component.

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -41,6 +41,15 @@ test('decimals === 0', () => {
   expect(
     parseUnits('69.5952141234124125231523412312', 0),
   ).toMatchInlineSnapshot('70n')
+  expect(parseUnits('12301000000000000020000', 0)).toMatchInlineSnapshot(
+    '12301000000000000020000n',
+  )
+  expect(parseUnits('12301000000000000020000.123', 0)).toMatchInlineSnapshot(
+    '12301000000000000020000n',
+  )
+  expect(parseUnits('12301000000000000020000.5', 0)).toMatchInlineSnapshot(
+    '12301000000000000020001n',
+  )
 })
 
 test('decimals < fraction length', () => {

--- a/src/utils/unit/parseUnits.test.ts
+++ b/src/utils/unit/parseUnits.test.ts
@@ -50,6 +50,9 @@ test('decimals === 0', () => {
   expect(parseUnits('12301000000000000020000.5', 0)).toMatchInlineSnapshot(
     '12301000000000000020001n',
   )
+  expect(parseUnits('99999999999999999999999.5', 0)).toMatchInlineSnapshot(
+    '100000000000000000000000n',
+  )
 })
 
 test('decimals < fraction length', () => {

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -9,7 +9,7 @@ export function parseUnits(value: string, decimals: number) {
 
   // round off if the fraction is larger than the number of decimals.
   if (decimals === 0) {
-    if (Number(fraction.charAt(0)) >= 5) {
+    if (Number(fraction.slice(0, 1)) >= 5) {
       integer = `${BigInt(integer) + 1n}`
     }
     fraction = ''

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -9,9 +9,8 @@ export function parseUnits(value: string, decimals: number) {
 
   // round off if the fraction is larger than the number of decimals.
   if (decimals === 0) {
-    if (Number(fraction.slice(0, 1)) >= 5) {
+    if (Math.round(Number(`.${fraction}`)) === 1)
       integer = `${BigInt(integer) + 1n}`
-    }
     fraction = ''
   } else if (fraction.length > decimals) {
     const [left, unit, right] = [

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -9,7 +9,9 @@ export function parseUnits(value: string, decimals: number) {
 
   // round off if the fraction is larger than the number of decimals.
   if (decimals === 0) {
-    integer = `${Math.round(Number(`${integer}.${fraction}`))}`
+    if (fraction.charAt(0) >= '5') {
+      integer = `${BigInt(integer) + 1n}`
+    }
     fraction = ''
   } else if (fraction.length > decimals) {
     const [left, unit, right] = [

--- a/src/utils/unit/parseUnits.ts
+++ b/src/utils/unit/parseUnits.ts
@@ -9,7 +9,7 @@ export function parseUnits(value: string, decimals: number) {
 
   // round off if the fraction is larger than the number of decimals.
   if (decimals === 0) {
-    if (fraction.charAt(0) >= '5') {
+    if (Number(fraction.charAt(0)) >= 5) {
       integer = `${BigInt(integer) + 1n}`
     }
     fraction = ''


### PR DESCRIPTION
When parseUnits is called with 0 decimals and a large enough integer, the `Number()` parse can convert to scientific notation:

```
const value: string = '12301000000000000020000';
parseUnits(value, 0);

SyntaxError: Cannot convert 1.2301e+22 to a BigInt
```

This fixes using a similar check to the `fraction.length > decimals` code path

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing an issue in the `parseUnits` function where it would throw an error for large numbers with a fraction component. 

### Detailed summary
- Fixed the issue where `parseUnits` would throw `Cannot convert to a BigInt` for large numbers with a fraction component.
- Updated the logic in the `parseUnits` function to round off the fraction if it is larger than the number of decimals.
- Added new test cases for `parseUnits` function to ensure correct behavior.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->