### PR TITLE
Fix wrong mapping of JSON RPC method for watchAsset

### DIFF
--- a/site/docs/actions/wallet/watchAsset.md
+++ b/site/docs/actions/wallet/watchAsset.md
@@ -141,4 +141,4 @@ const success = await walletClient.watchAsset({
 
 ## JSON-RPC Methods
 
-[`eth_switchEthereumChain`](https://eips.ethereum.org/EIPS/eip-747)
+[`wallet_watchAsset`](https://eips.ethereum.org/EIPS/eip-747)


### PR DESCRIPTION
The docs stated the JSON RPC method was `eth_switchEthereumChain` but it should be `wallet_watchAsset`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the JSON-RPC method `eth_switchEthereumChain` to `wallet_watchAsset`.

### Detailed summary
- Renamed `eth_switchEthereumChain` JSON-RPC method to `wallet_watchAsset`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->