### PR TITLE
fix: capture unsupported error signatures in `ContractFunctionRevertedError`

### DIFF
--- a/.changeset/dirty-adults-scream.md
+++ b/.changeset/dirty-adults-scream.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Capture error signatures that do not exist on the ABI in `ContractFunctionRevertedError`.

--- a/src/actions/public/readContract.test.ts
+++ b/src/actions/public/readContract.test.ts
@@ -328,6 +328,36 @@ describe('contract errors', () => {
       Version: viem@1.0.2]
     `)
   })
+
+  test('custom error does not exist on abi', async () => {
+    const { contractAddress } = await deployErrorExample()
+
+    const abi = errorsExampleABI.filter(
+      (abiItem) => abiItem.name !== 'SimpleError',
+    )
+
+    await expect(() =>
+      readContract(publicClient, {
+        abi,
+        address: contractAddress!,
+        functionName: 'simpleCustomRead',
+      }),
+    ).rejects.toMatchInlineSnapshot(`
+      [ContractFunctionExecutionError: The contract function "simpleCustomRead" reverted with the following signature:
+      0xf9006398
+
+      Unable to decode signature "0xf9006398" as it was not found on the provided ABI.
+      Make sure you are using the correct ABI and that the error exists on it.
+      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xf9006398.
+       
+      Contract Call:
+        address:   0x0000000000000000000000000000000000000000
+        function:  simpleCustomRead()
+
+      Docs: https://viem.sh/docs/contract/decodeErrorResult.html
+      Version: viem@1.0.2]
+    `)
+  })
 })
 
 test('fake contract address', async () => {

--- a/src/errors/abi.ts
+++ b/src/errors/abi.ts
@@ -163,17 +163,21 @@ export class AbiErrorNotFoundError extends BaseError {
 
 export class AbiErrorSignatureNotFoundError extends BaseError {
   override name = 'AbiErrorSignatureNotFoundError'
+
+  signature: Hex
+
   constructor(signature: Hex, { docsPath }: { docsPath: string }) {
     super(
       [
         `Encoded error signature "${signature}" not found on ABI.`,
         'Make sure you are using the correct ABI and that the error exists on it.',
-        `You can look up the signature here: https://openchain.xyz/signatures?query=${signature}.`,
+        `You can look up the decoded signature here: https://openchain.xyz/signatures?query=${signature}.`,
       ].join('\n'),
       {
         docsPath,
       },
     )
+    this.signature = signature
   }
 }
 

--- a/src/errors/contract.test.ts
+++ b/src/errors/contract.test.ts
@@ -393,4 +393,24 @@ describe('ContractFunctionRevertedError', () => {
       Version: viem@1.0.2]
     `)
   })
+
+  test('data: error signature does not exist on ABI', () => {
+    expect(
+      new ContractFunctionRevertedError({
+        abi: errorsExampleABI,
+        data: '0xdb731cfa000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000450000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000004500000000000000000000000000000000000000000000000000000000000000066275676765720000000000000000000000000000000000000000000000000000',
+        functionName: 'totalSupply',
+      }),
+    ).toMatchInlineSnapshot(`
+      [ContractFunctionRevertedError: The contract function "totalSupply" reverted with the following signature:
+      0xdb731cfa
+
+      Unable to decode signature "0xdb731cfa" as it was not found on the provided ABI.
+      Make sure you are using the correct ABI and that the error exists on it.
+      You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xdb731cfa.
+
+      Docs: https://viem.sh/docs/contract/decodeErrorResult.html
+      Version: viem@1.0.2]
+    `)
+  })
 })

--- a/src/utils/abi/decodeErrorResult.test.ts
+++ b/src/utils/abi/decodeErrorResult.test.ts
@@ -211,7 +211,7 @@ test("errors: error doesn't exist", () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     "Encoded error signature \\"0xa3741467\\" not found on ABI.
     Make sure you are using the correct ABI and that the error exists on it.
-    You can look up the signature here: https://openchain.xyz/signatures?query=0xa3741467.
+    You can look up the decoded signature here: https://openchain.xyz/signatures?query=0xa3741467.
 
     Docs: https://viem.sh/docs/contract/decodeErrorResult.html
     Version: viem@1.0.2"


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on capturing error signatures that do not exist on the ABI in `ContractFunctionRevertedError`. The notable changes are:

- Added `signature` property to `ContractFunctionRevertedError` class.
- Updated error message to include the decoded signature and a link to look it up.
- Updated test cases to reflect the changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->