### PR TITLE
fix: Rename the  and  types with the appropriate file prefixes

### DIFF
--- a/.changeset/honest-grapes-leave.md
+++ b/.changeset/honest-grapes-leave.md
@@ -1,0 +1,12 @@
+---
+"viem": minor
+---
+
+Renamed the `OnLogParameter` and `OnLogFn` types with the appropriate file prefixes.
+
+- `watchEvent.ts`
+  - Renamed to `WatchEventOnLogParameter` and `WatchEventOnLogFn`.
+  - Deprecated the `OnLogParameter` and `OnLogFn` exports.
+- `watchContractEvent.ts`
+  - Renamed to `WatchContractEventOnLogParameter` and `WatchContractEventOnLogFn`.
+  - Exported both types.

--- a/.changeset/honest-grapes-leave.md
+++ b/.changeset/honest-grapes-leave.md
@@ -1,12 +1,6 @@
 ---
-"viem": minor
+"viem": patch
 ---
 
-Renamed the `OnLogParameter` and `OnLogFn` types with the appropriate file prefixes.
-
-- `watchEvent.ts`
-  - Renamed to `WatchEventOnLogParameter` and `WatchEventOnLogFn`.
-  - Deprecated the `OnLogParameter` and `OnLogFn` exports.
-- `watchContractEvent.ts`
-  - Renamed to `WatchContractEventOnLogParameter` and `WatchContractEventOnLogFn`.
-  - Exported both types.
+Deprecated `OnLogParameter` & `OnLogFn` in favor of `WatchEventOnLogParameter` & `WatchEventOnLogFn` types.
+Added `WatchContractEventOnLogParameter` & `WatchContractEventOnLogFn` types.

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -161,10 +161,10 @@ export {
 } from './public/watchBlockNumber.js'
 export {
   type WatchEventOnLogsFn,
-  /** @deprecated - use WatchEventOnLogsFn instead. */
+  /** @deprecated - use `WatchEventOnLogsFn` instead. */
   type WatchEventOnLogsFn as OnLogsFn,
   type WatchEventOnLogsParameter,
-  /** @deprecated - use WatchEventOnLogsParameter instead. */
+  /** @deprecated - use `WatchEventOnLogsParameter` instead. */
   type WatchEventOnLogsParameter as OnLogsParameter,
   type WatchEventParameters,
   type WatchEventReturnType,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -161,10 +161,10 @@ export {
 } from './public/watchBlockNumber.js'
 export {
   type WatchEventOnLogsFn,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsFn instead. */
   type WatchEventOnLogsFn as OnLogsFn,
   type WatchEventOnLogsParameter,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsParameter instead. */
   type WatchEventOnLogsParameter as OnLogsParameter,
   type WatchEventParameters,
   type WatchEventReturnType,

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -160,8 +160,12 @@ export {
   watchBlockNumber,
 } from './public/watchBlockNumber.js'
 export {
-  type OnLogsFn,
-  type OnLogsParameter,
+  type WatchEventOnLogsFn,
+  /** @deprecated */
+  type WatchEventOnLogsFn as OnLogsFn,
+  type WatchEventOnLogsParameter,
+  /** @deprecated */
+  type WatchEventOnLogsParameter as OnLogsParameter,
   type WatchEventParameters,
   type WatchEventReturnType,
   watchEvent,

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -16,7 +16,7 @@ import * as getBlockNumber from './getBlockNumber.js'
 import * as getFilterChanges from './getFilterChanges.js'
 import * as getLogs from './getLogs.js'
 import {
-  type OnLogsParameter,
+  type WatchContractEventOnLogsParameter,
   watchContractEvent,
 } from './watchContractEvent.js'
 
@@ -45,7 +45,9 @@ beforeAll(async () => {
 test(
   'default',
   async () => {
-    const logs: OnLogsParameter<typeof usdcContractConfig.abi>[] = []
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
 
     const unwatch = watchContractEvent(publicClient, {
       abi: usdcContractConfig.abi,
@@ -114,7 +116,7 @@ test(
 )
 
 test('args: batch', async () => {
-  const logs: OnLogsParameter[] = []
+  const logs: WatchContractEventOnLogsParameter[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -152,7 +154,9 @@ test('args: batch', async () => {
 })
 
 test('args: eventName', async () => {
-  const logs: OnLogsParameter<typeof usdcContractConfig.abi>[] = []
+  const logs: WatchContractEventOnLogsParameter<
+    typeof usdcContractConfig.abi
+  >[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -208,7 +212,9 @@ test('args: eventName', async () => {
 })
 
 test('args: args', async () => {
-  const logs: OnLogsParameter<typeof usdcContractConfig.abi>[] = []
+  const logs: WatchContractEventOnLogsParameter<
+    typeof usdcContractConfig.abi
+  >[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -254,7 +260,9 @@ test('args: args', async () => {
 })
 
 test('args: args', async () => {
-  const logs: OnLogsParameter<typeof usdcContractConfig.abi>[] = []
+  const logs: WatchContractEventOnLogsParameter<
+    typeof usdcContractConfig.abi
+  >[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -306,7 +314,9 @@ test('args: args', async () => {
 })
 
 test('args: args', async () => {
-  const logs: OnLogsParameter<typeof usdcContractConfig.abi>[] = []
+  const logs: WatchContractEventOnLogsParameter<
+    typeof usdcContractConfig.abi
+  >[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -372,7 +382,7 @@ test('args: args unnamed', async () => {
       ],
     },
   ] as const
-  const logs: OnLogsParameter<typeof unnamedAbi>[] = []
+  const logs: WatchContractEventOnLogsParameter<typeof unnamedAbi>[] = []
 
   const unwatch = watchContractEvent(publicClient, {
     ...usdcContractConfig,
@@ -435,7 +445,7 @@ describe('`getLogs` fallback', () => {
         'createContractEventFilter',
       ).mockRejectedValueOnce(new Error('foo'))
 
-      const logs: OnLogsParameter[] = []
+      const logs: WatchContractEventOnLogsParameter[] = []
 
       const unwatch = watchContractEvent(publicClient, {
         abi: usdcContractConfig.abi,
@@ -487,7 +497,7 @@ describe('`getLogs` fallback', () => {
         'createContractEventFilter',
       ).mockRejectedValueOnce(new Error('foo'))
 
-      const logs: OnLogsParameter[] = []
+      const logs: WatchContractEventOnLogsParameter[] = []
 
       const unwatch = watchContractEvent(publicClient, {
         abi: usdcContractConfig.abi,

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -23,18 +23,18 @@ import { getFilterChanges } from './getFilterChanges.js'
 import { type GetLogsParameters, getLogs } from './getLogs.js'
 import { uninstallFilter } from './uninstallFilter.js'
 
-export type OnLogsParameter<
+export type WatchContractEventOnLogsParameter<
   TAbi extends Abi | readonly unknown[] = readonly unknown[],
   TEventName extends string = string,
   TStrict extends boolean | undefined = undefined,
 > = TAbi extends Abi
   ? Log<bigint, number, ExtractAbiEvent<TAbi, TEventName>, TStrict>[]
   : Log[]
-export type OnLogsFn<
+export type WatchContractEventOnLogsFn<
   TAbi extends Abi | readonly unknown[] = readonly unknown[],
   TEventName extends string = string,
   TStrict extends boolean | undefined = undefined,
-> = (logs: OnLogsParameter<TAbi, TEventName, TStrict>) => void
+> = (logs: WatchContractEventOnLogsParameter<TAbi, TEventName, TStrict>) => void
 
 export type WatchContractEventParameters<
   TAbi extends Abi | readonly unknown[] = readonly unknown[],
@@ -53,7 +53,7 @@ export type WatchContractEventParameters<
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
   /** The callback to call when new event logs are received. */
-  onLogs: OnLogsFn<TAbi, TEventName, TStrict>
+  onLogs: WatchContractEventOnLogsFn<TAbi, TEventName, TStrict>
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
   pollingInterval?: number
   /**

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -15,7 +15,7 @@ import * as createEventFilter from './createEventFilter.js'
 import * as getBlockNumber from './getBlockNumber.js'
 import * as getFilterChanges from './getFilterChanges.js'
 import * as getLogs from './getLogs.js'
-import { type OnLogsParameter, watchEvent } from './watchEvent.js'
+import { type WatchEventOnLogsParameter, watchEvent } from './watchEvent.js'
 
 const event = {
   transfer: {
@@ -88,7 +88,7 @@ beforeAll(async () => {
 test(
   'default',
   async () => {
-    const logs: OnLogsParameter[] = []
+    const logs: WatchEventOnLogsParameter[] = []
 
     const unwatch = watchEvent(publicClient, {
       onLogs: (logs_) => logs.push(logs_),
@@ -125,7 +125,7 @@ test(
 )
 
 test('args: batch', async () => {
-  const logs: OnLogsParameter[] = []
+  const logs: WatchEventOnLogsParameter[] = []
 
   const unwatch = watchEvent(publicClient, {
     batch: false,
@@ -162,8 +162,8 @@ test('args: batch', async () => {
 })
 
 test('args: address', async () => {
-  const logs: OnLogsParameter[] = []
-  const logs2: OnLogsParameter[] = []
+  const logs: WatchEventOnLogsParameter[] = []
+  const logs2: WatchEventOnLogsParameter[] = []
 
   const unwatch = watchEvent(publicClient, {
     address: usdcContractConfig.address,
@@ -190,8 +190,8 @@ test('args: address', async () => {
 })
 
 test('args: address + event', async () => {
-  const logs: OnLogsParameter<typeof event.transfer>[] = []
-  const logs2: OnLogsParameter<typeof event.approval>[] = []
+  const logs: WatchEventOnLogsParameter<typeof event.transfer>[] = []
+  const logs2: WatchEventOnLogsParameter<typeof event.approval>[] = []
 
   const unwatch = watchEvent(publicClient, {
     address: usdcContractConfig.address,
@@ -241,7 +241,7 @@ describe('`getLogs` fallback', () => {
         new Error('foo'),
       )
 
-      const logs: OnLogsParameter[] = []
+      const logs: WatchEventOnLogsParameter[] = []
 
       const unwatch = watchEvent(publicClient, {
         onLogs: (logs_) => logs.push(logs_),
@@ -291,7 +291,7 @@ describe('`getLogs` fallback', () => {
         new Error('foo'),
       )
 
-      const logs: OnLogsParameter[] = []
+      const logs: WatchEventOnLogsParameter[] = []
 
       const unwatch = watchEvent(publicClient, {
         onLogs: (logs_) => logs.push(logs_),

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -22,16 +22,16 @@ import { getFilterChanges } from './getFilterChanges.js'
 import { getLogs } from './getLogs.js'
 import { uninstallFilter } from './uninstallFilter.js'
 
-export type OnLogsParameter<
+export type WatchEventOnLogsParameter<
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = Log<bigint, number, TAbiEvent, TStrict, [TAbiEvent], TEventName>[]
-export type OnLogsFn<
+export type WatchEventOnLogsFn<
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
-> = (logs: OnLogsParameter<TAbiEvent, TStrict, TEventName>) => void
+> = (logs: WatchEventOnLogsParameter<TAbiEvent, TStrict, TEventName>) => void
 
 export type WatchEventParameters<
   TAbiEvent extends AbiEvent | undefined = undefined,
@@ -48,7 +48,7 @@ export type WatchEventParameters<
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
   /** The callback to call when new event logs are received. */
-  onLogs: OnLogsFn<TAbiEvent, TStrict, TEventName>
+  onLogs: WatchEventOnLogsFn<TAbiEvent, TStrict, TEventName>
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
   pollingInterval?: number
 } & (

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -24,8 +24,12 @@ export {
   multicall,
 } from './actions/public/multicall.js'
 export type {
-  OnLogsFn,
-  OnLogsParameter,
+  WatchEventOnLogsFn,
+  /** @deprecated */
+  WatchEventOnLogsFn as OnLogsFn,
+  WatchEventOnLogsParameter,
+  /** @deprecated */
+  WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {
   type ReadContractParameters,

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -25,10 +25,10 @@ export {
 } from './actions/public/multicall.js'
 export type {
   WatchEventOnLogsFn,
-  /** @deprecated - use WatchEventOnLogsFn instead. */
+  /** @deprecated - use `WatchEventOnLogsFn` instead. */
   WatchEventOnLogsFn as OnLogsFn,
   WatchEventOnLogsParameter,
-  /** @deprecated - use WatchEventOnLogsParameter instead. */
+  /** @deprecated - use `WatchEventOnLogsParameter` instead. */
   WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -25,10 +25,10 @@ export {
 } from './actions/public/multicall.js'
 export type {
   WatchEventOnLogsFn,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsFn instead. */
   WatchEventOnLogsFn as OnLogsFn,
   WatchEventOnLogsParameter,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsParameter instead. */
   WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,10 +157,10 @@ export type {
 } from './actions/public/watchBlockNumber.js'
 export type {
   WatchEventOnLogsFn,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsFn instead. */
   WatchEventOnLogsFn as OnLogFn,
   WatchEventOnLogsParameter,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsParameter instead. */
   WatchEventOnLogsParameter as OnLogParameter,
   WatchEventParameters,
   WatchEventReturnType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,10 +157,10 @@ export type {
 } from './actions/public/watchBlockNumber.js'
 export type {
   WatchEventOnLogsFn,
-  /** @deprecated - use WatchEventOnLogsFn instead. */
+  /** @deprecated - use `WatchEventOnLogsFn` instead. */
   WatchEventOnLogsFn as OnLogFn,
   WatchEventOnLogsParameter,
-  /** @deprecated - use WatchEventOnLogsParameter instead. */
+  /** @deprecated - use `WatchEventOnLogsParameter` instead. */
   WatchEventOnLogsParameter as OnLogParameter,
   WatchEventParameters,
   WatchEventReturnType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,8 +156,12 @@ export type {
   WatchBlockNumberReturnType,
 } from './actions/public/watchBlockNumber.js'
 export type {
-  OnLogsFn,
-  OnLogsParameter,
+  WatchEventOnLogsFn,
+  /** @deprecated */
+  WatchEventOnLogsFn as OnLogFn,
+  WatchEventOnLogsParameter,
+  /** @deprecated */
+  WatchEventOnLogsParameter as OnLogParameter,
   WatchEventParameters,
   WatchEventReturnType,
 } from './actions/public/watchEvent.js'
@@ -233,6 +237,7 @@ export type {
   VerifyHashReturnType,
 } from './actions/public/verifyHash.js'
 export type {
+  WatchContractEventOnLogsParameter,
   WatchContractEventParameters,
   WatchContractEventReturnType,
 } from './actions/public/watchContractEvent.js'

--- a/src/public.ts
+++ b/src/public.ts
@@ -115,10 +115,10 @@ export {
 export {
   watchEvent,
   type WatchEventOnLogsFn,
-  /** @deprecated - use WatchEventOnLogsFn instead. */
+  /** @deprecated - use `WatchEventOnLogsFn` instead. */
   type WatchEventOnLogsFn as OnLogsFn,
   type WatchEventOnLogsParameter,
-  /** @deprecated - use WatchEventOnLogsParameter instead. */
+  /** @deprecated - use `WatchEventOnLogsParameter` instead. */
   type WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {

--- a/src/public.ts
+++ b/src/public.ts
@@ -114,8 +114,12 @@ export {
 } from './actions/public/watchBlocks.js'
 export {
   watchEvent,
-  type OnLogsFn,
-  type OnLogsParameter,
+  type WatchEventOnLogsFn,
+  /** @deprecated */
+  type WatchEventOnLogsFn as OnLogsFn,
+  type WatchEventOnLogsParameter,
+  /** @deprecated */
+  type WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {
   watchPendingTransactions,

--- a/src/public.ts
+++ b/src/public.ts
@@ -115,10 +115,10 @@ export {
 export {
   watchEvent,
   type WatchEventOnLogsFn,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsFn instead. */
   type WatchEventOnLogsFn as OnLogsFn,
   type WatchEventOnLogsParameter,
-  /** @deprecated */
+  /** @deprecated - use WatchEventOnLogsParameter instead. */
   type WatchEventOnLogsParameter as OnLogsParameter,
 } from './actions/public/watchEvent.js'
 export {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Deprecated `OnLogParameter` and `OnLogFn` types in favor of `WatchEventOnLogParameter` and `WatchEventOnLogFn` types.
- Added `WatchContractEventOnLogParameter` and `WatchContractEventOnLogFn` types.
- Renamed and aliased types in multiple files to use the new types.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->

Resolves https://github.com/wagmi-dev/viem/issues/938