### PR TITLE
feat: support `events` on event actions

### DIFF
--- a/.changeset/nervous-impalas-cough.md
+++ b/.changeset/nervous-impalas-cough.md
@@ -16,8 +16,8 @@ import { publicClient } from './client'
 
 const logs = publicClient.getLogs({
   events: parseAbi([
-    'event Approval(address sender, address owner, uint256 value)',
-    'event Transfer(address from, address to, uint256 value)',
+    'event Approval(address indexed owner, address indexed sender, uint256 value)',
+    'event Transfer(address indexed from, address indexed to, uint256 value)',
   ])
 })
 ```

--- a/.changeset/nervous-impalas-cough.md
+++ b/.changeset/nervous-impalas-cough.md
@@ -1,0 +1,23 @@
+---
+"viem": minor
+---
+
+Added support for multiple `events` on Filters/Log Actions:
+
+- `createEventFilter`
+- `getLogs`
+- `watchEvent`
+
+Example:
+
+```ts
+import { parseAbi } from 'viem'
+import { publicClient } from './client'
+
+const logs = publicClient.getLogs({
+  events: parseAbi([
+    'event Approval(address sender, address owner, uint256 value)',
+    'event Transfer(address from, address to, uint256 value)',
+  ])
+})
+```

--- a/site/docs/actions/public/createEventFilter.md
+++ b/site/docs/actions/public/createEventFilter.md
@@ -184,6 +184,21 @@ const filter = await publicClient.createEventFilter({
 })
 ```
 
+### Multiple Events
+
+A Filter can be scoped to **multiple events**:
+
+```ts
+const filter = await publicClient.createEventFilter({
+  events: parseAbi([ // [!code focus:4]
+    'event Approval(address indexed owner, address indexed sender, uint256 value)',
+    'event Transfer(address indexed from, address indexed to, uint256 value)',
+  ]),
+})
+```
+
+Note: A Filter scoped to multiple events cannot be also scoped with [indexed arguments](#arguments) (`args`).
+
 ### Strict Mode
 
 By default, `createEventFilter` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`.
@@ -202,7 +217,7 @@ logs[0].args
 
 You can turn on `strict` mode to only return logs that conform to the indexed & non-indexed arguments on the `event`, meaning that `args` will always be defined. The trade-off is that non-conforming logs will be filtered out.
 
-```ts {8}
+```ts {9}
 const filter = await publicClient.createEventFilter({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),

--- a/site/docs/actions/public/getLogs.md
+++ b/site/docs/actions/public/getLogs.md
@@ -14,7 +14,7 @@ head:
 
 # getLogs
 
-Returns a list of **event** logs matching the provided parameters. 
+Returns a list of **event** logs matching the provided parameters.
 
 ## Usage
 
@@ -82,7 +82,7 @@ By default, `event` accepts the [`AbiEvent`](/docs/glossary/types#abievent) type
 ```ts [example.ts]
 import { publicClient } from './client'
 
-const filter = await publicClient.getLogs(publicClient, {
+const logs = await publicClient.getLogs(publicClient, {
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: { // [!code focus:8]
     name: 'Transfer', 
@@ -115,14 +115,14 @@ export const publicClient = createPublicClient({
 
 ### Address
 
-A Filter can be scoped to an **address**:
+Logs can be scoped to an **address**:
 
 ::: code-group
 
 ```ts [example.ts]
 import { publicClient } from './client'
 
-const filter = await publicClient.getLogs({
+const logs = await publicClient.getLogs({
   address: '0xfba3912ca04dd458c843e2ee08967fc04f3579c2' // [!code focus]
 })
 ```
@@ -141,7 +141,7 @@ export const publicClient = createPublicClient({
 
 ### Event
 
-A Filter can be scoped to an **event**.
+Logs can be scoped to an **event**.
 
 The `event` argument takes in an event in ABI format – we have a [`parseAbiItem` utility](/docs/abi/parseAbiItem) that you can use to convert from a human-readable event signature → ABI.
 
@@ -151,7 +151,7 @@ The `event` argument takes in an event in ABI format – we have a [`parseAbiIte
 import { parseAbiItem } from 'viem' // [!code focus]
 import { publicClient } from './client'
 
-const filter = await publicClient.getLogs({
+const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'), // [!code focus]
 })
@@ -171,10 +171,10 @@ export const publicClient = createPublicClient({
 
 ### Arguments
 
-A Filter can be scoped to given **_indexed_ arguments**:
+Logs can be scoped to given **_indexed_ arguments**:
 
 ```ts
-const filter = await publicClient.getLogs({
+const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),
   args: { // [!code focus:4]
@@ -186,10 +186,10 @@ const filter = await publicClient.getLogs({
 
 Only indexed arguments in `event` are candidates for `args`.
 
-A Filter Argument can also be an array to indicate that other values can exist in the position:
+An argument can also be an array to indicate that other values can exist in the position:
 
 ```ts
-const filter = await publicClient.getLogs({
+const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),
   args: { // [!code focus:8]
@@ -205,10 +205,10 @@ const filter = await publicClient.getLogs({
 
 ### Block Range
 
-A Filter can be scoped to a **block range**:
+Logs can be scoped to a **block range**:
 
 ```ts
-const filter = await publicClient.getLogs({
+const logs = await publicClient.getLogs({
   address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 value)'),
   fromBlock: 16330000n, // [!code focus]
@@ -216,9 +216,24 @@ const filter = await publicClient.getLogs({
 })
 ```
 
+### Multiple Events
+
+Logs can be scoped to **multiple events**:
+
+```ts
+const logs = await publicClient.getLogs({
+  events: parseAbi([ // [!code focus:4]
+    'event Approval(address indexed owner, address indexed sender, uint256 value)',
+    'event Transfer(address indexed from, address indexed to, uint256 value)',
+  ]),
+})
+```
+
+Note: Logs scoped to multiple events cannot be also scoped with [indexed arguments](#arguments) (`args`).
+
 ### Strict Mode
 
-By default, `getLogs` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`. 
+By default, `getLogs` will include logs that [do not conform](/docs/glossary/terms.html#non-conforming-log) to the indexed & non-indexed arguments on the `event`.
 viem will not return a value for arguments that do not conform to the ABI, thus, some arguments on `args` may be undefined.
 
 ```ts {7}

--- a/site/docs/actions/public/watchEvent.md
+++ b/site/docs/actions/public/watchEvent.md
@@ -16,13 +16,13 @@ head:
 
 Watches and returns emitted [Event Logs](/docs/glossary/terms#event-log).
 
-This Action will batch up all the Event Logs found within the [`pollingInterval`](#pollinginterval-optional), and invoke them via [`onLogs`](#onLogs).
+This Action will batch up all the Event Logs found within the [`pollingInterval`](#pollinginterval-optional), and invoke them via [`onLogs`](#onlogs).
 
 `watchEvent` will attempt to create an [Event Filter](https://viem.sh/docs/actions/public/createEventFilter.html) and listen to changes to the Filter per polling interval, however, if the RPC Provider does not support Filters (ie. `eth_newFilter`), then `watchEvent` will fall back to using [`getLogs`](/docs/actions/public/getLogs) instead.
 
 ## Usage
 
-By default, you can watch all broadcasted events to the blockchain by just passing `onLogs`. 
+By default, you can watch all broadcasted events to the blockchain by just passing `onLogs`.
 
 These events will be batched up into [Event Logs](/docs/glossary/terms#event-log) and sent to `onLogs`:
 
@@ -157,7 +157,7 @@ export const publicClient = createPublicClient({
 
 ### Arguments
 
-`watchEvents` can be scoped to given **_indexed_ arguments** on the event:
+`watchEvent` can be scoped to given **_indexed_ arguments** on the event:
 
 ::: code-group
 
@@ -210,6 +210,22 @@ const unwatch = publicClient.watchEvent({
   onLogs: logs => console.log(logs)
 })
 ```
+
+### Multiple Events
+
+`watchEvent` can be scoped to **multiple events**:
+
+```ts
+const unwatch = publicClient.watchEvent({
+  events: parseAbi([ // [!code focus:5]
+    'event Approval(address indexed owner, address indexed sender, uint256 value)',
+    'event Transfer(address indexed from, address indexed to, uint256 value)',
+  ]),
+  onLogs: logs => console.log(logs)
+})
+```
+
+Note: `watchEvent` scoped to multiple events cannot be also scoped with [indexed arguments](#arguments) (`args`).
 
 ## Returns
 
@@ -285,6 +301,7 @@ const unwatch = publicClient.watchEvent(
   }
 )
 ```
+
 ### batch (optional)
 
 - **Type:** `boolean`

--- a/src/actions/public/createEventFilter.test.ts
+++ b/src/actions/public/createEventFilter.test.ts
@@ -30,6 +30,27 @@ const event = {
     name: 'Transfer',
     type: 'event',
   },
+  approve: {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+  },
   unnamed: {
     inputs: [
       {
@@ -88,6 +109,23 @@ describe('default', () => {
     expect(filter.args).toBeUndefined()
     expect(filter.abi).toEqual([event.default])
     expect(filter.eventName).toEqual('Transfer')
+  })
+
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [event.default, event.approve],
+    })
+    assertType<typeof filter>({
+      abi: [event.default, event.approve],
+      eventName: undefined,
+      id: '0x',
+      request,
+      strict: undefined,
+      type: 'event',
+    })
+    expect(filter.args).toBeUndefined()
+    expect(filter.abi).toEqual([event.default, event.approve])
+    expect(filter.eventName).toBeUndefined()
   })
 
   test('args: args (named)', async () => {

--- a/src/actions/public/getFilterChanges.test-d.ts
+++ b/src/actions/public/getFilterChanges.test-d.ts
@@ -227,6 +227,95 @@ describe('createEventFilter', () => {
     >()
   })
 
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+        {
+          type: 'event',
+          name: 'Approval',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+  })
+
   test('strict: named', async () => {
     const filter = await createEventFilter(publicClient, {
       event: {
@@ -378,6 +467,37 @@ describe('createContractEventFilter', () => {
           spender?: Address
           value?: bigint
         }
+      | {
+          owner?: Address
+          spender?: Address
+          foo?: Address
+          value?: bigint
+          bar?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(logs[0].eventName === 'Foo' && logs[0].args).toEqualTypeOf<
+      | false
       | {
           owner?: Address
           spender?: Address

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -57,6 +57,27 @@ const event = {
     name: 'Transfer',
     type: 'event',
   },
+  approve: {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+  },
   invalid: {
     inputs: [
       {
@@ -725,6 +746,65 @@ describe('events', () => {
       value: 1n,
     })
     expect(logs[1].eventName).toEqual('Transfer')
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(0)
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[2].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+
+    logs = await getFilterChanges(publicClient, { filter })
+    expect(logs.length).toBe(1)
+    expect(logs[0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[2].address),
+      value: 1n,
+    })
+    expect(logs[0].eventName).toEqual('Transfer')
+  })
+
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [event.default, event.approve],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'approve',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+
+    await mine(testClient, { blocks: 1 })
+
+    let logs = await getFilterChanges(publicClient, {
+      filter,
+    })
+
+    expect(logs.length).toBe(2)
+    expect(logs[0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0].eventName).toEqual('Transfer')
+    expect(logs[1].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(accounts[1].address),
+      value: 1n,
+    })
+    expect(logs[1].eventName).toEqual('Approval')
 
     logs = await getFilterChanges(publicClient, { filter })
     expect(logs.length).toBe(0)

--- a/src/actions/public/getFilterChanges.ts
+++ b/src/actions/public/getFilterChanges.ts
@@ -16,8 +16,8 @@ import { formatLog } from '../../utils/formatters/log.js'
 
 export type GetFilterChangesParameters<
   TFilterType extends FilterType = FilterType,
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
   TToBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -35,8 +35,8 @@ export type GetFilterChangesParameters<
 
 export type GetFilterChangesReturnType<
   TFilterType extends FilterType = FilterType,
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
   TToBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -138,7 +138,7 @@ export async function getFilterChanges<
   TTransport extends Transport,
   TChain extends Chain | undefined,
   TFilterType extends FilterType,
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] | undefined,
   TEventName extends string | undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,

--- a/src/actions/public/getFilterLogs.test-d.ts
+++ b/src/actions/public/getFilterLogs.test-d.ts
@@ -227,6 +227,95 @@ describe('createEventFilter', () => {
     >()
   })
 
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [
+        {
+          inputs: [
+            {
+              indexed: true,
+              name: 'from',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'to',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+          name: 'Transfer',
+          type: 'event',
+        },
+        {
+          type: 'event',
+          name: 'Approval',
+          inputs: [
+            {
+              indexed: true,
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              indexed: true,
+              name: 'spender',
+              type: 'address',
+            },
+            {
+              indexed: false,
+              name: 'value',
+              type: 'uint256',
+            },
+          ],
+        },
+      ],
+    })
+    const logs = await getFilterLogs(publicClient, {
+      filter,
+    })
+    expectTypeOf(logs[0].topics).toEqualTypeOf<
+      [`0x${string}`, `0x${string}`, `0x${string}`]
+    >()
+    expectTypeOf(logs[0].eventName).toEqualTypeOf<'Transfer' | 'Approval'>()
+    expectTypeOf(logs[0].args).toEqualTypeOf<
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+
+    expectTypeOf(
+      logs[0].eventName === 'Transfer' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          from?: Address
+          to?: Address
+          value?: bigint
+        }
+    >()
+    expectTypeOf(
+      logs[0].eventName === 'Approval' && logs[0].args,
+    ).toEqualTypeOf<
+      | false
+      | {
+          owner?: Address
+          spender?: Address
+          value?: bigint
+        }
+    >()
+  })
+
   test('strict: named', async () => {
     const filter = await createEventFilter(publicClient, {
       event: {

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -52,6 +52,27 @@ const event = {
     name: 'Transfer',
     type: 'event',
   },
+  approve: {
+    type: 'event',
+    name: 'Approval',
+    inputs: [
+      {
+        indexed: true,
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        name: 'spender',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        name: 'value',
+        type: 'uint256',
+      },
+    ],
+  },
   invalid: {
     inputs: [
       {
@@ -659,6 +680,42 @@ describe('raw events', () => {
       value: 1n,
     })
     expect(logs[1].eventName).toEqual('Transfer')
+  })
+
+  test('args: events', async () => {
+    const filter = await createEventFilter(publicClient, {
+      events: [event.default, event.approve],
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'approve',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+
+    await mine(testClient, { blocks: 1 })
+
+    const logs = await getFilterLogs(publicClient, { filter })
+    expect(logs.length).toBe(2)
+    expect(logs[0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0].eventName).toEqual('Transfer')
+    expect(logs[1].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(accounts[1].address),
+      value: 1n,
+    })
+    expect(logs[1].eventName).toEqual('Approval')
   })
 
   test('args: fromBlock/toBlock', async () => {

--- a/src/actions/public/getFilterLogs.ts
+++ b/src/actions/public/getFilterLogs.ts
@@ -14,8 +14,8 @@ import { decodeEventLog } from '../../utils/abi/decodeEventLog.js'
 import { formatLog } from '../../utils/formatters/log.js'
 
 export type GetFilterLogsParameters<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
   TToBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -23,8 +23,8 @@ export type GetFilterLogsParameters<
   filter: Filter<'event', TAbi, TEventName, any, TStrict, TFromBlock, TToBlock>
 }
 export type GetFilterLogsReturnType<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = string,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
+  TEventName extends string | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
   TToBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -67,7 +67,7 @@ export type GetFilterLogsReturnType<
  */
 export async function getFilterLogs<
   TChain extends Chain | undefined,
-  TAbi extends Abi | readonly unknown[],
+  TAbi extends Abi | readonly unknown[] | undefined,
   TEventName extends string | undefined,
   TStrict extends boolean | undefined = undefined,
   TFromBlock extends BlockNumber | BlockTag | undefined = undefined,

--- a/src/actions/public/getLogs.test-d.ts
+++ b/src/actions/public/getLogs.test-d.ts
@@ -41,7 +41,6 @@ test('event: const assertion', async () => {
   const logs = await getLogs(publicClient, {
     event,
   })
-  logs[0].topics
   expectTypeOf(logs[0]['eventName']).toEqualTypeOf<'Transfer'>()
   expectTypeOf(logs[0]['topics']).toEqualTypeOf<
     [`0x${string}`, `0x${string}`, `0x${string}`]

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -1,4 +1,4 @@
-import type { AbiEvent, Address } from 'abitype'
+import type { AbiEvent, Address, Narrow } from 'abitype'
 
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
@@ -19,24 +19,38 @@ import {
 } from './createEventFilter.js'
 import { getBlockNumber } from './getBlockNumber.js'
 import { getFilterChanges } from './getFilterChanges.js'
-import { getLogs } from './getLogs.js'
+import { type GetLogsParameters, getLogs } from './getLogs.js'
 import { uninstallFilter } from './uninstallFilter.js'
 
 export type WatchEventOnLogsParameter<
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
   TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
-> = Log<bigint, number, false, TAbiEvent, TStrict, [TAbiEvent], TEventName>[]
+> = Log<bigint, number, false, TAbiEvent, TStrict, TAbiEvents, TEventName>[]
 export type WatchEventOnLogsFn<
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
-  TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
-> = (logs: WatchEventOnLogsParameter<TAbiEvent, TStrict, TEventName>) => void
+  _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
+> = (
+  logs: WatchEventOnLogsParameter<TAbiEvent, TAbiEvents, TStrict, _EventName>,
+) => void
 
 export type WatchEventParameters<
   TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
-  TEventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
+  _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
 > = {
   /** The address of the contract. */
   address?: Address | Address[]
@@ -48,13 +62,14 @@ export type WatchEventParameters<
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
   /** The callback to call when new event logs are received. */
-  onLogs: WatchEventOnLogsFn<TAbiEvent, TStrict, TEventName>
+  onLogs: WatchEventOnLogsFn<TAbiEvent, TAbiEvents, TStrict, _EventName>
   /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
   pollingInterval?: number
 } & (
   | {
-      event: TAbiEvent
-      args?: MaybeExtractEventArgsFromAbi<[TAbiEvent], TEventName>
+      event: Narrow<TAbiEvent>
+      events?: never
+      args?: MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
       /**
        * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
        * @default false
@@ -63,6 +78,17 @@ export type WatchEventParameters<
     }
   | {
       event?: never
+      events?: Narrow<TAbiEvents>
+      args?: never
+      /**
+       * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
+       * @default false
+       */
+      strict?: TStrict
+    }
+  | {
+      event?: never
+      events?: never
       args?: never
       strict?: never
     }
@@ -104,9 +130,13 @@ export type WatchEventReturnType = () => void
  */
 export function watchEvent<
   TChain extends Chain | undefined,
-  TAbiEvent extends AbiEvent | undefined,
-  TEventName extends string | undefined,
+  TAbiEvent extends AbiEvent | undefined = undefined,
+  TAbiEvents extends
+    | readonly AbiEvent[]
+    | readonly unknown[]
+    | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
   TStrict extends boolean | undefined = undefined,
+  _EventName extends string | undefined = undefined,
 >(
   client: Client<Transport, TChain>,
   {
@@ -114,11 +144,12 @@ export function watchEvent<
     args,
     batch = true,
     event,
+    events,
     onError,
     onLogs,
     pollingInterval = client.pollingInterval,
     strict: strict_,
-  }: WatchEventParameters<TAbiEvent, TStrict>,
+  }: WatchEventParameters<TAbiEvent, TAbiEvents, TStrict>,
 ): WatchEventReturnType {
   const observerId = stringify([
     'watchEvent',
@@ -133,7 +164,7 @@ export function watchEvent<
 
   return observe(observerId, { onLogs, onError }, (emit) => {
     let previousBlockNumber: bigint
-    let filter: Filter<'event', [TAbiEvent], TEventName, any>
+    let filter: Filter<'event', TAbiEvents, _EventName, any>
     let initialized = false
 
     const unwatch = poll(
@@ -144,11 +175,12 @@ export function watchEvent<
               address,
               args,
               event: event!,
+              events,
               strict,
             } as unknown as CreateEventFilterParameters)) as unknown as Filter<
               'event',
-              [TAbiEvent],
-              TEventName
+              TAbiEvents,
+              _EventName
             >
           } catch {}
           initialized = true
@@ -173,10 +205,11 @@ export function watchEvent<
               logs = await getLogs(client, {
                 address,
                 args,
+                event: event!,
+                events,
                 fromBlock: previousBlockNumber + 1n,
                 toBlock: blockNumber,
-                event: event!,
-              })
+              } as unknown as GetLogsParameters)
             } else {
               logs = []
             }

--- a/src/clients/decorators/public.ts
+++ b/src/clients/decorators/public.ts
@@ -325,32 +325,35 @@ export type PublicActions<
    * })
    */
   createEventFilter: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
     TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
     TToBlock extends BlockNumber | BlockTag | undefined = undefined,
-    _Abi extends Abi | readonly unknown[] = [TAbiEvent],
     _EventName extends string | undefined = MaybeAbiEventName<TAbiEvent>,
     _Args extends
-      | MaybeExtractEventArgsFromAbi<_Abi, _EventName>
+      | MaybeExtractEventArgsFromAbi<TAbiEvents, _EventName>
       | undefined = undefined,
   >(
     args?: CreateEventFilterParameters<
       TAbiEvent,
+      TAbiEvents,
       TStrict,
       TFromBlock,
       TToBlock,
-      _Abi,
       _EventName,
       _Args
     >,
   ) => Promise<
     CreateEventFilterReturnType<
       TAbiEvent,
+      TAbiEvents,
       TStrict,
       TFromBlock,
       TToBlock,
-      _Abi,
       _EventName,
       _Args
     >
@@ -841,7 +844,7 @@ export type PublicActions<
    */
   getFilterChanges: <
     TFilterType extends FilterType,
-    TAbi extends Abi | readonly unknown[],
+    TAbi extends Abi | readonly unknown[] | undefined,
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
     TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -892,7 +895,7 @@ export type PublicActions<
    * const logs = await client.getFilterLogs({ filter })
    */
   getFilterLogs: <
-    TAbi extends Abi | readonly unknown[],
+    TAbi extends Abi | readonly unknown[] | undefined,
     TEventName extends string | undefined,
     TStrict extends boolean | undefined = undefined,
     TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
@@ -948,13 +951,25 @@ export type PublicActions<
    * const logs = await client.getLogs()
    */
   getLogs: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
     TFromBlock extends BlockNumber | BlockTag | undefined = undefined,
     TToBlock extends BlockNumber | BlockTag | undefined = undefined,
   >(
-    args?: GetLogsParameters<TAbiEvent, TStrict, TFromBlock, TToBlock>,
-  ) => Promise<GetLogsReturnType<TAbiEvent, TStrict, TFromBlock, TToBlock>>
+    args?: GetLogsParameters<
+      TAbiEvent,
+      TAbiEvents,
+      TStrict,
+      TFromBlock,
+      TToBlock
+    >,
+  ) => Promise<
+    GetLogsReturnType<TAbiEvent, TAbiEvents, TStrict, TFromBlock, TToBlock>
+  >
   /**
    * Returns the value from a storage slot at a given address.
    *
@@ -1406,10 +1421,14 @@ export type PublicActions<
    * })
    */
   watchEvent: <
-    TAbiEvent extends AbiEvent | undefined,
+    TAbiEvent extends AbiEvent | undefined = undefined,
+    TAbiEvents extends
+      | readonly AbiEvent[]
+      | readonly unknown[]
+      | undefined = TAbiEvent extends AbiEvent ? [TAbiEvent] : undefined,
     TStrict extends boolean | undefined = undefined,
   >(
-    args: WatchEventParameters<TAbiEvent, TStrict>,
+    args: WatchEventParameters<TAbiEvent, TAbiEvents, TStrict>,
   ) => WatchEventReturnType
   /**
    * Watches and returns pending transaction hashes.

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -83,9 +83,13 @@ export type MaybeAbiEventName<TAbiEvent extends AbiEvent | undefined> =
   TAbiEvent extends AbiEvent ? TAbiEvent['name'] : undefined
 
 export type MaybeExtractEventArgsFromAbi<
-  TAbi extends Abi | readonly unknown[] = Abi,
-  TEventName extends string | undefined = undefined,
-> = TEventName extends string ? GetEventArgs<TAbi, TEventName> : undefined
+  TAbi extends Abi | readonly unknown[] | undefined,
+  TEventName extends string | undefined,
+> = TAbi extends Abi | readonly unknown[]
+  ? TEventName extends string
+    ? GetEventArgs<TAbi, TEventName>
+    : undefined
+  : undefined
 
 //////////////////////////////////////////////////////////////////////
 // ABI item name

--- a/src/types/filter.ts
+++ b/src/types/filter.ts
@@ -17,7 +17,7 @@ type FilterRpcSchema = Filter_<
 
 export type Filter<
   TFilterType extends FilterType = 'event',
-  TAbi extends Abi | readonly unknown[] = Abi,
+  TAbi extends Abi | readonly unknown[] | undefined = undefined,
   TEventName extends string | undefined = undefined,
   TArgs extends
     | MaybeExtractEventArgsFromAbi<TAbi, TEventName>

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -18,7 +18,9 @@ export type Log<
   TPending extends boolean = boolean,
   TAbiEvent extends AbiEvent | undefined = undefined,
   TStrict extends boolean | undefined = undefined,
-  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
+  TAbi extends Abi | readonly unknown[] | undefined = TAbiEvent extends AbiEvent
+    ? [TAbiEvent]
+    : undefined,
   TEventName extends string | undefined = TAbiEvent extends AbiEvent
     ? TAbiEvent['name']
     : undefined,
@@ -80,7 +82,9 @@ type GetTopics<
 
 type GetInferredLogValues<
   TAbiEvent extends AbiEvent | undefined = undefined,
-  TAbi extends Abi | readonly unknown[] = [TAbiEvent],
+  TAbi extends Abi | readonly unknown[] | undefined = TAbiEvent extends AbiEvent
+    ? [TAbiEvent]
+    : undefined,
   TEventName extends string | undefined = TAbiEvent extends AbiEvent
     ? TAbiEvent['name']
     : undefined,
@@ -111,7 +115,7 @@ type GetInferredLogValues<
         [TName in _EventNames]: {
           args: GetEventArgs<
             TAbi,
-            string,
+            TName,
             {
               EnableUnion: false
               IndexedOnly: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added support for multiple events on Filters/Log Actions
- Updated `createEventFilter`, `getLogs`, and `watchEvent` to accept an array of events
- Added example usage in the documentation

> The following files were skipped due to too many changes: `site/docs/actions/public/createEventFilter.md`, `src/actions/public/getFilterChanges.test.ts`, `src/actions/public/getFilterChanges.test-d.ts`, `site/docs/actions/public/watchEvent.md`, `src/actions/public/watchEvent.test.ts`, `src/clients/decorators/public.ts`, `src/actions/public/getLogs.ts`, `site/docs/actions/public/getLogs.md`, `src/actions/public/watchEvent.ts`, `src/actions/public/createEventFilter.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->