### PR TITLE
Add re-initialization logic for event filters

### DIFF
--- a/.changeset/brown-horses-design.md
+++ b/.changeset/brown-horses-design.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Add filter reinitialization logic for watchContractEvent and watchEvent

--- a/.changeset/brown-horses-design.md
+++ b/.changeset/brown-horses-design.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Add filter reinitialization logic for watchContractEvent and watchEvent
+Added filter reinitialization logic for `watchContractEvent` and `watchEvent` for when a filter has been uninstalled.

--- a/.changeset/gold-days-juggle.md
+++ b/.changeset/gold-days-juggle.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Added event filter reinitialization logic to watchContractEvent

--- a/.changeset/gold-days-juggle.md
+++ b/.changeset/gold-days-juggle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added event filter reinitialization logic to watchContractEvent

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -11,6 +11,7 @@ import { setBalance } from '../test/setBalance.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { writeContract } from '../wallet/writeContract.js'
 
+import { InvalidInputRpcError, RpcRequestError } from '../../index.js'
 import * as createEventFilter from './createEventFilter.js'
 import * as getBlockNumber from './getBlockNumber.js'
 import * as getFilterChanges from './getFilterChanges.js'
@@ -385,4 +386,35 @@ describe('errors', () => {
     },
     { retry: 3 },
   )
+
+  test('re-initializes the filter if the active filter uninstalls', async () => {
+    const filterCreator = vi.spyOn(createEventFilter, 'createEventFilter')
+
+    const unwatch = watchEvent(publicClient, {
+      ...usdcContractConfig,
+      onLogs: () => null,
+      onError: () => null,
+      pollingInterval: 200,
+    })
+
+    await wait(250)
+    expect(filterCreator).toBeCalledTimes(1)
+
+    vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+      new InvalidInputRpcError(
+        new RpcRequestError({
+          body: { foo: 'bar' },
+          url: 'url',
+          error: {
+            code: -32000,
+            message: 'message',
+          },
+        }),
+      ),
+    )
+
+    await wait(500)
+    expect(filterCreator).toBeCalledTimes(2)
+    unwatch()
+  })
 })

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -13,6 +13,7 @@ import { observe } from '../../utils/observe.js'
 import { poll } from '../../utils/poll.js'
 import { stringify } from '../../utils/stringify.js'
 
+import { InvalidInputRpcError } from '../../errors/rpc.js'
 import {
   type CreateEventFilterParameters,
   createEventFilter,
@@ -187,6 +188,9 @@ export function watchEvent<
           if (batch) emit.onLogs(logs as any)
           else logs.forEach((log) => emit.onLogs([log] as any))
         } catch (err) {
+          // If a filter has been set and gets uninstalled, providers will throw an InvalidInput error.
+          // Reinitalize the filter when this occurs
+          if (filter && err instanceof InvalidInputRpcError) initialized = false
           emit.onError?.(err as Error)
         }
       },


### PR DESCRIPTION
Here's my proposal to address #836.  Filters can timeout or get into a bad state where reinitialization is necessary to continue getting filter changes on the polling interval. This request adds fallback reinitialization, so if 'getFilterChanges' fails repeatedly, it will attempt to recreate the filter.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on adding filter reinitialization logic for `watchContractEvent` and `watchEvent` when a filter has been uninstalled.

### Detailed summary:
- Added filter reinitialization logic for `watchContractEvent` and `watchEvent` when a filter has been uninstalled.
- Imported `InvalidInputRpcError` in `watchEvent.ts` and `watchContractEvent.ts`.
- Added error handling and filter reinitialization logic in `watchEvent.ts` and `watchContractEvent.ts` if a filter has been set and gets uninstalled.
- Added a test case to verify the filter reinitialization logic in `watchEvent.test.ts` and `watchContractEvent.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->