### PR TITLE
feat: support a string or array of keys for `getEnsText`

### DIFF
--- a/site/docs/ens/actions/getEnsText.md
+++ b/site/docs/ens/actions/getEnsText.md
@@ -14,9 +14,9 @@ head:
 
 # getEnsText
 
-Gets a text record for specified ENS name.
+Gets a text record(s) for specified ENS name.
 
-Calls `resolve(bytes, bytes)` on ENS Universal Resolver Contract.
+Calls `resolve(bytes, bytes[])` on ENS Universal Resolver Contract.
 
 ## Usage
 
@@ -52,9 +52,11 @@ Since ENS names prohibit certain forbidden characters (e.g. underscore) and have
 
 ## Returns
 
-`string | null`
+`string | null` when given a single key.
 
-The text record for ENS name.
+`(string | null)[]) | null` when given an array of keys.
+
+The text record(s) for ENS name.
 
 Returns `null` if name does not have text assigned.
 
@@ -75,14 +77,23 @@ const ensText = await publicClient.getEnsText({
 
 ### key
 
-- **Type:** `string`
+- **Type:** `string` | `string[]`
 
-ENS key to get Text for.
+ENS key(s) to get Text for.
 
 ```ts
 const ensText = await publicClient.getEnsText({
   name: normalize('wagmi-dev.eth'),
   key: 'com.twitter', // [!code focus]
+})
+```
+
+or
+
+```ts
+const ensText = await publicClient.getEnsText({
+  name: normalize('wagmi-dev.eth'),
+  key: ['com.twitter', 'description', 'url'], // [!code focus]
 })
 ```
 

--- a/src/actions/ens/getEnsText.test.ts
+++ b/src/actions/ens/getEnsText.test.ts
@@ -23,6 +23,17 @@ test('gets text record for name', async () => {
   ).resolves.toMatchInlineSnapshot('"wagmi_sh"')
 })
 
+test('gets multiple text records for name', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'wagmi-dev.eth',
+      key: ['com.twitter', 'description', 'url'],
+    }),
+  ).resolves.toMatchInlineSnapshot(
+    '["wagmi_sh", "React Hooks for Ethereum", "wagmi.sh"]',
+  )
+})
+
 test('name without text record', async () => {
   await expect(
     getEnsText(publicClient, {
@@ -30,6 +41,24 @@ test('name without text record', async () => {
       key: 'com.twitter',
     }),
   ).resolves.toBeNull()
+})
+
+test('name with some empty text records', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'wagmi-dev.eth',
+      key: ['com.twitter', 'emptyrecord'],
+    }),
+  ).resolves.toMatchInlineSnapshot('["wagmi_sh", null]')
+})
+
+test('name with all empty text records', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'wagmi-dev.eth',
+      key: ['emptyrecord1', 'emptyrecord2'],
+    }),
+  ).resolves.toMatchInlineSnapshot('[null, null]')
 })
 
 test('name with resolver that does not support text()', async () => {
@@ -46,6 +75,15 @@ test('name without resolver', async () => {
     getEnsText(publicClient, {
       name: 'random1223232222.eth',
       key: 'com.twitter',
+    }),
+  ).resolves.toBeNull()
+})
+
+test('name without resolver and multiple keys', async () => {
+  await expect(
+    getEnsText(publicClient, {
+      name: 'random1223232222.eth',
+      key: ['com.twitter', 'description', 'url'],
     }),
   ).resolves.toBeNull()
 })

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -20,7 +20,9 @@ import {
   readContract,
 } from '../public/readContract.js'
 
-export type GetEnsTextParameters<TKeys extends  string | readonly string[] = string | readonly string[]> = Prettify<
+export type GetEnsTextParameters<
+  TKeys extends string | readonly string[] = string | readonly string[],
+> = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** ENS name to get Text for. */
     name: string
@@ -31,8 +33,10 @@ export type GetEnsTextParameters<TKeys extends  string | readonly string[] = str
   }
 >
 
-// if a single key is passed, return a single string or null. otherwise, return an array of strings or nulls.
-export type GetEnsTextReturnType<TKeys extends  string | readonly string[] = string | readonly string[]> =
+// If a single key is passed, return a single string or null. Otherwise, return an array of strings or nulls.
+export type GetEnsTextReturnType<
+  TKeys extends string | readonly string[] = string | readonly string[],
+> =
   | (TKeys extends string ? string | null : never)
   | (TKeys extends readonly string[] ? (string | null)[] | null : never)
 
@@ -135,7 +139,9 @@ export async function getEnsText<
       decodedRecords.length === 1 ? decodedRecords[0] : decodedRecords
     ) as GetEnsTextReturnType<TKeys>
   } catch (err) {
-    if (isNullUniversalResolverError(err, 'resolve')) return null
+    if (isNullUniversalResolverError(err, 'resolve')) {
+      return null as GetEnsTextReturnType<TKeys>
+    }
     throw err
   }
 }

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -20,7 +20,7 @@ import {
   readContract,
 } from '../public/readContract.js'
 
-export type GetEnsTextParameters<TKeys> = Prettify<
+export type GetEnsTextParameters<TKeys extends  string | readonly string[] = string | readonly string[]> = Prettify<
   Pick<ReadContractParameters, 'blockNumber' | 'blockTag'> & {
     /** ENS name to get Text for. */
     name: string
@@ -32,9 +32,9 @@ export type GetEnsTextParameters<TKeys> = Prettify<
 >
 
 // if a single key is passed, return a single string or null. otherwise, return an array of strings or nulls.
-export type GetEnsTextReturnType<T> = T extends string
-  ? string | null
-  : (string | null)[] | null
+export type GetEnsTextReturnType<TKeys extends  string | readonly string[] = string | readonly string[]> =
+  | (TKeys extends string ? string | null : never)
+  | (TKeys extends readonly string[] ? (string | null)[] | null : never)
 
 /**
  * Gets a text record(s) for specified ENS name.
@@ -67,7 +67,7 @@ export type GetEnsTextReturnType<T> = T extends string
  */
 export async function getEnsText<
   TChain extends Chain | undefined,
-  TKeys extends string | string[],
+  TKeys extends string | readonly string[],
 >(
   client: Client<Transport, TChain>,
   {

--- a/src/constants/abis.test.ts
+++ b/src/constants/abis.test.ts
@@ -171,6 +171,43 @@ test('exports abis', () => {
           "type": "function",
         },
       ],
+      "universalResolverResolveArrayAbi": [
+        {
+          "inputs": [],
+          "name": "ResolverNotFound",
+          "type": "error",
+        },
+        {
+          "inputs": [],
+          "name": "ResolverWildcardNotSupported",
+          "type": "error",
+        },
+        {
+          "inputs": [
+            {
+              "name": "name",
+              "type": "bytes",
+            },
+            {
+              "name": "data",
+              "type": "bytes[]",
+            },
+          ],
+          "name": "resolve",
+          "outputs": [
+            {
+              "name": "",
+              "type": "bytes[]",
+            },
+            {
+              "name": "address",
+              "type": "address",
+            },
+          ],
+          "stateMutability": "view",
+          "type": "function",
+        },
+      ],
       "universalResolverReverseAbi": [
         {
           "inputs": [],

--- a/src/constants/abis.ts
+++ b/src/constants/abis.ts
@@ -73,6 +73,23 @@ export const universalResolverResolveAbi = [
   },
 ] as const
 
+export const universalResolverResolveArrayAbi = [
+  ...universalResolverErrors,
+  {
+    name: 'resolve',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'name', type: 'bytes' },
+      { name: 'data', type: 'bytes[]' },
+    ],
+    outputs: [
+      { name: '', type: 'bytes[]' },
+      { name: 'address', type: 'address' },
+    ],
+  },
+] as const
+
 export const universalResolverReverseAbi = [
   ...universalResolverErrors,
   {


### PR DESCRIPTION
This allows `getEnsText` to accept an array of keys to resolve via the ENS Universal Resolver. The return type is dynamic based on the `key` parameter. It can still take a string, causing no API changes.

Usage:
```ts
const ensText = await publicClient.getEnsText({
  name: normalize('wagmi-dev.eth'),
  key: 'com.twitter',
})
```

or

```ts
const ensText = await publicClient.getEnsText({
  name: normalize('wagmi-dev.eth'),
  key: ['com.twitter', 'description', 'url'],
})
```

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `universalResolverResolveArrayAbi` constant in `src/constants/abis.ts` and updated its usage in `src/actions/ens/getEnsText.ts`.
- Updated `getEnsText` function in `src/actions/ens/getEnsText.ts` to handle multiple text records.
- Updated documentation in `site/docs/ens/actions/getEnsText.md` to reflect the changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->