### PR TITLE
set fees to zero for zero base fee chains (e.g. anvil)

### DIFF
--- a/src/utils/transaction/prepareRequest.test.ts
+++ b/src/utils/transaction/prepareRequest.test.ts
@@ -70,6 +70,42 @@ describe('prepareRequest', () => {
     `)
   })
 
+  test('zero base fee', async () => {
+    await setup()
+    await setNextBlockBaseFeePerGas(testClient, {
+      baseFeePerGas: 0n,
+    })
+
+    const {
+      maxFeePerGas,
+      nonce: _nonce,
+      ...rest
+    } = await prepareRequest(walletClient, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      to: targetAccount.address,
+      value: parseEther('1'),
+    })
+    expect(maxFeePerGas).toEqual(0n)
+    expect(rest).toMatchInlineSnapshot(`
+      {
+        "account": {
+          "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          "publicKey": "0x048318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed753547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5",
+          "signMessage": [Function],
+          "signTransaction": [Function],
+          "signTypedData": [Function],
+          "source": "privateKey",
+          "type": "local",
+        },
+        "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        "gas": 21000n,
+        "maxPriorityFeePerGas": 1500000000n,
+        "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+
   test('legacy fees', async () => {
     await setup()
 

--- a/src/utils/transaction/prepareRequest.ts
+++ b/src/utils/transaction/prepareRequest.ts
@@ -78,10 +78,16 @@ export async function prepareRequest<
 
     // EIP-1559 fees
     if (typeof maxFeePerGas === 'undefined') {
-      // Set a buffer of 1.2x on top of the base fee to account for fluctuations.
-      request.maxPriorityFeePerGas = maxPriorityFeePerGas ?? defaultTip
-      request.maxFeePerGas =
-        (block.baseFeePerGas * 120n) / 100n + request.maxPriorityFeePerGas
+      // Set fees to zero when running anvil with zero base fee
+      if (block.baseFeePerGas === 0n) {
+        request.maxFeePerGas = 0n
+        request.maxPriorityFeePerGas = 0n
+      } else {
+        // Set a buffer of 1.2x on top of the base fee to account for fluctuations.
+        request.maxPriorityFeePerGas = maxPriorityFeePerGas ?? defaultTip
+        request.maxFeePerGas =
+          (block.baseFeePerGas * 120n) / 100n + request.maxPriorityFeePerGas
+      }
     } else {
       if (
         typeof maxPriorityFeePerGas === 'undefined' &&


### PR DESCRIPTION
We use anvil locally with `--block-base-fee-per-gas 0`, because we often create arbitrary burner accounts and don't want to do all the plumbing to fund new accounts per local instance.

However, viem isn't accounting for this in its fee calculation, always sending 1.5 gwei unless you 1) fund the account or 2) manually set each transaction call to `{ maxFeePerGas: 0n, maxPriorityFeePerGas: 0n }`.

We'd like to avoid the former, and the latter would leave us with wrapping viem or our own contract abstraction or something, but would be nice to keep to plain ol' viem.

See related issues that were fixed in foundry/anvil:
- https://github.com/foundry-rs/foundry/issues/5161
- https://github.com/foundry-rs/foundry/pull/5163

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on implementing EIP-1559 fees and handling zero base fee. 

### Detailed summary:
- Added logic to set fees to zero when running with zero base fee.
- Implemented a buffer of 1.2x on top of the base fee to account for fluctuations.
- Added tests for zero base fee and legacy fees.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->