### PR TITLE
fix: `getFunctionSelector`/`getEventSelector` returning incorrect selectors

### DIFF
--- a/.changeset/beige-singers-divide.md
+++ b/.changeset/beige-singers-divide.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed issue where `getFunctionSelector` & `getEventSelector` were returning incorrect selectors for tuple parameters.

--- a/src/utils/hash/getEventSelector.test.ts
+++ b/src/utils/hash/getEventSelector.test.ts
@@ -191,4 +191,55 @@ test('creates event signature for `AbiEvent`', () => {
       ],
     }),
   ).toBe('0x17307eab39ab6107e8899845ad3d59bd9653f200f220920489ca2b5937696c31')
+
+  expect(
+    getEventSelector({
+      anonymous: false,
+      inputs: [
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'smolRecipeId',
+          type: 'uint256',
+        },
+        {
+          components: [
+            {
+              components: [
+                {
+                  internalType: 'uint24',
+                  name: 'background',
+                  type: 'uint24',
+                },
+                { internalType: 'uint24', name: 'body', type: 'uint24' },
+                { internalType: 'uint24', name: 'clothes', type: 'uint24' },
+                { internalType: 'uint24', name: 'mouth', type: 'uint24' },
+                { internalType: 'uint24', name: 'glasses', type: 'uint24' },
+                { internalType: 'uint24', name: 'hat', type: 'uint24' },
+                { internalType: 'uint24', name: 'hair', type: 'uint24' },
+                { internalType: 'uint24', name: 'skin', type: 'uint24' },
+                { internalType: 'uint8', name: 'gender', type: 'uint8' },
+                { internalType: 'uint8', name: 'headSize', type: 'uint8' },
+              ],
+              internalType: 'struct Smol',
+              name: 'smol',
+              type: 'tuple',
+            },
+            { internalType: 'bool', name: 'exists', type: 'bool' },
+            {
+              internalType: 'uint8',
+              name: 'smolInputAmount',
+              type: 'uint8',
+            },
+          ],
+          indexed: false,
+          internalType: 'struct Transmolgrifier.SmolData',
+          name: 'smolData',
+          type: 'tuple',
+        },
+      ],
+      name: 'SmolRecipeAdded',
+      type: 'event',
+    }),
+  ).toBe('0x2cc6298312f9877815b420162c5268cf83c13ba43ac9ac9af8ac68611ce6752e')
 })

--- a/src/utils/hash/getFunctionSelector.test.ts
+++ b/src/utils/hash/getFunctionSelector.test.ts
@@ -118,4 +118,42 @@ test('creates function signature from `AbiFunction`', () => {
       stateMutability: 'view',
     }),
   ).toEqual('0xe834a834')
+
+  expect(
+    getFunctionSelector({
+      inputs: [
+        {
+          components: [
+            {
+              internalType: 'uint64',
+              name: 'position',
+              type: 'uint64',
+            },
+            {
+              internalType: 'address',
+              name: 'owner',
+              type: 'address',
+            },
+            {
+              internalType: 'enum UsingStratagemsTypes.Color',
+              name: 'color',
+              type: 'uint8',
+            },
+            {
+              internalType: 'uint8',
+              name: 'life',
+              type: 'uint8',
+            },
+          ],
+          internalType: 'struct IStratagemsDebug.SimpleCell[]',
+          name: 'cells',
+          type: 'tuple[]',
+        },
+      ],
+      name: 'forceSimpleCells',
+      outputs: [],
+      stateMutability: 'nonpayable',
+      type: 'function',
+    }),
+  ).toEqual('0xd703f50a')
 })

--- a/src/utils/hash/hashFunction.ts
+++ b/src/utils/hash/hashFunction.ts
@@ -1,3 +1,4 @@
+import { formatAbiItem } from '../abi/formatAbiItem.js'
 import {
   extractFunctionName,
   extractFunctionParams,
@@ -15,6 +16,6 @@ export function hashFunction(def: string) {
   return hash(`${name}(${params.map(({ type }) => type).join(',')})`)
 }
 
-export function hashAbiItem(def: AbiFunction | AbiEvent) {
-  return hash(`${def.name}(${def.inputs.map(({ type }) => type).join(',')})`)
+export function hashAbiItem(abiItem: AbiFunction | AbiEvent) {
+  return hash(formatAbiItem(abiItem))
 }


### PR DESCRIPTION
Fixes #972, #799

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing the issue where `getFunctionSelector` and `getEventSelector` were returning incorrect selectors for tuple parameters.

### Detailed summary:
- Modified `hashAbiItem` function to use `formatAbiItem` for generating the hash.
- Added test cases for `getFunctionSelector` and `getEventSelector` functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->