### PR TITLE
Fix typo in ethers migration docs

### DIFF
--- a/site/docs/ethers-migration.md
+++ b/site/docs/ethers-migration.md
@@ -1233,7 +1233,7 @@ const address = utils.getCreate2Address(from, salt, initCodeHash);
 #### viem
 
 ```ts {3-8}
-import { getContractAddress } from 'ethers'
+import { getContractAddress } from 'viem'
 
 const address = getContractAddress({
   bytecode: '0x6394198df16000526103ff60206004601c335afa6040516060f3',


### PR DESCRIPTION
There was a small typo in the ethers migration docs for [`getCreate2Address`](https://viem.sh/docs/ethers-migration.html#getcreate2address).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the import statement for the `getContractAddress` function from the `ethers` library to the `viem` library.

### Detailed summary
- Updated the import statement for the `getContractAddress` function from `ethers` to `viem`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->