### PR TITLE
export signTransaction, update docs

### DIFF
--- a/.changeset/ninety-goats-grab.md
+++ b/.changeset/ninety-goats-grab.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `signTransaction` & `privateKeyToAddress` exports to `viem/accounts` entrypoint.

--- a/site/docs/accounts/custom.md
+++ b/site/docs/accounts/custom.md
@@ -25,8 +25,14 @@ import { toAccount } from 'viem/accounts'
 ## Usage
 
 ```ts
-import { createWalletClient, getAddress, http } from 'viem'
-import { signMessage, signTransaction, toAccount } from 'viem/accounts' // [!code focus]
+import { createWalletClient, http } from 'viem'
+import {  // [!code focus:7]
+  signMessage, 
+  signTransaction, 
+  signTypedData, 
+  privateKeyToAddress,
+  toAccount 
+} from 'viem/accounts'
 import { mainnet } from 'viem/chains'
 
 const privateKey = '0x...' // [!code focus:13]

--- a/site/docs/accounts/custom.md
+++ b/site/docs/accounts/custom.md
@@ -25,10 +25,9 @@ import { toAccount } from 'viem/accounts'
 ## Usage
 
 ```ts
-import { createWalletClient, http } from 'viem'
-import { toAccount } from 'viem/accounts' // [!code focus]
+import { createWalletClient, getAddress, http } from 'viem'
+import { signMessage, signTransaction, toAccount } from 'viem/accounts' // [!code focus]
 import { mainnet } from 'viem/chains'
-import { getAddress, signMessage, signTransaction } from './sign-utils' // [!code focus]
 
 const privateKey = '0x...' // [!code focus:13]
 const account = toAccount({

--- a/site/docs/accounts/signMessage.md
+++ b/site/docs/accounts/signMessage.md
@@ -24,7 +24,7 @@ With the calculated signature, you can:
 ## Usage
 
 ```ts
-import { privateKeyToAccount } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
 

--- a/site/docs/accounts/signTransaction.md
+++ b/site/docs/accounts/signTransaction.md
@@ -19,7 +19,8 @@ Signs a transaction with the Account's private key.
 ## Usage
 
 ```ts
-import { privateKeyToAccount, parseGwei } from 'viem'
+import { parseGwei } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
 
@@ -38,7 +39,8 @@ const signature = await account.signTransaction({
 viem has a built-in serializer for **Legacy**, **EIP-2930** (`0x01`) and **EIP-1559** (`0x02`) transaction types. If you would like to serialize on another transaction type that viem does not support internally, you can pass a custom serializer.
 
 ```ts
-import { privateKeyToAccount, parseGwei } from 'viem'
+import { parseGwei } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 
 const account = privateKeyToAccount('0x...')
 

--- a/site/docs/accounts/signTypedData.md
+++ b/site/docs/accounts/signTypedData.md
@@ -21,7 +21,7 @@ Signs typed data and calculates an Ethereum-specific signature in [https://eips.
 ::: code-group
 
 ```ts [example.ts]
-import { privateKeyToAccount } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
 import { domain, types } from './data'
 
 const account = privateKeyToAccount('0x...')

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -24,6 +24,11 @@ export {
   signMessage,
 } from './utils/signMessage.js'
 export {
+  type SignTransactionParameters,
+  type SignTransactionReturnType,
+  signTransaction,
+} from './utils/signTransaction.js'
+export {
   type SignTypedDataParameters,
   type SignTypedDataReturnType,
   signTypedData,

--- a/src/accounts/index.ts
+++ b/src/accounts/index.ts
@@ -35,6 +35,7 @@ export {
 } from './utils/signTypedData.js'
 export { parseAccount } from './utils/parseAccount.js'
 export { publicKeyToAddress } from './utils/publicKeyToAddress.js'
+export { privateKeyToAddress } from './utils/privateKeyToAddress.js'
 export { czech } from './wordlists/czech.js'
 export { english } from './wordlists/english.js'
 export { french } from './wordlists/french.js'

--- a/src/accounts/utils/privateKeyToAddress.test.ts
+++ b/src/accounts/utils/privateKeyToAddress.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'vitest'
+
+import { accounts } from '../../_test/constants.js'
+import { privateKeyToAddress } from './privateKeyToAddress.js'
+
+test('default', () => {
+  expect(privateKeyToAddress(accounts[0].privateKey).toLowerCase()).toEqual(
+    accounts[0].address,
+  )
+})

--- a/src/accounts/utils/privateKeyToAddress.ts
+++ b/src/accounts/utils/privateKeyToAddress.ts
@@ -1,0 +1,20 @@
+import { secp256k1 } from '@noble/curves/secp256k1'
+import type { Address } from 'abitype'
+
+import type { Hex } from '../../types/misc.js'
+import { bytesToHex } from '../../utils/encoding/toHex.js'
+import { publicKeyToAddress } from './publicKeyToAddress.js'
+
+/**
+ * @description Converts an ECDSA private key to an address.
+ *
+ * @param privateKey The private key to convert.
+ *
+ * @returns The address.
+ */
+export function privateKeyToAddress(privateKey: Hex): Address {
+  const publicKey = bytesToHex(
+    secp256k1.getPublicKey(privateKey.slice(2), false),
+  )
+  return publicKeyToAddress(publicKey)
+}

--- a/src/accounts/utils/signTransaction.ts
+++ b/src/accounts/utils/signTransaction.ts
@@ -12,7 +12,7 @@ import {
 
 import { sign } from './sign.js'
 
-export type SignTransactionArgs<
+export type SignTransactionParameters<
   TTransactionSerializable extends TransactionSerializable = TransactionSerializable,
 > = {
   privateKey: Hex
@@ -31,7 +31,7 @@ export async function signTransaction<
   privateKey,
   transaction,
   serializer = serializeTransaction,
-}: SignTransactionArgs<TTransactionSerializable>): Promise<
+}: SignTransactionParameters<TTransactionSerializable>): Promise<
   SignTransactionReturnType<TTransactionSerializable>
 > {
   const signature = await sign({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on adding new exports to the `viem/accounts` entrypoint, specifically `signTransaction` and `privateKeyToAddress`.

### Detailed summary:
- Added `signTransaction` and `privateKeyToAddress` exports to `viem/accounts` entrypoint.
- Updated imports in `site/docs/accounts/signMessage.md` and `site/docs/accounts/signTypedData.md`.
- Added new test for `privateKeyToAddress` in `src/accounts/utils/privateKeyToAddress.test.ts`.
- Updated `src/accounts/utils/signTransaction.ts` to use `SignTransactionParameters` type.
- Updated imports in `site/docs/accounts/custom.md` and `site/docs/accounts/signTransaction.md`.
- Added `privateKeyToAddress` export to `src/accounts/index.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->