### PR TITLE
Fix typo in client docs import statement

### DIFF
--- a/site/docs/clients/wallet.md
+++ b/site/docs/clients/wallet.md
@@ -96,7 +96,7 @@ If you do not wish to pass an account around to every Action that requires an `a
 
 ```ts
 import { createWalletClient, http } from 'viem'
-import { mainnnet } from 'viem/chains'
+import { mainnet } from 'viem/chains'
 
 const [account] = await window.ethereum.request({ method: 'eth_requestAccounts' })
 


### PR DESCRIPTION
Fixes a type in the client docs when importing `mainnet`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a typo in an import statement. 

### Detailed summary
- Fixed a typo in the import statement for the `mainnet` module

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->