### PR TITLE
fix estimateGas documentation (account is no longer optional)

### DIFF
--- a/site/docs/actions/public/estimateGas.md
+++ b/site/docs/actions/public/estimateGas.md
@@ -56,7 +56,7 @@ The gas estimate (in wei).
 
 ## Parameters
 
-### account (optional)
+### account
 
 - **Type:** `Account | Address`
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- The focus of this PR is to update the `estimateGas.md` file in the `site/docs/actions/public` directory.
- The notable change is in the `Parameters` section where the `account` parameter is updated from optional to required.
- The `Type` of the `account` parameter is specified as `Account | Address`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->