### PR TITLE
fix: docs path in `estimateContractGas`

### DIFF
--- a/.changeset/mighty-ants-deny.md
+++ b/.changeset/mighty-ants-deny.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+fix estimateContractGas' error docsPath

--- a/.changeset/mighty-ants-deny.md
+++ b/.changeset/mighty-ants-deny.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-fix estimateContractGas' error docsPath
+Fixed `docsPath` value in `estimateContractGas`.

--- a/src/actions/public/estimateContractGas.test.ts
+++ b/src/actions/public/estimateContractGas.test.ts
@@ -75,7 +75,7 @@ describe('wagmi', () => {
         args:             (0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC, 420)
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2"
     `)
     await expect(() =>
@@ -95,7 +95,7 @@ describe('wagmi', () => {
         args:          (1)
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2"
     `)
     await expect(() =>
@@ -119,7 +119,7 @@ describe('wagmi', () => {
         args:                      (0x1a1E021A302C237453D3D45c7B82B19cEEB7E2e6, 0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC, 1)
         sender:    0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2"
     `)
   })
@@ -194,7 +194,7 @@ describe('BAYC', () => {
           args:             (1)
           sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-        Docs: https://viem.sh/docs/contract/simulateContract.html
+        Docs: https://viem.sh/docs/contract/estimateContractGas.html
         Version: viem@1.0.2"
       `)
     })
@@ -234,7 +234,7 @@ describe('contract errors', () => {
         function:  revertWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -258,7 +258,7 @@ describe('contract errors', () => {
         function:  assertWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -282,7 +282,7 @@ describe('contract errors', () => {
         function:  overflowWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -306,7 +306,7 @@ describe('contract errors', () => {
         function:  divideByZeroWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -329,7 +329,7 @@ describe('contract errors', () => {
         function:  requireWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -355,7 +355,7 @@ describe('contract errors', () => {
         function:  simpleCustomWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })
@@ -381,7 +381,7 @@ describe('contract errors', () => {
         function:  complexCustomWrite()
         sender:    0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266
 
-      Docs: https://viem.sh/docs/contract/simulateContract.html
+      Docs: https://viem.sh/docs/contract/estimateContractGas.html
       Version: viem@1.0.2]
     `)
   })

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -92,7 +92,7 @@ export async function estimateContractGas<
       abi: abi as Abi,
       address,
       args,
-      docsPath: '/docs/contract/simulateContract',
+      docsPath: '/docs/contract/estimateContractGas',
       functionName,
       sender: account?.address,
     })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on fixing the `docsPath` value in the `estimateContractGas` function. 

### Detailed summary
- Fixed `docsPath` value in `estimateContractGas` from '/docs/contract/simulateContract' to '/docs/contract/estimateContractGas'
- Updated the `Docs` link in the test file to 'https://viem.sh/docs/contract/estimateContractGas.html'

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->