### PR TITLE
Support eth_subscribe over websockets for watchEvent and watchContractEvent

### DIFF
--- a/site/docs/actions/public/watchEvent.md
+++ b/site/docs/actions/public/watchEvent.md
@@ -351,9 +351,9 @@ const publicClient = createPublicClient({
   transport: webSocket()
 })
 
-const unwatch = publicClient.watchBlocks(
+const unwatch = publicClient.watchEvent(
   { 
-    onBlock: block => console.log(block),
+    onLogs: logs => console.log(logs),
     poll: true, // [!code focus]
   }
 )

--- a/site/docs/actions/public/watchEvent.md
+++ b/site/docs/actions/public/watchEvent.md
@@ -333,6 +333,32 @@ const unwatch = publicClient.watchEvent(
 )
 ```
 
+### poll (optional)
+
+- **Type:** `boolean`
+- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+
+Whether or not to use a polling mechanism to check for new logs instead of a WebSocket subscription.
+
+This option is only configurable for Clients with a [WebSocket Transport](/docs/clients/transports/websocket).
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket()
+})
+
+const unwatch = publicClient.watchBlocks(
+  { 
+    onBlock: block => console.log(block),
+    poll: true, // [!code focus]
+  }
+)
+```
+
 ### pollingInterval (optional)
 
 - **Type:** `number`
@@ -356,11 +382,15 @@ Check out the usage of `watchEvent` in the live [Event Logs Example](https://sta
 
 ## JSON-RPC Methods
 
-**RPC Provider supports `eth_newFilter`:**
+**When poll `true` and RPC Provider supports `eth_newFilter`:**
 
 - Calls [`eth_newFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter) to create a filter (called on initialize).
 - On a polling interval, it will call [`eth_getFilterChanges`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges).
 
-**RPC Provider does not support `eth_newFilter`:**
+**When poll `true` RPC Provider does not support `eth_newFilter`:**
 
 - Calls [`eth_getLogs`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) for each block between the polling interval.
+
+**When poll `false` and WebSocket Transport:**
+
+- Uses a WebSocket subscription via `eth_subscribe` and the "logs" event.

--- a/site/docs/contract/watchContractEvent.md
+++ b/site/docs/contract/watchContractEvent.md
@@ -16,7 +16,7 @@ head:
 
 Watches and returns emitted contract event logs.
 
-This Action will batch up all the event logs found within the [`pollingInterval`](#pollinginterval-optional), and invoke them via [`onLogs`](#onLogs).
+This Action will batch up all the event logs found within the [`pollingInterval`](#pollinginterval-optional), and invoke them via [`onLogs`](#onlogs).
 
 `watchContractEvent` will attempt to create an [Event Filter](/docs/contract/createContractEventFilter) and listen to changes to the Filter per polling interval, however, if the RPC Provider does not support Filters (ie. `eth_newFilter`), then `watchContractEvent` will fall back to using [`getLogs`](/docs/actions/public/getLogs) instead.
 
@@ -303,9 +303,10 @@ const publicClient = createPublicClient({
   transport: webSocket()
 })
 
-const unwatch = publicClient.watchBlocks(
+const unwatch = publicClient.watchContractEvent(
   { 
-    onBlock: block => console.log(block),
+    address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+    abi: wagmiAbi,
     poll: true, // [!code focus]
   }
 )

--- a/site/docs/contract/watchContractEvent.md
+++ b/site/docs/contract/watchContractEvent.md
@@ -285,6 +285,32 @@ const unwatch = publicClient.watchContractEvent({
 })
 ```
 
+### poll (optional)
+
+- **Type:** `boolean`
+- **Default:** `false` for WebSocket Clients, `true` for non-WebSocket Clients
+
+Whether or not to use a polling mechanism to check for new logs instead of a WebSocket subscription.
+
+This option is only configurable for Clients with a [WebSocket Transport](/docs/clients/transports/websocket).
+
+```ts
+import { createPublicClient, webSocket } from 'viem'
+import { mainnet } from 'viem/chains'
+
+const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: webSocket()
+})
+
+const unwatch = publicClient.watchBlocks(
+  { 
+    onBlock: block => console.log(block),
+    poll: true, // [!code focus]
+  }
+)
+```
+
 ### pollingInterval (optional)
 
 - **Type:** `number`
@@ -299,3 +325,18 @@ const unwatch = publicClient.watchContractEvent({
   onLogs: logs => console.log(logs)
 })
 ```
+
+## JSON-RPC Methods
+
+**When poll `true` and RPC Provider supports `eth_newFilter`:**
+
+- Calls [`eth_newFilter`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter) to create a filter (called on initialize).
+- On a polling interval, it will call [`eth_getFilterChanges`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges).
+
+**When poll `true` RPC Provider does not support `eth_newFilter`:**
+
+- Calls [`eth_getLogs`](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getlogs) for each block between the polling interval.
+
+**When poll `false` and WebSocket Transport:**
+
+- Uses a WebSocket subscription via `eth_subscribe` and the "logs" event.

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -8,6 +8,7 @@ import {
   walletClient,
   webSocketClient,
 } from '../../_test/utils.js'
+import type { PublicClient } from '../../clients/createPublicClient.js'
 import { getAddress } from '../../utils/address/getAddress.js'
 import { wait } from '../../utils/wait.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
@@ -48,21 +49,127 @@ beforeAll(async () => {
   }
 })
 
-test(
-  'default',
-  async () => {
+describe('poll', () => {
+  test(
+    'default',
+    async () => {
+      const logs: WatchContractEventOnLogsParameter<
+        typeof usdcContractConfig.abi
+      >[] = []
+
+      const unwatch = watchContractEvent(publicClient, {
+        abi: usdcContractConfig.abi,
+        onLogs: (logs_) => {
+          assertType<typeof logs_[0]['args']>({
+            owner: '0x',
+            spender: '0x',
+            value: 0n,
+          })
+          assertType<typeof logs_[0]['args']>({
+            from: '0x',
+            to: '0x',
+            value: 0n,
+          })
+          logs.push(logs_)
+        },
+      })
+
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        account: address.vitalik,
+        functionName: 'transfer',
+        args: [address.vitalik, 1n],
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        account: address.vitalik,
+        functionName: 'transfer',
+        args: [address.vitalik, 1n],
+      })
+      await wait(1000)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        account: address.vitalik,
+        functionName: 'approve',
+        args: [address.vitalik, 1n],
+      })
+
+      await wait(2000)
+      unwatch()
+
+      expect(logs.length).toBe(2)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+
+      expect(logs[0][0].args).toEqual({
+        from: getAddress(address.vitalik),
+        to: getAddress(address.vitalik),
+        value: 1n,
+      })
+      expect(logs[0][0].eventName).toEqual('Transfer')
+      expect(logs[0][1].args).toEqual({
+        from: getAddress(address.vitalik),
+        to: getAddress(address.vitalik),
+        value: 1n,
+      })
+      expect(logs[0][1].eventName).toEqual('Transfer')
+      expect(logs[1][0].args).toEqual({
+        owner: getAddress(address.vitalik),
+        spender: getAddress(address.vitalik),
+        value: 1n,
+      })
+      expect(logs[1][0].eventName).toEqual('Approval')
+    },
+    { retry: 3 },
+  )
+
+  test('args: batch', async () => {
+    const logs: WatchContractEventOnLogsParameter[] = []
+
+    const unwatch = watchContractEvent(publicClient, {
+      ...usdcContractConfig,
+      batch: false,
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(3)
+    expect(logs[0].length).toBe(1)
+    expect(logs[1].length).toBe(1)
+    expect(logs[2].length).toBe(1)
+  })
+
+  test('args: eventName', async () => {
     const logs: WatchContractEventOnLogsParameter<
       typeof usdcContractConfig.abi
     >[] = []
 
     const unwatch = watchContractEvent(publicClient, {
-      abi: usdcContractConfig.abi,
+      ...usdcContractConfig,
+      eventName: 'Transfer',
       onLogs: (logs_) => {
-        assertType<typeof logs_[0]['args']>({
-          owner: '0x',
-          spender: '0x',
-          value: 0n,
-        })
         assertType<typeof logs_[0]['args']>({
           from: '0x',
           to: '0x',
@@ -95,9 +202,8 @@ test(
     await wait(2000)
     unwatch()
 
-    expect(logs.length).toBe(2)
+    expect(logs.length).toBe(1)
     expect(logs[0].length).toBe(2)
-    expect(logs[1].length).toBe(1)
 
     expect(logs[0][0].args).toEqual({
       from: getAddress(address.vitalik),
@@ -111,483 +217,366 @@ test(
       value: 1n,
     })
     expect(logs[0][1].eventName).toEqual('Transfer')
-    expect(logs[1][0].args).toEqual({
-      owner: getAddress(address.vitalik),
-      spender: getAddress(address.vitalik),
+  })
+
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(publicClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        to: accounts[0].address,
+      },
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(1)
+    expect(logs[0].length).toBe(1)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
       value: 1n,
     })
-    expect(logs[1][0].eventName).toEqual('Approval')
-  },
-  { retry: 3 },
-)
-
-test('args: batch', async () => {
-  const logs: WatchContractEventOnLogsParameter[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    batch: false,
-    onLogs: (logs_) => logs.push(logs_),
+    expect(logs[0][0].eventName).toEqual('Transfer')
   })
 
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [address.vitalik, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [address.vitalik, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
 
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(3)
-  expect(logs[0].length).toBe(1)
-  expect(logs[1].length).toBe(1)
-  expect(logs[2].length).toBe(1)
-})
-
-test('args: eventName', async () => {
-  const logs: WatchContractEventOnLogsParameter<
-    typeof usdcContractConfig.abi
-  >[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    eventName: 'Transfer',
-    onLogs: (logs_) => {
-      assertType<typeof logs_[0]['args']>({
-        from: '0x',
-        to: '0x',
-        value: 0n,
-      })
-      logs.push(logs_)
-    },
-  })
-
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [address.vitalik, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [address.vitalik, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
-
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(2)
-
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(address.vitalik),
-    value: 1n,
-  })
-  expect(logs[0][0].eventName).toEqual('Transfer')
-  expect(logs[0][1].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(address.vitalik),
-    value: 1n,
-  })
-  expect(logs[0][1].eventName).toEqual('Transfer')
-})
-
-test('args: args', async () => {
-  const logs: WatchContractEventOnLogsParameter<
-    typeof usdcContractConfig.abi
-  >[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    eventName: 'Transfer',
-    args: {
-      to: accounts[0].address,
-    },
-    onLogs: (logs_) => logs.push(logs_),
-  })
-
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[1].address, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
-
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(1)
-
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(accounts[0].address),
-    value: 1n,
-  })
-  expect(logs[0][0].eventName).toEqual('Transfer')
-})
-
-test('args: args', async () => {
-  const logs: WatchContractEventOnLogsParameter<
-    typeof usdcContractConfig.abi
-  >[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    eventName: 'Transfer',
-    args: {
-      to: [accounts[0].address, accounts[1].address],
-    },
-    onLogs: (logs_) => logs.push(logs_),
-  })
-
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[1].address, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
-
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(2)
-
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(accounts[0].address),
-    value: 1n,
-  })
-  expect(logs[0][0].eventName).toEqual('Transfer')
-  expect(logs[0][1].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(accounts[1].address),
-    value: 1n,
-  })
-  expect(logs[0][1].eventName).toEqual('Transfer')
-})
-
-test('args: args', async () => {
-  const logs: WatchContractEventOnLogsParameter<
-    typeof usdcContractConfig.abi
-  >[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    eventName: 'Transfer',
-    args: {
-      from: address.usdcHolder,
-    },
-    onLogs: (logs_) => logs.push(logs_),
-  })
-
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.usdcHolder,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[1].address, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
-
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(1)
-
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.usdcHolder),
-    to: getAddress(accounts[0].address),
-    value: 1n,
-  })
-  expect(logs[0][0].eventName).toEqual('Transfer')
-})
-
-test('args: args unnamed', async () => {
-  const unnamedAbi = [
-    {
-      type: 'event',
-      name: 'Transfer',
-      inputs: [
-        {
-          indexed: true,
-          type: 'address',
-        },
-        {
-          indexed: true,
-          type: 'address',
-        },
-        {
-          indexed: false,
-          type: 'uint256',
-        },
-      ],
-    },
-  ] as const
-  const logs: WatchContractEventOnLogsParameter<typeof unnamedAbi>[] = []
-
-  const unwatch = watchContractEvent(publicClient, {
-    ...usdcContractConfig,
-    abi: unnamedAbi,
-    eventName: 'Transfer',
-    onLogs: (logs_) => logs.push(logs_),
-  })
-
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'transfer',
-    args: [accounts[1].address, 1n],
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    account: address.vitalik,
-    functionName: 'approve',
-    args: [address.vitalik, 1n],
-  })
-
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(2)
-
-  expect(logs[0][0].args).toEqual([
-    getAddress(address.vitalik),
-    getAddress(accounts[0].address),
-    1n,
-  ])
-  expect(logs[0][0].eventName).toEqual('Transfer')
-  expect(logs[0][1].args).toEqual([
-    getAddress(address.vitalik),
-    getAddress(accounts[1].address),
-    1n,
-  ])
-  expect(logs[0][1].eventName).toEqual('Transfer')
-})
-
-describe('`getLogs` fallback', () => {
-  test(
-    'falls back to `getLogs` if `createContractEventFilter` throws',
-    async () => {
-      // TODO: Something weird going on where the `getFilterChanges` spy is taking
-      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-      await wait(1)
-      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
-      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-      vi.spyOn(
-        createContractEventFilter,
-        'createContractEventFilter',
-      ).mockRejectedValueOnce(new Error('foo'))
-
-      const logs: WatchContractEventOnLogsParameter[] = []
-
-      const unwatch = watchContractEvent(publicClient, {
-        abi: usdcContractConfig.abi,
-        onLogs: (logs_) => logs.push(logs_),
-      })
-
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[1].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(2000)
-      unwatch()
-
-      expect(logs.length).toBe(2)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-      expect(getFilterChangesSpy).toBeCalledTimes(0)
-      expect(getLogsSpy).toBeCalled()
-    },
-    { retry: 3 },
-  )
-
-  test(
-    'missed blocks',
-    async () => {
-      // TODO: Something weird going on where the `getFilterChanges` spy is taking
-      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-      await wait(1)
-      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
-      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-      vi.spyOn(
-        createContractEventFilter,
-        'createContractEventFilter',
-      ).mockRejectedValueOnce(new Error('foo'))
-
-      const logs: WatchContractEventOnLogsParameter[] = []
-
-      const unwatch = watchContractEvent(publicClient, {
-        abi: usdcContractConfig.abi,
-        onLogs: (logs_) => logs.push(logs_),
-      })
-
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[1].address, 1n],
-        account: address.usdcHolder,
-      })
-      await mine(testClient, { blocks: 1 })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await mine(testClient, { blocks: 2 })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await mine(testClient, { blocks: 5 })
-      await wait(2000)
-      unwatch()
-
-      expect(logs.length).toBe(3)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-      expect(logs[2].length).toBe(2)
-      expect(getFilterChangesSpy).toBeCalledTimes(0)
-      expect(getLogsSpy).toBeCalled()
-    },
-    { retry: 3 },
-  )
-})
-
-describe('errors', () => {
-  test('handles error thrown from creating filter', async () => {
-    vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValueOnce(
-      new Error('foo'),
-    )
-    vi.spyOn(
-      createContractEventFilter,
-      'createContractEventFilter',
-    ).mockRejectedValueOnce(new Error('foo'))
-
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchContractEvent(publicClient, {
-        ...usdcContractConfig,
-        onLogs: () => null,
-        onError: resolve,
-      })
+    const unwatch = watchContractEvent(publicClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        to: [accounts[0].address, accounts[1].address],
+      },
+      onLogs: (logs_) => logs.push(logs_),
     })
-    expect(error).toMatchInlineSnapshot('[Error: foo]')
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
     unwatch()
+
+    expect(logs.length).toBe(1)
+    expect(logs[0].length).toBe(2)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][1].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[1].address),
+      value: 1n,
+    })
+    expect(logs[0][1].eventName).toEqual('Transfer')
   })
 
-  test(
-    'handles error thrown from filter changes',
-    async () => {
-      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-        new Error('bar'),
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(publicClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        from: address.usdcHolder,
+      },
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(1)
+    expect(logs[0].length).toBe(1)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.usdcHolder),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+  })
+
+  test('args: args unnamed', async () => {
+    const unnamedAbi = [
+      {
+        type: 'event',
+        name: 'Transfer',
+        inputs: [
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: false,
+            type: 'uint256',
+          },
+        ],
+      },
+    ] as const
+    const logs: WatchContractEventOnLogsParameter<typeof unnamedAbi>[] = []
+
+    const unwatch = watchContractEvent(publicClient, {
+      ...usdcContractConfig,
+      abi: unnamedAbi,
+      eventName: 'Transfer',
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(1)
+    expect(logs[0].length).toBe(2)
+
+    expect(logs[0][0].args).toEqual([
+      getAddress(address.vitalik),
+      getAddress(accounts[0].address),
+      1n,
+    ])
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][1].args).toEqual([
+      getAddress(address.vitalik),
+      getAddress(accounts[1].address),
+      1n,
+    ])
+    expect(logs[0][1].eventName).toEqual('Transfer')
+  })
+
+  describe('`getLogs` fallback', () => {
+    test(
+      'falls back to `getLogs` if `createContractEventFilter` throws',
+      async () => {
+        // TODO: Something weird going on where the `getFilterChanges` spy is taking
+        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+        await wait(1)
+        const getFilterChangesSpy = vi.spyOn(
+          getFilterChanges,
+          'getFilterChanges',
+        )
+        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+        vi.spyOn(
+          createContractEventFilter,
+          'createContractEventFilter',
+        ).mockRejectedValueOnce(new Error('foo'))
+
+        const logs: WatchContractEventOnLogsParameter[] = []
+
+        const unwatch = watchContractEvent(publicClient, {
+          abi: usdcContractConfig.abi,
+          onLogs: (logs_) => logs.push(logs_),
+        })
+
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[1].address, 1n],
+          account: address.vitalik,
+        })
+        await wait(2000)
+        unwatch()
+
+        expect(logs.length).toBe(2)
+        expect(logs[0].length).toBe(2)
+        expect(logs[1].length).toBe(1)
+        expect(getFilterChangesSpy).toBeCalledTimes(0)
+        expect(getLogsSpy).toBeCalled()
+      },
+      { retry: 3 },
+    )
+
+    test(
+      'missed blocks',
+      async () => {
+        // TODO: Something weird going on where the `getFilterChanges` spy is taking
+        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+        await wait(1)
+        const getFilterChangesSpy = vi.spyOn(
+          getFilterChanges,
+          'getFilterChanges',
+        )
+        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+        vi.spyOn(
+          createContractEventFilter,
+          'createContractEventFilter',
+        ).mockRejectedValueOnce(new Error('foo'))
+
+        const logs: WatchContractEventOnLogsParameter[] = []
+
+        const unwatch = watchContractEvent(publicClient, {
+          abi: usdcContractConfig.abi,
+          onLogs: (logs_) => logs.push(logs_),
+        })
+
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[1].address, 1n],
+          account: address.usdcHolder,
+        })
+        await mine(testClient, { blocks: 1 })
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await mine(testClient, { blocks: 2 })
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await mine(testClient, { blocks: 5 })
+        await wait(2000)
+        unwatch()
+
+        expect(logs.length).toBe(3)
+        expect(logs[0].length).toBe(2)
+        expect(logs[1].length).toBe(1)
+        expect(logs[2].length).toBe(2)
+        expect(getFilterChangesSpy).toBeCalledTimes(0)
+        expect(getLogsSpy).toBeCalled()
+      },
+      { retry: 3 },
+    )
+  })
+
+  describe('errors', () => {
+    test('handles error thrown from creating filter', async () => {
+      vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValueOnce(
+        new Error('foo'),
       )
+      vi.spyOn(
+        createContractEventFilter,
+        'createContractEventFilter',
+      ).mockRejectedValueOnce(new Error('foo'))
 
       let unwatch: () => void = () => null
       const error = await new Promise((resolve) => {
@@ -597,44 +586,64 @@ describe('errors', () => {
           onError: resolve,
         })
       })
-      expect(error).toMatchInlineSnapshot('[Error: bar]')
+      expect(error).toMatchInlineSnapshot('[Error: foo]')
       unwatch()
-    },
-    { retry: 3 },
-  )
-
-  test('re-initializes the filter if the active filter uninstalls', async () => {
-    const filterCreator = vi.spyOn(
-      createContractEventFilter,
-      'createContractEventFilter',
-    )
-
-    const unwatch = watchContractEvent(publicClient, {
-      ...usdcContractConfig,
-      onLogs: () => null,
-      onError: () => null,
-      pollingInterval: 200,
     })
 
-    await wait(250)
-    expect(filterCreator).toBeCalledTimes(1)
+    test(
+      'handles error thrown from filter changes',
+      async () => {
+        vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+          new Error('bar'),
+        )
 
-    vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-      new InvalidInputRpcError(
-        new RpcRequestError({
-          body: { foo: 'bar' },
-          url: 'url',
-          error: {
-            code: -32000,
-            message: 'message',
-          },
-        }),
-      ),
+        let unwatch: () => void = () => null
+        const error = await new Promise((resolve) => {
+          unwatch = watchContractEvent(publicClient, {
+            ...usdcContractConfig,
+            onLogs: () => null,
+            onError: resolve,
+          })
+        })
+        expect(error).toMatchInlineSnapshot('[Error: bar]')
+        unwatch()
+      },
+      { retry: 3 },
     )
 
-    await wait(500)
-    expect(filterCreator).toBeCalledTimes(2)
-    unwatch()
+    test('re-initializes the filter if the active filter uninstalls', async () => {
+      const filterCreator = vi.spyOn(
+        createContractEventFilter,
+        'createContractEventFilter',
+      )
+
+      const unwatch = watchContractEvent(publicClient, {
+        ...usdcContractConfig,
+        onLogs: () => null,
+        onError: () => null,
+        pollingInterval: 200,
+      })
+
+      await wait(250)
+      expect(filterCreator).toBeCalledTimes(1)
+
+      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+        new InvalidInputRpcError(
+          new RpcRequestError({
+            body: { foo: 'bar' },
+            url: 'url',
+            error: {
+              code: -32000,
+              message: 'message',
+            },
+          }),
+        ),
+      )
+
+      await wait(500)
+      expect(filterCreator).toBeCalledTimes(2)
+      unwatch()
+    })
   })
 })
 
@@ -699,4 +708,325 @@ describe('subscribe', () => {
     },
     { timeout: 10_000 },
   )
+
+  test('args: eventName', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(webSocketClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      onLogs: (logs_) => {
+        assertType<typeof logs_[0]['args']>({
+          from: '0x',
+          to: '0x',
+          value: 0n,
+        })
+        logs.push(logs_)
+      },
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(2)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(address.vitalik),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[1][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(address.vitalik),
+      value: 1n,
+    })
+    expect(logs[1][0].eventName).toEqual('Transfer')
+  })
+
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(webSocketClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        to: accounts[0].address,
+      },
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(1)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+  })
+
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(webSocketClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        to: [accounts[0].address, accounts[1].address],
+      },
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(2)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[1][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[1].address),
+      value: 1n,
+    })
+    expect(logs[1][0].eventName).toEqual('Transfer')
+  })
+
+  test('args: args', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
+
+    const unwatch = watchContractEvent(webSocketClient, {
+      ...usdcContractConfig,
+      eventName: 'Transfer',
+      args: {
+        from: address.usdcHolder,
+      },
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.usdcHolder,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(1)
+
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.usdcHolder),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+  })
+
+  test('args: args unnamed', async () => {
+    const unnamedAbi = [
+      {
+        type: 'event',
+        name: 'Transfer',
+        inputs: [
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: true,
+            type: 'address',
+          },
+          {
+            indexed: false,
+            type: 'uint256',
+          },
+        ],
+      },
+    ] as const
+    const logs: WatchContractEventOnLogsParameter<typeof unnamedAbi>[] = []
+
+    const unwatch = watchContractEvent(webSocketClient, {
+      ...usdcContractConfig,
+      abi: unnamedAbi,
+      eventName: 'Transfer',
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(2)
+
+    expect(logs[0][0].args).toEqual([
+      getAddress(address.vitalik),
+      getAddress(accounts[0].address),
+      1n,
+    ])
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[1][0].args).toEqual([
+      getAddress(address.vitalik),
+      getAddress(accounts[1].address),
+      1n,
+    ])
+    expect(logs[1][0].eventName).toEqual('Transfer')
+  })
+
+  describe('errors', () => {
+    test('handles error thrown on init', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe() {
+            throw new Error('error')
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchContractEvent(client, {
+          abi: [],
+          onLogs: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
+
+    test('handles error thrown on event', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe({ onError }: any) {
+            onError(new Error('error'))
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchContractEvent(client as PublicClient, {
+          abi: [],
+          onLogs: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
+  })
 })

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -2,10 +2,13 @@ import type { Abi, AbiEvent, Address, ExtractAbiEvent, Narrow } from 'abitype'
 
 import type { Client } from '../../clients/createClient.js'
 import type { Transport } from '../../clients/transports/createTransport.js'
+import type { EncodeEventTopicsParameters, LogTopic } from '../../index.js'
 import type { Chain } from '../../types/chain.js'
 import type { GetEventArgs, InferEventName } from '../../types/contract.js'
 import type { Filter } from '../../types/filter.js'
 import type { Log } from '../../types/log.js'
+import type { GetTransportConfig } from '../../types/transport.js'
+
 import {
   type GetAbiItemParameters,
   getAbiItem,
@@ -14,7 +17,14 @@ import { observe } from '../../utils/observe.js'
 import { poll } from '../../utils/poll.js'
 import { stringify } from '../../utils/stringify.js'
 
-import { InvalidInputRpcError } from '../../index.js'
+import { DecodeLogDataMismatch } from '../../errors/abi.js'
+import {
+  DecodeLogTopicsMismatch,
+  InvalidInputRpcError,
+  decodeEventLog,
+  encodeEventTopics,
+  formatLog,
+} from '../../index.js'
 import {
   type CreateContractEventFilterParameters,
   createContractEventFilter,
@@ -23,6 +33,19 @@ import { getBlockNumber } from './getBlockNumber.js'
 import { getFilterChanges } from './getFilterChanges.js'
 import { getLogs } from './getLogs.js'
 import { uninstallFilter } from './uninstallFilter.js'
+
+type PollOptions = {
+  /**
+   * Whether or not the transaction hashes should be batched on each invocation.
+   * @default true
+   */
+  batch?: boolean
+  /**
+   * Polling frequency (in ms). Defaults to Client's pollingInterval config.
+   * @default client.pollingInterval
+   */
+  pollingInterval?: number
+}
 
 export type WatchContractEventOnLogsParameter<
   TAbi extends Abi | readonly unknown[] = readonly unknown[],
@@ -47,22 +70,38 @@ export type WatchContractEventParameters<
   /** Contract ABI. */
   abi: Narrow<TAbi>
   args?: GetEventArgs<TAbi, TEventName>
-  /** Whether or not the event logs should be batched on each invocation. */
-  batch?: boolean
   /** Contract event. */
   eventName?: InferEventName<TAbi, TEventName>
   /** The callback to call when an error occurred when trying to get for a new block. */
   onError?: (error: Error) => void
   /** The callback to call when new event logs are received. */
   onLogs: WatchContractEventOnLogsFn<TAbi, TEventName, TStrict>
-  /** Polling frequency (in ms). Defaults to Client's pollingInterval config. */
-  pollingInterval?: number
   /**
    * Whether or not the logs must match the indexed/non-indexed arguments on `event`.
    * @default false
    */
   strict?: TStrict
-}
+} & (GetTransportConfig<Transport>['type'] extends 'webSocket'
+  ?
+      | {
+          batch?: never
+          /**
+           * Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`.
+           * @default false
+           */
+          poll?: false
+          pollingInterval?: never
+        }
+      | (PollOptions & {
+          /**
+           * Whether or not the WebSocket Transport should poll the JSON-RPC, rather than using `eth_subscribe`.
+           * @default true
+           */
+          poll?: true
+        })
+  : PollOptions & {
+      poll?: true
+    })
 
 export type WatchContractEventReturnType = () => void
 
@@ -111,96 +150,169 @@ export function watchContractEvent<
     eventName,
     onError,
     onLogs,
+    poll: poll_,
     pollingInterval = client.pollingInterval,
     strict: strict_,
   }: WatchContractEventParameters<TAbi, TEventName, TStrict>,
 ): WatchContractEventReturnType {
-  const observerId = stringify([
-    'watchContractEvent',
-    address,
-    args,
-    batch,
-    client.uid,
-    eventName,
-    pollingInterval,
-  ])
-  const strict = strict_ ?? false
+  const enablePolling =
+    typeof poll_ !== 'undefined' ? poll_ : client.transport.type !== 'webSocket'
 
-  return observe(observerId, { onLogs, onError }, (emit) => {
-    let previousBlockNumber: bigint
-    let filter: Filter<'event', TAbi, TEventName> | undefined
-    let initialized = false
+  const pollContractEvent = () => {
+    const observerId = stringify([
+      'watchContractEvent',
+      address,
+      args,
+      batch,
+      client.uid,
+      eventName,
+      pollingInterval,
+    ])
+    const strict = strict_ ?? false
 
-    const unwatch = poll(
-      async () => {
-        if (!initialized) {
-          try {
-            filter = (await createContractEventFilter(client, {
-              abi,
-              address,
-              args,
-              eventName,
-              strict,
-            } as unknown as CreateContractEventFilterParameters)) as Filter<
-              'event',
-              TAbi,
-              TEventName
-            >
-          } catch {}
-          initialized = true
-          return
-        }
+    return observe(observerId, { onLogs, onError }, (emit) => {
+      let previousBlockNumber: bigint
+      let filter: Filter<'event', TAbi, TEventName> | undefined
+      let initialized = false
 
-        try {
-          let logs: Log[]
-          if (filter) {
-            logs = await getFilterChanges(client, { filter })
-          } else {
-            // If the filter doesn't exist, we will fall back to use `getLogs`.
-            // The fall back exists because some RPC Providers do not support filters.
-
-            // Fetch the block number to use for `getLogs`.
-            const blockNumber = await getBlockNumber(client)
-
-            // If the block number has changed, we will need to fetch the logs.
-            // If the block number doesn't exist, we are yet to reach the first poll interval,
-            // so do not emit any logs.
-            if (previousBlockNumber && previousBlockNumber !== blockNumber) {
-              logs = await getLogs(client, {
+      const unwatch = poll(
+        async () => {
+          if (!initialized) {
+            try {
+              filter = (await createContractEventFilter(client, {
+                abi,
                 address,
                 args,
-                fromBlock: previousBlockNumber + 1n,
-                toBlock: blockNumber,
-                event: getAbiItem({
-                  abi,
-                  name: eventName,
-                } as unknown as GetAbiItemParameters) as AbiEvent,
-              })
-            } else {
-              logs = []
-            }
-            previousBlockNumber = blockNumber
+                eventName,
+                strict,
+              } as unknown as CreateContractEventFilterParameters)) as Filter<
+                'event',
+                TAbi,
+                TEventName
+              >
+            } catch {}
+            initialized = true
+            return
           }
 
-          if (logs.length === 0) return
-          if (batch) emit.onLogs(logs as any)
-          else logs.forEach((log) => emit.onLogs([log] as any))
-        } catch (err) {
-          // If a filter has been set and gets uninstalled, providers will throw an InvalidInput error.
-          // Reinitalize the filter when this occurs
-          if (filter && err instanceof InvalidInputRpcError) initialized = false
-          emit.onError?.(err as Error)
-        }
-      },
-      {
-        emitOnBegin: true,
-        interval: pollingInterval,
-      },
-    )
+          try {
+            let logs: Log[]
+            if (filter) {
+              logs = await getFilterChanges(client, { filter })
+            } else {
+              // If the filter doesn't exist, we will fall back to use `getLogs`.
+              // The fall back exists because some RPC Providers do not support filters.
 
-    return async () => {
-      if (filter) await uninstallFilter(client, { filter })
-      unwatch()
-    }
-  })
+              // Fetch the block number to use for `getLogs`.
+              const blockNumber = await getBlockNumber(client)
+
+              // If the block number has changed, we will need to fetch the logs.
+              // If the block number doesn't exist, we are yet to reach the first poll interval,
+              // so do not emit any logs.
+              if (previousBlockNumber && previousBlockNumber !== blockNumber) {
+                logs = await getLogs(client, {
+                  address,
+                  args,
+                  fromBlock: previousBlockNumber + 1n,
+                  toBlock: blockNumber,
+                  event: getAbiItem({
+                    abi,
+                    name: eventName,
+                  } as unknown as GetAbiItemParameters) as AbiEvent,
+                })
+              } else {
+                logs = []
+              }
+              previousBlockNumber = blockNumber
+            }
+
+            if (logs.length === 0) return
+            if (batch) emit.onLogs(logs as any)
+            else logs.forEach((log) => emit.onLogs([log] as any))
+          } catch (err) {
+            // If a filter has been set and gets uninstalled, providers will throw an InvalidInput error.
+            // Reinitalize the filter when this occurs
+            if (filter && err instanceof InvalidInputRpcError)
+              initialized = false
+            emit.onError?.(err as Error)
+          }
+        },
+        {
+          emitOnBegin: true,
+          interval: pollingInterval,
+        },
+      )
+
+      return async () => {
+        if (filter) await uninstallFilter(client, { filter })
+        unwatch()
+      }
+    })
+  }
+
+  const subscribeContractEvent = () => {
+    let active = true
+    let unsubscribe = () => (active = false)
+    ;(async () => {
+      try {
+        const topics: LogTopic[] = encodeEventTopics({
+          abi: abi,
+          eventName: eventName,
+          args,
+        } as EncodeEventTopicsParameters)
+
+        const { unsubscribe: unsubscribe_ } = await client.transport.subscribe({
+          params: ['logs', { address, topics }],
+          onData(data: any) {
+            if (!active) return
+            const log = data.result
+            try {
+              const { eventName, args } = decodeEventLog({
+                abi: abi,
+                data: log.data,
+                topics: log.topics as any,
+                strict: strict_,
+              })
+              const formatted = formatLog(log, {
+                args,
+                eventName: eventName as string,
+              })
+              onLogs([formatted] as any)
+            } catch (err) {
+              let eventName
+              let isUnnamed
+              if (
+                err instanceof DecodeLogDataMismatch ||
+                err instanceof DecodeLogTopicsMismatch
+              ) {
+                // If strict mode is on, and log data/topics do not match event definition, skip.
+                if (strict_) return
+                eventName = err.abiItem.name
+                isUnnamed = err.abiItem.inputs?.some(
+                  (x) => !('name' in x && x.name),
+                )
+              }
+
+              // Set args to empty if there is an error decoding (e.g. indexed/non-indexed params mismatch).
+              const formatted = formatLog(log, {
+                args: isUnnamed ? [] : {},
+                eventName,
+              })
+              onLogs([formatted] as any)
+            }
+          },
+          onError(error: Error) {
+            onError?.(error)
+          },
+        })
+        unsubscribe = unsubscribe_
+        if (!active) unsubscribe()
+      } catch (err) {
+        onError?.(err as Error)
+      }
+    })()
+    return unsubscribe
+  }
+
+  return enablePolling ? pollContractEvent() : subscribeContractEvent()
 }

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -255,11 +255,13 @@ export function watchContractEvent<
     let unsubscribe = () => (active = false)
     ;(async () => {
       try {
-        const topics: LogTopic[] = encodeEventTopics({
-          abi: abi,
-          eventName: eventName,
-          args,
-        } as EncodeEventTopicsParameters)
+        const topics: LogTopic[] = eventName
+          ? encodeEventTopics({
+              abi: abi,
+              eventName: eventName,
+              args,
+            } as EncodeEventTopicsParameters)
+          : []
 
         const { unsubscribe: unsubscribe_ } = await client.transport.subscribe({
           params: ['logs', { address, topics }],

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -2,7 +2,13 @@ import { beforeAll, describe, expect, test, vi } from 'vitest'
 
 import { usdcContractConfig, wagmiContractConfig } from '../../_test/abis.js'
 import { accounts, address } from '../../_test/constants.js'
-import { publicClient, testClient, walletClient } from '../../_test/utils.js'
+import {
+  publicClient,
+  testClient,
+  walletClient,
+  webSocketClient,
+} from '../../_test/utils.js'
+import type { PublicClient } from '../../index.js'
 import { getAddress } from '../../utils/address/getAddress.js'
 import { wait } from '../../utils/wait.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
@@ -86,12 +92,51 @@ beforeAll(async () => {
   }
 })
 
-test(
-  'default',
-  async () => {
+describe('poll', () => {
+  test(
+    'default',
+    async () => {
+      const logs: WatchEventOnLogsParameter[] = []
+
+      const unwatch = watchEvent(publicClient, {
+        onLogs: (logs_) => logs.push(logs_),
+      })
+
+      await wait(1000)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await wait(1000)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[1].address, 1n],
+        account: address.vitalik,
+      })
+      await wait(2000)
+      unwatch()
+
+      expect(logs.length).toBe(2)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+    },
+    { retry: 3 },
+  )
+
+  test('args: batch', async () => {
     const logs: WatchEventOnLogsParameter[] = []
 
     const unwatch = watchEvent(publicClient, {
+      batch: false,
       onLogs: (logs_) => logs.push(logs_),
     })
 
@@ -118,179 +163,94 @@ test(
     await wait(2000)
     unwatch()
 
-    expect(logs.length).toBe(2)
-    expect(logs[0].length).toBe(2)
+    expect(logs.length).toBe(3)
+    expect(logs[0].length).toBe(1)
     expect(logs[1].length).toBe(1)
-  },
-  { retry: 3 },
-)
-
-test('args: batch', async () => {
-  const logs: WatchEventOnLogsParameter[] = []
-
-  const unwatch = watchEvent(publicClient, {
-    batch: false,
-    onLogs: (logs_) => logs.push(logs_),
+    expect(logs[2].length).toBe(1)
   })
 
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-    account: address.vitalik,
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-    account: address.vitalik,
-  })
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[1].address, 1n],
-    account: address.vitalik,
-  })
-  await wait(2000)
-  unwatch()
+  test('args: address', async () => {
+    const logs: WatchEventOnLogsParameter[] = []
+    const logs2: WatchEventOnLogsParameter[] = []
 
-  expect(logs.length).toBe(3)
-  expect(logs[0].length).toBe(1)
-  expect(logs[1].length).toBe(1)
-  expect(logs[2].length).toBe(1)
-})
+    const unwatch = watchEvent(publicClient, {
+      address: usdcContractConfig.address,
+      onLogs: (logs_) => logs.push(logs_),
+    })
+    const unwatch2 = watchEvent(publicClient, {
+      address: '0x0000000000000000000000000000000000000000',
+      onLogs: (logs_) => logs2.push(logs_),
+    })
 
-test('args: address', async () => {
-  const logs: WatchEventOnLogsParameter[] = []
-  const logs2: WatchEventOnLogsParameter[] = []
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await wait(2000)
+    unwatch()
+    unwatch2()
 
-  const unwatch = watchEvent(publicClient, {
-    address: usdcContractConfig.address,
-    onLogs: (logs_) => logs.push(logs_),
-  })
-  const unwatch2 = watchEvent(publicClient, {
-    address: '0x0000000000000000000000000000000000000000',
-    onLogs: (logs_) => logs2.push(logs_),
+    expect(logs.length).toBe(1)
+    expect(logs2.length).toBe(0)
   })
 
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-    account: address.vitalik,
-  })
-  await wait(2000)
-  unwatch()
-  unwatch2()
+  test('args: address + event', async () => {
+    const logs: WatchEventOnLogsParameter<typeof event.transfer>[] = []
+    const logs2: WatchEventOnLogsParameter<typeof event.approval>[] = []
 
-  expect(logs.length).toBe(1)
-  expect(logs2.length).toBe(0)
-})
+    const unwatch = watchEvent(publicClient, {
+      address: usdcContractConfig.address,
+      event: event.transfer,
+      onLogs: (logs_) => logs.push(logs_),
+    })
+    const unwatch2 = watchEvent(publicClient, {
+      address: usdcContractConfig.address,
+      event: event.approval,
+      onLogs: (logs_) => logs2.push(logs_),
+    })
 
-test('args: address + event', async () => {
-  const logs: WatchEventOnLogsParameter<typeof event.transfer>[] = []
-  const logs2: WatchEventOnLogsParameter<typeof event.approval>[] = []
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await wait(2000)
+    unwatch()
+    unwatch2()
 
-  const unwatch = watchEvent(publicClient, {
-    address: usdcContractConfig.address,
-    event: event.transfer,
-    onLogs: (logs_) => logs.push(logs_),
-  })
-  const unwatch2 = watchEvent(publicClient, {
-    address: usdcContractConfig.address,
-    event: event.approval,
-    onLogs: (logs_) => logs2.push(logs_),
-  })
+    expect(logs.length).toBe(1)
+    expect(logs2.length).toBe(0)
 
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-    account: address.vitalik,
-  })
-  await wait(2000)
-  unwatch()
-  unwatch2()
-
-  expect(logs.length).toBe(1)
-  expect(logs2.length).toBe(0)
-
-  expect(logs[0][0].eventName).toEqual('Transfer')
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(accounts[0].address),
-    value: 1n,
-  })
-})
-
-test('args: address + events', async () => {
-  const logs: WatchEventOnLogsParameter<
-    undefined,
-    [typeof event.transfer, typeof event.approval]
-  >[] = []
-
-  const unwatch = watchEvent(publicClient, {
-    address: usdcContractConfig.address,
-    events: [event.transfer, event.approval],
-    onLogs: (logs_) => logs.push(logs_),
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
   })
 
-  await wait(1000)
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'transfer',
-    args: [accounts[0].address, 1n],
-    account: address.vitalik,
-  })
-  await writeContract(walletClient, {
-    ...usdcContractConfig,
-    functionName: 'approve',
-    args: [accounts[1].address, 2n],
-    account: address.vitalik,
-  })
-  await mine(testClient, { blocks: 1 })
-  await wait(2000)
-  unwatch()
-
-  expect(logs.length).toBe(1)
-  expect(logs[0].length).toBe(2)
-
-  expect(logs[0][0].eventName).toEqual('Transfer')
-  expect(logs[0][0].args).toEqual({
-    from: getAddress(address.vitalik),
-    to: getAddress(accounts[0].address),
-    value: 1n,
-  })
-
-  expect(logs[0][1].eventName).toEqual('Approval')
-  expect(logs[0][1].args).toEqual({
-    owner: getAddress(address.vitalik),
-    spender: getAddress(accounts[1].address),
-    value: 2n,
-  })
-})
-
-test(
-  'args: events',
-  async () => {
+  test('args: address + events', async () => {
     const logs: WatchEventOnLogsParameter<
       undefined,
       [typeof event.transfer, typeof event.approval]
     >[] = []
 
     const unwatch = watchEvent(publicClient, {
+      address: usdcContractConfig.address,
       events: [event.transfer, event.approval],
       onLogs: (logs_) => logs.push(logs_),
     })
 
     await wait(1000)
     await writeContract(walletClient, {
-      ...wagmiContractConfig,
-      functionName: 'mint',
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
     await writeContract(walletClient, {
@@ -308,8 +268,9 @@ test(
 
     expect(logs[0][0].eventName).toEqual('Transfer')
     expect(logs[0][0].args).toEqual({
-      from: address.burn,
-      to: getAddress(address.vitalik),
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
     })
 
     expect(logs[0][1].eventName).toEqual('Approval')
@@ -318,155 +279,189 @@ test(
       spender: getAddress(accounts[1].address),
       value: 2n,
     })
-  },
-  { retry: 3 },
-)
-
-test.todo('args: args')
-
-describe('`getLogs` fallback', () => {
-  test(
-    'falls back to `getLogs` if `createEventFilter` throws',
-    async () => {
-      // Something weird going on where the `getFilterChanges` spy is taking
-      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-      await wait(1)
-      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
-      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-      vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
-        new Error('foo'),
-      )
-
-      const logs: WatchEventOnLogsParameter[] = []
-
-      const unwatch = watchEvent(publicClient, {
-        onLogs: (logs_) => logs.push(logs_),
-      })
-
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(2000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[1].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(2000)
-      unwatch()
-
-      expect(logs.length).toBe(2)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-      expect(getFilterChangesSpy).toBeCalledTimes(0)
-      expect(getLogsSpy).toBeCalled()
-    },
-    { retry: 3 },
-  )
-
-  test(
-    'missed blocks',
-    async () => {
-      // Something weird going on where the `getFilterChanges` spy is taking
-      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-      await wait(1)
-      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
-      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-      vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
-        new Error('foo'),
-      )
-
-      const logs: WatchEventOnLogsParameter[] = []
-
-      const unwatch = watchEvent(publicClient, {
-        onLogs: (logs_) => logs.push(logs_),
-      })
-
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[1].address, 1n],
-        account: address.usdcHolder,
-      })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await mine(testClient, { blocks: 2 })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[2].address, 1n],
-        account: address.vitalik,
-      })
-      await mine(testClient, { blocks: 5 })
-      await wait(2000)
-      unwatch()
-
-      expect(logs.length).toBe(3)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-      expect(logs[2].length).toBe(2)
-      expect(getFilterChangesSpy).toBeCalledTimes(0)
-      expect(getLogsSpy).toBeCalled()
-    },
-    { retry: 3 },
-  )
-})
-
-describe('errors', () => {
-  test('handles error thrown from creating filter', async () => {
-    vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValueOnce(
-      new Error('foo'),
-    )
-    vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
-      new Error('foo'),
-    )
-
-    let unwatch: () => void = () => null
-    const error = await new Promise((resolve) => {
-      unwatch = watchEvent(publicClient, {
-        onLogs: () => null,
-        onError: resolve,
-      })
-    })
-    expect(error).toMatchInlineSnapshot('[Error: foo]')
-    unwatch()
   })
 
   test(
-    'handles error thrown from filter changes',
+    'args: events',
     async () => {
-      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-        new Error('bar'),
+      const logs: WatchEventOnLogsParameter<
+        undefined,
+        [typeof event.transfer, typeof event.approval]
+      >[] = []
+
+      const unwatch = watchEvent(publicClient, {
+        events: [event.transfer, event.approval],
+        onLogs: (logs_) => logs.push(logs_),
+      })
+
+      await wait(1000)
+      await writeContract(walletClient, {
+        ...wagmiContractConfig,
+        functionName: 'mint',
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'approve',
+        args: [accounts[1].address, 2n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(2000)
+      unwatch()
+
+      expect(logs.length).toBe(1)
+      expect(logs[0].length).toBe(2)
+
+      expect(logs[0][0].eventName).toEqual('Transfer')
+      expect(logs[0][0].args).toEqual({
+        from: address.burn,
+        to: getAddress(address.vitalik),
+      })
+
+      expect(logs[0][1].eventName).toEqual('Approval')
+      expect(logs[0][1].args).toEqual({
+        owner: getAddress(address.vitalik),
+        spender: getAddress(accounts[1].address),
+        value: 2n,
+      })
+    },
+    { retry: 3 },
+  )
+
+  test.todo('args: args')
+
+  describe('`getLogs` fallback', () => {
+    test(
+      'falls back to `getLogs` if `createEventFilter` throws',
+      async () => {
+        // Something weird going on where the `getFilterChanges` spy is taking
+        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+        await wait(1)
+        const getFilterChangesSpy = vi.spyOn(
+          getFilterChanges,
+          'getFilterChanges',
+        )
+        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+        vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
+          new Error('foo'),
+        )
+
+        const logs: WatchEventOnLogsParameter[] = []
+
+        const unwatch = watchEvent(publicClient, {
+          onLogs: (logs_) => logs.push(logs_),
+        })
+
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await wait(2000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[1].address, 1n],
+          account: address.vitalik,
+        })
+        await wait(2000)
+        unwatch()
+
+        expect(logs.length).toBe(2)
+        expect(logs[0].length).toBe(2)
+        expect(logs[1].length).toBe(1)
+        expect(getFilterChangesSpy).toBeCalledTimes(0)
+        expect(getLogsSpy).toBeCalled()
+      },
+      { retry: 3 },
+    )
+
+    test(
+      'missed blocks',
+      async () => {
+        // Something weird going on where the `getFilterChanges` spy is taking
+        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+        await wait(1)
+        const getFilterChangesSpy = vi.spyOn(
+          getFilterChanges,
+          'getFilterChanges',
+        )
+        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+        vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
+          new Error('foo'),
+        )
+
+        const logs: WatchEventOnLogsParameter[] = []
+
+        const unwatch = watchEvent(publicClient, {
+          onLogs: (logs_) => logs.push(logs_),
+        })
+
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[0].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[1].address, 1n],
+          account: address.usdcHolder,
+        })
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await mine(testClient, { blocks: 2 })
+        await wait(1000)
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await writeContract(walletClient, {
+          ...usdcContractConfig,
+          functionName: 'transfer',
+          args: [accounts[2].address, 1n],
+          account: address.vitalik,
+        })
+        await mine(testClient, { blocks: 5 })
+        await wait(2000)
+        unwatch()
+
+        expect(logs.length).toBe(3)
+        expect(logs[0].length).toBe(2)
+        expect(logs[1].length).toBe(1)
+        expect(logs[2].length).toBe(2)
+        expect(getFilterChangesSpy).toBeCalledTimes(0)
+        expect(getLogsSpy).toBeCalled()
+      },
+      { retry: 3 },
+    )
+  })
+
+  describe('errors', () => {
+    test('handles error thrown from creating filter', async () => {
+      vi.spyOn(getBlockNumber, 'getBlockNumber').mockRejectedValueOnce(
+        new Error('foo'),
+      )
+      vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
+        new Error('foo'),
       )
 
       let unwatch: () => void = () => null
@@ -476,40 +471,293 @@ describe('errors', () => {
           onError: resolve,
         })
       })
-      expect(error).toMatchInlineSnapshot('[Error: bar]')
+      expect(error).toMatchInlineSnapshot('[Error: foo]')
       unwatch()
-    },
-    { retry: 3 },
-  )
-
-  test('re-initializes the filter if the active filter uninstalls', async () => {
-    const filterCreator = vi.spyOn(createEventFilter, 'createEventFilter')
-
-    const unwatch = watchEvent(publicClient, {
-      ...usdcContractConfig,
-      onLogs: () => null,
-      onError: () => null,
-      pollingInterval: 200,
     })
 
-    await wait(250)
-    expect(filterCreator).toBeCalledTimes(1)
+    test(
+      'handles error thrown from filter changes',
+      async () => {
+        vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+          new Error('bar'),
+        )
 
-    vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-      new InvalidInputRpcError(
-        new RpcRequestError({
-          body: { foo: 'bar' },
-          url: 'url',
-          error: {
-            code: -32000,
-            message: 'message',
-          },
-        }),
-      ),
+        let unwatch: () => void = () => null
+        const error = await new Promise((resolve) => {
+          unwatch = watchEvent(publicClient, {
+            onLogs: () => null,
+            onError: resolve,
+          })
+        })
+        expect(error).toMatchInlineSnapshot('[Error: bar]')
+        unwatch()
+      },
+      { retry: 3 },
     )
 
-    await wait(500)
-    expect(filterCreator).toBeCalledTimes(2)
+    test('re-initializes the filter if the active filter uninstalls', async () => {
+      const filterCreator = vi.spyOn(createEventFilter, 'createEventFilter')
+
+      const unwatch = watchEvent(publicClient, {
+        ...usdcContractConfig,
+        onLogs: () => null,
+        onError: () => null,
+        pollingInterval: 200,
+      })
+
+      await wait(250)
+      expect(filterCreator).toBeCalledTimes(1)
+
+      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+        new InvalidInputRpcError(
+          new RpcRequestError({
+            body: { foo: 'bar' },
+            url: 'url',
+            error: {
+              code: -32000,
+              message: 'message',
+            },
+          }),
+        ),
+      )
+
+      await wait(500)
+      expect(filterCreator).toBeCalledTimes(2)
+      unwatch()
+    })
+  })
+})
+
+describe('subscribe', () => {
+  test('default', async () => {
+    const logs: WatchEventOnLogsParameter[] = []
+
+    const unwatch = watchEvent(webSocketClient, {
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+    await wait(2000)
     unwatch()
+
+    expect(logs.length).toBe(2)
+  })
+
+  test('args: address', async () => {
+    const logs: WatchEventOnLogsParameter[] = []
+    const logs2: WatchEventOnLogsParameter[] = []
+
+    const unwatch = watchEvent(webSocketClient, {
+      address: usdcContractConfig.address,
+      onLogs: (logs_) => logs.push(logs_),
+    })
+    const unwatch2 = watchEvent(webSocketClient, {
+      address: '0x0000000000000000000000000000000000000000',
+      onLogs: (logs_) => logs2.push(logs_),
+    })
+
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await wait(2000)
+    unwatch()
+    unwatch2()
+
+    expect(logs.length).toBe(1)
+    expect(logs2.length).toBe(0)
+  })
+
+  test('args: address + event', async () => {
+    const logs: WatchEventOnLogsParameter<typeof event.transfer>[] = []
+    const logs2: WatchEventOnLogsParameter<typeof event.approval>[] = []
+
+    const unwatch = watchEvent(webSocketClient, {
+      address: usdcContractConfig.address,
+      event: event.transfer,
+      onLogs: (logs_) => logs.push(logs_),
+    })
+    const unwatch2 = watchEvent(webSocketClient, {
+      address: usdcContractConfig.address,
+      event: event.approval,
+      onLogs: (logs_) => logs2.push(logs_),
+    })
+
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(2000)
+    unwatch()
+    unwatch2()
+
+    expect(logs.length).toBe(1)
+    expect(logs2.length).toBe(0)
+
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+  })
+
+  test('args: address + events', async () => {
+    const logs: WatchEventOnLogsParameter<
+      undefined,
+      [typeof event.transfer, typeof event.approval]
+    >[] = []
+
+    const unwatch = watchEvent(webSocketClient, {
+      address: usdcContractConfig.address,
+      events: [event.transfer, event.approval],
+      onLogs: (logs_) => logs.push(logs_),
+    })
+
+    await wait(1000)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'approve',
+      args: [accounts[1].address, 2n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(2000)
+    unwatch()
+
+    expect(logs.length).toBe(2)
+
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(accounts[0].address),
+      value: 1n,
+    })
+
+    expect(logs[1][0].eventName).toEqual('Approval')
+    expect(logs[1][0].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(accounts[1].address),
+      value: 2n,
+    })
+  })
+
+  test(
+    'args: events',
+    async () => {
+      const logs: WatchEventOnLogsParameter<
+        undefined,
+        [typeof event.transfer, typeof event.approval]
+      >[] = []
+
+      const unwatch = watchEvent(webSocketClient, {
+        events: [event.transfer, event.approval],
+        onLogs: (logs_) => logs.push(logs_),
+      })
+
+      await wait(1000)
+      await writeContract(walletClient, {
+        ...wagmiContractConfig,
+        functionName: 'mint',
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'approve',
+        args: [accounts[1].address, 2n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(1000)
+      unwatch()
+
+      expect(logs.length).toBe(2)
+
+      expect(logs[0][0].eventName).toEqual('Transfer')
+      expect(logs[0][0].args).toEqual({
+        from: address.burn,
+        to: getAddress(address.vitalik),
+      })
+
+      expect(logs[1][0].eventName).toEqual('Approval')
+      expect(logs[1][0].args).toEqual({
+        owner: getAddress(address.vitalik),
+        spender: getAddress(accounts[1].address),
+        value: 2n,
+      })
+    },
+    { timeout: 10_000 },
+  )
+
+  describe('errors', () => {
+    test('handles error thrown on init', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe() {
+            throw new Error('error')
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchEvent(client, {
+          onLogs: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
+
+    test('handles error thrown on event', async () => {
+      const client = {
+        ...webSocketClient,
+        transport: {
+          ...webSocketClient.transport,
+          subscribe({ onError }: any) {
+            onError(new Error('error'))
+          },
+        },
+      }
+
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchEvent(client as PublicClient, {
+          onLogs: () => null,
+          onError: resolve,
+        })
+      })
+      expect(error).toMatchInlineSnapshot('[Error: error]')
+      unwatch()
+    })
   })
 })


### PR DESCRIPTION
dupe of #985

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary:
- Added a new `poll` option to the `watchEvent` and `watchContractEvent` functions.
- The `poll` option allows clients to use a polling mechanism to check for new logs instead of a WebSocket subscription.
- The default value for `poll` is `false` for WebSocket clients and `true` for non-WebSocket clients.
- When `poll` is `true` and the RPC Provider supports `eth_newFilter`, the functions will call `eth_newFilter` to create a filter and `eth_getFilterChanges` on a polling interval to get new logs.
- When `poll` is `true` and the RPC Provider does not support `eth_newFilter`, the functions will call `eth_getLogs` for each block between the polling interval to get new logs.
- When `poll` is `false` and the WebSocket Transport is used, the functions will use a WebSocket subscription via `eth_subscribe` and the "logs" event to get new logs.
- Added the `pollingInterval` option to specify the polling frequency in milliseconds. The default value is the client's `pollingInterval` config.
- Updated the documentation for `watchEvent` and `watchContractEvent` to include information about the new `poll` option and the different behaviors based on the RPC Provider support and WebSocket Transport usage.

> The following files were skipped due to too many changes: `src/actions/public/watchContractEvent.ts`, `src/actions/public/watchEvent.ts`, `src/actions/public/watchEvent.test.ts`, `src/actions/public/watchContractEvent.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->