### PR TITLE
improve: export  EIP1193Events

### DIFF
--- a/.changeset/orange-dogs-add.md
+++ b/.changeset/orange-dogs-add.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `EIP1193EventMap` type.

--- a/src/index.ts
+++ b/src/index.ts
@@ -597,6 +597,7 @@ export type {
 } from './types/chain.js'
 export type {
   AddEthereumChainParameter,
+  EIP1193EventMap,
   EIP1193Events,
   EIP1193Parameters,
   EIP1193Provider,

--- a/src/types/eip1193.ts
+++ b/src/types/eip1193.ts
@@ -51,7 +51,7 @@ export type ProviderMessage = {
   data: unknown
 }
 
-type EIP1193EventMap = {
+export type EIP1193EventMap = {
   accountsChanged(accounts: Address[]): void
   chainChanged(chainId: string): void
   connect(connectInfo: ProviderConnectInfo): void


### PR DESCRIPTION
This PR exposes the `EIP1193Events` type for projects to use when importing Viem.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the `EIP1193EventMap` type. 

### Detailed summary
- Added `EIP1193EventMap` type in `src/index.ts`.
- Exported `EIP1193EventMap` type in `src/types/eip1193.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->