### PR TITLE
fix: uncatchable waitForTransactionReceipt

### DIFF
--- a/.changeset/shiny-steaks-brake.md
+++ b/.changeset/shiny-steaks-brake.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where `waitForTransactionReceipt` would be infinitely pending when an error is thrown after a transaction has been replaced.

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -192,56 +192,62 @@ export async function waitForTransactionReceipt<
                 (err instanceof TransactionNotFoundError ||
                   err instanceof TransactionReceiptNotFoundError)
               ) {
-                replacedTransaction = transaction
+                try {
 
-                // Let's retrieve the transactions from the current block.
-                const block = await getBlock(client, {
-                  blockNumber,
-                  includeTransactions: true,
-                })
 
-                const replacementTransaction = (
-                  block.transactions as Transaction[]
-                ).find(
-                  ({ from, nonce }) =>
-                    from === replacedTransaction!.from &&
-                    nonce === replacedTransaction!.nonce,
-                )
+                  replacedTransaction = transaction
 
-                // If we couldn't find a replacement transaction, continue polling.
-                if (!replacementTransaction) return
-
-                // If we found a replacement transaction, return it's receipt.
-                receipt = await getTransactionReceipt(client, {
-                  hash: replacementTransaction.hash,
-                })
-
-                // Check if we have enough confirmations. If not, continue polling.
-                if (blockNumber - receipt.blockNumber + 1n < confirmations)
-                  return
-
-                let reason: ReplacementReason = 'replaced'
-                if (
-                  replacementTransaction.to === replacedTransaction.to &&
-                  replacementTransaction.value === replacedTransaction.value
-                ) {
-                  reason = 'repriced'
-                } else if (
-                  replacementTransaction.from === replacementTransaction.to &&
-                  replacementTransaction.value === 0n
-                ) {
-                  reason = 'cancelled'
-                }
-
-                done(() => {
-                  emit.onReplaced?.({
-                    reason,
-                    replacedTransaction: replacedTransaction!,
-                    transaction: replacementTransaction,
-                    transactionReceipt: receipt,
+                  // Let's retrieve the transactions from the current block.
+                  const block = await getBlock(client, {
+                    blockNumber,
+                    includeTransactions: true,
                   })
-                  emit.resolve(receipt)
-                })
+
+                  const replacementTransaction = (
+                    block.transactions as Transaction[]
+                  ).find(
+                    ({ from, nonce }) =>
+                      from === replacedTransaction!.from &&
+                      nonce === replacedTransaction!.nonce,
+                  )
+
+                  // If we couldn't find a replacement transaction, continue polling.
+                  if (!replacementTransaction) return
+
+                  // If we found a replacement transaction, return it's receipt.
+                  receipt = await getTransactionReceipt(client, {
+                    hash: replacementTransaction.hash,
+                  })
+
+                  // Check if we have enough confirmations. If not, continue polling.
+                  if (blockNumber - receipt.blockNumber + 1n < confirmations)
+                    return
+
+                  let reason: ReplacementReason = 'replaced'
+                  if (
+                    replacementTransaction.to === replacedTransaction.to &&
+                    replacementTransaction.value === replacedTransaction.value
+                  ) {
+                    reason = 'repriced'
+                  } else if (
+                    replacementTransaction.from === replacementTransaction.to &&
+                    replacementTransaction.value === 0n
+                  ) {
+                    reason = 'cancelled'
+                  }
+
+                  done(() => {
+                    emit.onReplaced?.({
+                      reason,
+                      replacedTransaction: replacedTransaction!,
+                      transaction: replacementTransaction,
+                      transactionReceipt: receipt,
+                    })
+                    emit.resolve(receipt)
+                  })
+                } catch (err_) {
+                  done(() => emit.reject(err_))
+                }
               } else {
                 done(() => emit.reject(err))
               }

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -193,8 +193,6 @@ export async function waitForTransactionReceipt<
                   err instanceof TransactionReceiptNotFoundError)
               ) {
                 try {
-
-
                   replacedTransaction = transaction
 
                   // Let's retrieve the transactions from the current block.


### PR DESCRIPTION
The `await getBlock` and `await getTransactionReceipt` in the `catch` statement cannot be caught by outside function `waitForTransactionReceipt`. This PR is trying to fix it.

See: https://github.com/wagmi-dev/viem/issues/923 https://github.com/wagmi-dev/viem/issues/760
This won't fix these issues but can provide the ability for user to catch them.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Fixed an issue where `waitForTransactionReceipt` would be infinitely pending when an error is thrown after a transaction has been replaced.
- Added a test case for when a transaction is replaced and `getBlock` fails.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->