### PR TITLE
fix: ensure that getEnsAddress returns the correct padded address length

### DIFF
--- a/.changeset/tame-kids-poke.md
+++ b/.changeset/tame-kids-poke.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `getEnsAddress` for addresses that start with `0`.

--- a/src/actions/ens/getEnsAddress.test.ts
+++ b/src/actions/ens/getEnsAddress.test.ts
@@ -25,6 +25,14 @@ test('gets address for name', async () => {
   )
 })
 
+test('gets address that starts with 0s for name', async () => {
+  await expect(
+    getEnsAddress(publicClient, { name: 'skeith.eth' }),
+  ).resolves.toMatchInlineSnapshot(
+    '"0x00A59Ec1F4BF9718EeE07078141b540272BAB807"',
+  )
+})
+
 test('gets address for name with coinType', async () => {
   await expect(
     getEnsAddress(publicClient, { name: 'awkweb.eth', coinType: 60 }),

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -107,18 +107,16 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
 
     if (res[0] === '0x') return null
 
-    const address = trim(
-      decodeFunctionResult({
-        abi: addressResolverAbi,
-        args: coinType != null ? [namehash(name), BigInt(coinType)] : undefined,
-        functionName: 'addr',
-        data: res[0],
-      }),
-    )
+    const address = decodeFunctionResult({
+      abi: addressResolverAbi,
+      args: coinType != null ? [namehash(name), BigInt(coinType)] : undefined,
+      functionName: 'addr',
+      data: res[0],
+    })
 
     if (address === '0x') return null
     if (trim(address) === '0x00') return null
-    return pad(address, { size: 20 })
+    return address
   } catch (err) {
     if (isNullUniversalResolverError(err, 'resolve')) return null
     throw err

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -16,7 +16,6 @@ import { toHex } from '../../utils/encoding/toHex.js'
 import { isNullUniversalResolverError } from '../../utils/ens/errors.js'
 import { namehash } from '../../utils/ens/namehash.js'
 import { packetToBytes } from '../../utils/ens/packetToBytes.js'
-import { pad } from '../../utils/index.js'
 import {
   type ReadContractParameters,
   readContract,

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -16,6 +16,7 @@ import { toHex } from '../../utils/encoding/toHex.js'
 import { isNullUniversalResolverError } from '../../utils/ens/errors.js'
 import { namehash } from '../../utils/ens/namehash.js'
 import { packetToBytes } from '../../utils/ens/packetToBytes.js'
+import { pad } from '../../utils/index.js'
 import {
   type ReadContractParameters,
   readContract,
@@ -117,7 +118,7 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
 
     if (address === '0x') return null
     if (trim(address) === '0x00') return null
-    return address
+    return pad(address, { size: 20 })
   } catch (err) {
     if (isNullUniversalResolverError(err, 'resolve')) return null
     throw err


### PR DESCRIPTION
## Introduction
Because the trim function is used on the value being returned by `getEnsAddress`, the returned address may sometimes become too short to be a valid Ethereum address if the address has 0s at the beginning. 

## Changes
This change adds a pad to the address returned by getEnsAddress() to ensure that it is always the correct length. It also adds a test for an ens name that resolves to an address that has 0s at the beginning.

## Related
Resolves #1032

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
Fixing the `getEnsAddress` function to handle addresses that start with `0`.

### Detailed summary:
- Fixed `getEnsAddress` for addresses that start with `0`.
- Updated the test to get the address for a name that starts with `0s`.
- Removed unnecessary code in `getEnsAddress.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->