### PR TITLE
Add ability to parse celo specific tx type

### DIFF
--- a/.changeset/cyan-bears-smoke.md
+++ b/.changeset/cyan-bears-smoke.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added `parseTransactionCelo` function for parsing serialized transactions that could be CIP42 tx or other serialized transaction types exported at viem/chains/utils 
+Added `parseTransactionCelo` to the `viem/chains/utils` entrypoint.

--- a/.changeset/cyan-bears-smoke.md
+++ b/.changeset/cyan-bears-smoke.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added `parseTransactionCelo` function for parsing serialized transactions that could be CIP42 tx or other serialized transaction types exported at viem/chains/utils 

--- a/src/chains/celo/parsers.test.ts
+++ b/src/chains/celo/parsers.test.ts
@@ -1,0 +1,226 @@
+import { accounts } from '../../_test/constants.js'
+import {
+  parseEther,
+  parseGwei,
+  parseTransaction as parseTransaction_,
+  serializeTransaction,
+  toRlp,
+} from '../../index.js'
+
+import {
+  type TransactionSerializableCIP42,
+  serializeTransactionCelo,
+} from './serializers.js'
+
+import { parseTransactionCelo } from './parsers.js'
+import { describe, expect, test } from 'vitest'
+
+describe('parseTransaction', () => {
+  test('should be able to parse a cip42 transaction', () => {
+    const signedTransaction =
+      '0x7cf84682a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0'
+
+    expect(parseTransactionCelo(signedTransaction)).toMatchInlineSnapshot(`
+      {
+        "chainId": 42220,
+        "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
+        "maxFeePerGas": 2000000000n,
+        "maxPriorityFeePerGas": 2000000000n,
+        "to": "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+        "type": "cip42",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+
+  const transaction = {
+    chainId: 1,
+    gas: 21001n,
+    maxFeePerGas: parseGwei('2'),
+    maxPriorityFeePerGas: parseGwei('2'),
+    to: accounts[3].address,
+    nonce: 785,
+    value: parseEther('1'),
+  }
+
+  test('should return same result as standard parser when not CIP42', () => {
+    const serialized = serializeTransaction(transaction)
+
+    expect(parseTransactionCelo(serialized)).toEqual(
+      parseTransaction_(serialized),
+    )
+  })
+
+  test('should parse a CIP42 transaction with gatewayFee', () => {
+    const transactionWithGatewayFee = {
+      ...transaction,
+      chainId: 42270,
+      gatewayFee: parseEther('0.1'),
+      gatewayFeeRecipient: accounts[1].address,
+    }
+
+    const serialized = serializeTransactionCelo(transactionWithGatewayFee)
+
+    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+      {
+        "chainId": 42270,
+        "gas": 21001n,
+        "gatewayFee": 100000000000000000n,
+        "gatewayFeeRecipient": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+        "maxFeePerGas": 2000000000n,
+        "maxPriorityFeePerGas": 2000000000n,
+        "nonce": 785,
+        "to": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+        "type": "cip42",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+
+  test('should parse a CIP42 transaction with access list', () => {
+    const transactionWithAccessList: TransactionSerializableCIP42 = {
+      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+      ...transaction,
+      chainId: 42270,
+      accessList: [
+        {
+          address: '0x0000000000000000000000000000000000000000',
+          storageKeys: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          ],
+        },
+      ],
+    }
+
+    const serialized = serializeTransactionCelo(transactionWithAccessList)
+
+    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+      {
+        "accessList": [
+          {
+            "address": "0x0000000000000000000000000000000000000000",
+            "storageKeys": [
+              "0x0000000000000000000000000000000000000000000000000000000000000001",
+              "0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe",
+            ],
+          },
+        ],
+        "chainId": 42270,
+        "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
+        "gas": 21001n,
+        "maxFeePerGas": 2000000000n,
+        "maxPriorityFeePerGas": 2000000000n,
+        "nonce": 785,
+        "to": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+        "type": "cip42",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+
+  test('should parse a CIP42 transaction with data as 0x', () => {
+    const transactionWithData: TransactionSerializableCIP42 = {
+      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+      ...transaction,
+      chainId: 42270,
+      data: '0x',
+    }
+
+    const serialized = serializeTransactionCelo(transactionWithData)
+
+    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+      {
+        "chainId": 42270,
+        "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
+        "gas": 21001n,
+        "maxFeePerGas": 2000000000n,
+        "maxPriorityFeePerGas": 2000000000n,
+        "nonce": 785,
+        "to": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+        "type": "cip42",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+  test('should parse a CIP42 transaction with data', () => {
+    const transactionWithData: TransactionSerializableCIP42 = {
+      ...transaction,
+      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+      chainId: 42270,
+      data: '0x1234',
+    }
+
+    const serialized = serializeTransactionCelo(transactionWithData)
+
+    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+      {
+        "chainId": 42270,
+        "data": "0x1234",
+        "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
+        "gas": 21001n,
+        "maxFeePerGas": 2000000000n,
+        "maxPriorityFeePerGas": 2000000000n,
+        "nonce": 785,
+        "to": "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+        "type": "cip42",
+        "value": 1000000000000000000n,
+      }
+    `)
+  })
+
+  test('invalid transaction (all missing)', () => {
+    expect(() =>
+      parseTransactionCelo(`0x7c${toRlp([]).slice(2)}`),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        "Invalid serialized transaction of type \\"cip42\\" was provided.
+
+        Serialized Transaction: \\"0x7cc0\\"
+        Missing Attributes: chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gas, feeCurrency, to, gatewayFeeRecipient, gatewayFee, value, data, accessList
+
+        Version: viem@1.0.2"
+      `)
+  })
+
+  test('invalid transaction (some missing)', () => {
+    expect(() =>
+      parseTransactionCelo(`0x7c${toRlp(['0x0', '0x1']).slice(2)}`),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        "Invalid serialized transaction of type \\"cip42\\" was provided.
+
+        Serialized Transaction: \\"0x7cc20001\\"
+        Missing Attributes: maxPriorityFeePerGas, maxFeePerGas, gas, feeCurrency, to, gatewayFeeRecipient, gatewayFee, value, data, accessList
+
+        Version: viem@1.0.2"
+      `)
+  })
+
+  test('invalid transaction (missing signature)', () => {
+    expect(() =>
+      parseTransactionCelo(
+        `0x7c${toRlp([
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+          '0x',
+        ]).slice(2)}`,
+      ),
+    ).toThrowErrorMatchingInlineSnapshot(`
+        "Invalid serialized transaction of type \\"cip42\\" was provided.
+
+        Serialized Transaction: \\"0x7ccd80808080808080808080808080\\"
+        Missing Attributes: r, s
+
+        Version: viem@1.0.2"
+      `)
+  })
+})

--- a/src/chains/celo/parsers.test.ts
+++ b/src/chains/celo/parsers.test.ts
@@ -1,3 +1,5 @@
+import { expect, test } from 'vitest'
+
 import { accounts } from '../../_test/constants.js'
 import {
   parseEther,
@@ -6,21 +8,15 @@ import {
   serializeTransaction,
   toRlp,
 } from '../../index.js'
-
-import {
-  type TransactionSerializableCIP42,
-  serializeTransactionCelo,
-} from './serializers.js'
-
 import { parseTransactionCelo } from './parsers.js'
-import { describe, expect, test } from 'vitest'
+import { serializeTransactionCelo } from './serializers.js'
+import type { TransactionSerializableCIP42 } from './types.js'
 
-describe('parseTransaction', () => {
-  test('should be able to parse a cip42 transaction', () => {
-    const signedTransaction =
-      '0x7cf84682a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0'
+test('should be able to parse a cip42 transaction', () => {
+  const signedTransaction =
+    '0x7cf84682a4ec80847735940084773594008094765de816845861e75a25fca122bb6898b8b1282a808094f39fd6e51aad88f6f4ce6ab8827279cfffb92266880de0b6b3a764000080c0'
 
-    expect(parseTransactionCelo(signedTransaction)).toMatchInlineSnapshot(`
+  expect(parseTransactionCelo(signedTransaction)).toMatchInlineSnapshot(`
       {
         "chainId": 42220,
         "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
@@ -31,37 +27,37 @@ describe('parseTransaction', () => {
         "value": 1000000000000000000n,
       }
     `)
-  })
+})
 
-  const transaction = {
-    chainId: 1,
-    gas: 21001n,
-    maxFeePerGas: parseGwei('2'),
-    maxPriorityFeePerGas: parseGwei('2'),
-    to: accounts[3].address,
-    nonce: 785,
-    value: parseEther('1'),
+const transaction = {
+  chainId: 1,
+  gas: 21001n,
+  maxFeePerGas: parseGwei('2'),
+  maxPriorityFeePerGas: parseGwei('2'),
+  to: accounts[3].address,
+  nonce: 785,
+  value: parseEther('1'),
+}
+
+test('should return same result as standard parser when not CIP42', () => {
+  const serialized = serializeTransaction(transaction)
+
+  expect(parseTransactionCelo(serialized)).toEqual(
+    parseTransaction_(serialized),
+  )
+})
+
+test('should parse a CIP42 transaction with gatewayFee', () => {
+  const transactionWithGatewayFee = {
+    ...transaction,
+    chainId: 42270,
+    gatewayFee: parseEther('0.1'),
+    gatewayFeeRecipient: accounts[1].address,
   }
 
-  test('should return same result as standard parser when not CIP42', () => {
-    const serialized = serializeTransaction(transaction)
+  const serialized = serializeTransactionCelo(transactionWithGatewayFee)
 
-    expect(parseTransactionCelo(serialized)).toEqual(
-      parseTransaction_(serialized),
-    )
-  })
-
-  test('should parse a CIP42 transaction with gatewayFee', () => {
-    const transactionWithGatewayFee = {
-      ...transaction,
-      chainId: 42270,
-      gatewayFee: parseEther('0.1'),
-      gatewayFeeRecipient: accounts[1].address,
-    }
-
-    const serialized = serializeTransactionCelo(transactionWithGatewayFee)
-
-    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+  expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
       {
         "chainId": 42270,
         "gas": 21001n,
@@ -75,27 +71,27 @@ describe('parseTransaction', () => {
         "value": 1000000000000000000n,
       }
     `)
-  })
+})
 
-  test('should parse a CIP42 transaction with access list', () => {
-    const transactionWithAccessList: TransactionSerializableCIP42 = {
-      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
-      ...transaction,
-      chainId: 42270,
-      accessList: [
-        {
-          address: '0x0000000000000000000000000000000000000000',
-          storageKeys: [
-            '0x0000000000000000000000000000000000000000000000000000000000000001',
-            '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
-          ],
-        },
-      ],
-    }
+test('should parse a CIP42 transaction with access list', () => {
+  const transactionWithAccessList: TransactionSerializableCIP42 = {
+    feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+    ...transaction,
+    chainId: 42270,
+    accessList: [
+      {
+        address: '0x0000000000000000000000000000000000000000',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+        ],
+      },
+    ],
+  }
 
-    const serialized = serializeTransactionCelo(transactionWithAccessList)
+  const serialized = serializeTransactionCelo(transactionWithAccessList)
 
-    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+  expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
       {
         "accessList": [
           {
@@ -117,19 +113,19 @@ describe('parseTransaction', () => {
         "value": 1000000000000000000n,
       }
     `)
-  })
+})
 
-  test('should parse a CIP42 transaction with data as 0x', () => {
-    const transactionWithData: TransactionSerializableCIP42 = {
-      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
-      ...transaction,
-      chainId: 42270,
-      data: '0x',
-    }
+test('should parse a CIP42 transaction with data as 0x', () => {
+  const transactionWithData: TransactionSerializableCIP42 = {
+    feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+    ...transaction,
+    chainId: 42270,
+    data: '0x',
+  }
 
-    const serialized = serializeTransactionCelo(transactionWithData)
+  const serialized = serializeTransactionCelo(transactionWithData)
 
-    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+  expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
       {
         "chainId": 42270,
         "feeCurrency": "0x765de816845861e75a25fca122bb6898b8b1282a",
@@ -142,18 +138,19 @@ describe('parseTransaction', () => {
         "value": 1000000000000000000n,
       }
     `)
-  })
-  test('should parse a CIP42 transaction with data', () => {
-    const transactionWithData: TransactionSerializableCIP42 = {
-      ...transaction,
-      feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
-      chainId: 42270,
-      data: '0x1234',
-    }
+})
 
-    const serialized = serializeTransactionCelo(transactionWithData)
+test('should parse a CIP42 transaction with data', () => {
+  const transactionWithData: TransactionSerializableCIP42 = {
+    ...transaction,
+    feeCurrency: '0x765de816845861e75a25fca122bb6898b8b1282a',
+    chainId: 42270,
+    data: '0x1234',
+  }
 
-    expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
+  const serialized = serializeTransactionCelo(transactionWithData)
+
+  expect(parseTransactionCelo(serialized)).toMatchInlineSnapshot(`
       {
         "chainId": 42270,
         "data": "0x1234",
@@ -167,12 +164,12 @@ describe('parseTransaction', () => {
         "value": 1000000000000000000n,
       }
     `)
-  })
+})
 
-  test('invalid transaction (all missing)', () => {
-    expect(() =>
-      parseTransactionCelo(`0x7c${toRlp([]).slice(2)}`),
-    ).toThrowErrorMatchingInlineSnapshot(`
+test('invalid transaction (all missing)', () => {
+  expect(() =>
+    parseTransactionCelo(`0x7c${toRlp([]).slice(2)}`),
+  ).toThrowErrorMatchingInlineSnapshot(`
         "Invalid serialized transaction of type \\"cip42\\" was provided.
 
         Serialized Transaction: \\"0x7cc0\\"
@@ -180,12 +177,12 @@ describe('parseTransaction', () => {
 
         Version: viem@1.0.2"
       `)
-  })
+})
 
-  test('invalid transaction (some missing)', () => {
-    expect(() =>
-      parseTransactionCelo(`0x7c${toRlp(['0x0', '0x1']).slice(2)}`),
-    ).toThrowErrorMatchingInlineSnapshot(`
+test('invalid transaction (some missing)', () => {
+  expect(() =>
+    parseTransactionCelo(`0x7c${toRlp(['0x0', '0x1']).slice(2)}`),
+  ).toThrowErrorMatchingInlineSnapshot(`
         "Invalid serialized transaction of type \\"cip42\\" was provided.
 
         Serialized Transaction: \\"0x7cc20001\\"
@@ -193,28 +190,28 @@ describe('parseTransaction', () => {
 
         Version: viem@1.0.2"
       `)
-  })
+})
 
-  test('invalid transaction (missing signature)', () => {
-    expect(() =>
-      parseTransactionCelo(
-        `0x7c${toRlp([
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-          '0x',
-        ]).slice(2)}`,
-      ),
-    ).toThrowErrorMatchingInlineSnapshot(`
+test('invalid transaction (missing signature)', () => {
+  expect(() =>
+    parseTransactionCelo(
+      `0x7c${toRlp([
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+        '0x',
+      ]).slice(2)}`,
+    ),
+  ).toThrowErrorMatchingInlineSnapshot(`
         "Invalid serialized transaction of type \\"cip42\\" was provided.
 
         Serialized Transaction: \\"0x7ccd80808080808080808080808080\\"
@@ -222,5 +219,4 @@ describe('parseTransaction', () => {
 
         Version: viem@1.0.2"
       `)
-  })
 })

--- a/src/chains/celo/parsers.ts
+++ b/src/chains/celo/parsers.ts
@@ -1,0 +1,117 @@
+import { InvalidSerializedTransactionError } from '../../errors/transaction.js'
+import {
+  type Hex,
+  type TransactionSerialized,
+  hexToBigInt,
+  hexToNumber,
+  isHex,
+  parseTransaction,
+  sliceHex,
+} from '../../index.js'
+import {
+  parseAccessList,
+  toTransactionArray,
+} from '../../utils/transaction/parseTransaction.js'
+import {
+  type CeloTransactionSerializable,
+  type SerializedCIP42TransactionReturnType,
+  type TransactionSerializableCIP42,
+  assertTransactionCIP42,
+} from './serializers.js'
+
+import type { RecursiveArray } from '../../utils/encoding/toRlp.js'
+
+export function parseTransactionCelo(
+  serializedTransaction:
+    | TransactionSerialized
+    | SerializedCIP42TransactionReturnType,
+): CeloTransactionSerializable {
+  const serializedType = sliceHex(serializedTransaction, 0, 1)
+
+  if (serializedType === '0x7c') {
+    return parseTransactionCIP42(
+      serializedTransaction as SerializedCIP42TransactionReturnType,
+    )
+  }
+
+  return parseTransaction(serializedTransaction)
+}
+
+function parseTransactionCIP42(
+  serializedTransaction: SerializedCIP42TransactionReturnType,
+): TransactionSerializableCIP42 {
+  const transactionArray = toTransactionArray(serializedTransaction)
+
+  const [
+    chainId,
+    nonce,
+    maxPriorityFeePerGas,
+    maxFeePerGas,
+    gas,
+    feeCurrency,
+    gatewayFeeRecipient,
+    gatewayFee,
+    to,
+    value,
+    data,
+    accessList,
+    v,
+    r,
+    s,
+  ] = transactionArray
+
+  if (transactionArray.length !== 15 && transactionArray.length !== 12) {
+    throw new InvalidSerializedTransactionError({
+      attributes: {
+        chainId,
+        nonce,
+        maxPriorityFeePerGas,
+        maxFeePerGas,
+        gas,
+        feeCurrency,
+        to,
+        gatewayFeeRecipient,
+        gatewayFee,
+        value,
+        data,
+        accessList,
+        ...(transactionArray.length > 12
+          ? {
+              v,
+              r,
+              s,
+            }
+          : {}),
+      },
+      serializedTransaction,
+      type: 'cip42',
+    })
+  }
+
+  const transaction: Partial<TransactionSerializableCIP42> = {
+    chainId: hexToNumber(chainId as Hex),
+    type: 'cip42',
+  }
+
+  if (isHex(to) && to !== '0x') transaction.to = to
+  if (isHex(gas) && gas !== '0x') transaction.gas = hexToBigInt(gas)
+  if (isHex(data) && data !== '0x') transaction.data = data
+  if (isHex(nonce) && nonce !== '0x') transaction.nonce = hexToNumber(nonce)
+  if (isHex(value) && value !== '0x') transaction.value = hexToBigInt(value)
+  if (isHex(feeCurrency) && feeCurrency !== '0x')
+    transaction.feeCurrency = feeCurrency
+  if (isHex(gatewayFeeRecipient) && gatewayFeeRecipient !== '0x')
+    transaction.gatewayFeeRecipient = gatewayFeeRecipient
+  if (isHex(gatewayFee) && gatewayFee !== '0x')
+    transaction.gatewayFee = hexToBigInt(gatewayFee)
+  if (isHex(maxFeePerGas) && maxFeePerGas !== '0x')
+    transaction.maxFeePerGas = hexToBigInt(maxFeePerGas)
+  if (isHex(maxPriorityFeePerGas) && maxPriorityFeePerGas !== '0x')
+    transaction.maxPriorityFeePerGas = hexToBigInt(maxPriorityFeePerGas)
+  if (accessList.length !== 0 && accessList !== '0x')
+    transaction.accessList = parseAccessList(accessList as RecursiveArray<Hex>)
+
+  assertTransactionCIP42(transaction as TransactionSerializableCIP42)
+
+  return transaction as TransactionSerializableCIP42
+}

--- a/src/chains/celo/serializers.ts
+++ b/src/chains/celo/serializers.ts
@@ -139,7 +139,9 @@ function isCIP42(transaction: CeloTransactionSerializable) {
 const MAX_MAX_FEE_PER_GAS =
   115792089237316195423570985008687907853269984665640564039457584007913129639935n
 
-function assertTransactionCIP42(transaction: TransactionSerializableCIP42) {
+export function assertTransactionCIP42(
+  transaction: TransactionSerializableCIP42,
+) {
   const {
     chainId,
     maxPriorityFeePerGas,

--- a/src/chains/celo/types.ts
+++ b/src/chains/celo/types.ts
@@ -1,17 +1,23 @@
 import type { Address } from 'abitype'
 
 import type { Block, BlockTag } from '../../types/block.js'
+import type { FeeValuesEIP1559 } from '../../types/fee.js'
 import type { Hex } from '../../types/misc.js'
 import type {
   RpcBlock,
   RpcTransaction,
   RpcTransactionReceipt,
   RpcTransactionRequest,
+  TransactionType,
 } from '../../types/rpc.js'
 import type {
+  AccessList,
   Transaction,
   TransactionReceipt,
   TransactionRequest,
+  TransactionSerializable,
+  TransactionSerializableBase,
+  TransactionSerialized,
 } from '../../types/transaction.js'
 import type { NeverBy } from '../../types/utils.js'
 import type { OptimismRpcTransaction } from '../optimism/types.js'
@@ -109,3 +115,29 @@ export type CeloTransactionRequestOverrides = {
 }
 export type CeloTransactionRequest = TransactionRequest &
   CeloTransactionRequestOverrides
+
+export type CeloTransactionSerializable =
+  | TransactionSerializableCIP42
+  | TransactionSerializable
+
+export type CeloTransactionSerialized<
+  TType extends CeloTransactionType = 'legacy',
+> = TransactionSerialized<TType> | TransactionSerializedCIP42
+
+export type CeloTransactionType = TransactionType | 'cip42'
+
+export type TransactionSerializableCIP42<
+  TQuantity = bigint,
+  TIndex = number,
+> = TransactionSerializableBase<TQuantity, TIndex> &
+  FeeValuesEIP1559<TQuantity> & {
+    accessList?: AccessList
+    gasPrice?: never
+    feeCurrency?: Address
+    gatewayFeeRecipient?: Address
+    gatewayFee?: TQuantity
+    chainId: number
+    type?: 'cip42'
+  }
+
+export type TransactionSerializedCIP42 = `0x7c${string}`

--- a/src/chains/utils.ts
+++ b/src/chains/utils.ts
@@ -1,13 +1,9 @@
 export { formattersCelo } from './celo/formatters.js'
 export {
-  type CeloTransactionSerializable,
-  type TransactionSerializableCIP42,
   serializeTransactionCelo,
   serializersCelo,
 } from './celo/serializers.js'
-
 export { parseTransactionCelo } from './celo/parsers.js'
-
 export type {
   CeloBlock,
   CeloBlockOverrides,
@@ -25,6 +21,11 @@ export type {
   CeloTransactionReceiptOverrides,
   CeloTransactionRequest,
   CeloTransactionRequestOverrides,
+  CeloTransactionSerializable,
+  CeloTransactionSerialized,
+  CeloTransactionType,
+  TransactionSerializableCIP42,
+  TransactionSerializedCIP42,
 } from './celo/types.js'
 
 export { formattersOptimism } from './optimism/formatters.js'

--- a/src/chains/utils.ts
+++ b/src/chains/utils.ts
@@ -5,6 +5,9 @@ export {
   serializeTransactionCelo,
   serializersCelo,
 } from './celo/serializers.js'
+
+export { parseTransactionCelo } from './celo/parsers.js'
+
 export type {
   CeloBlock,
   CeloBlockOverrides,

--- a/src/utils/transaction/parseTransaction.test.ts
+++ b/src/utils/transaction/parseTransaction.test.ts
@@ -14,7 +14,11 @@ import { keccak256 } from '../hash/keccak256.js'
 import { parseEther } from '../unit/parseEther.js'
 import { parseGwei } from '../unit/parseGwei.js'
 
-import { parseTransaction } from './parseTransaction.js'
+import {
+  parseAccessList,
+  parseTransaction,
+  toTransactionArray,
+} from './parseTransaction.js'
 import { serializeTransaction } from './serializeTransaction.js'
 
 const base = {
@@ -691,4 +695,53 @@ describe('errors', () => {
     `,
     )
   })
+})
+
+test('toTransactionArray', () => {
+  expect(
+    toTransactionArray(
+      serializeTransaction({
+        ...base,
+        chainId: 1,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
+      }),
+    ),
+  ).toMatchInlineSnapshot(`
+    [
+      "0x01",
+      "0x0311",
+      "0x01",
+      "0x01",
+      "0x",
+      "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+      "0x0de0b6b3a7640000",
+      "0x",
+      [],
+    ]
+  `)
+})
+
+test('parseAccessList', () => {
+  expect(
+    parseAccessList([
+      [
+        '0x1234512345123451234512345123451234512345',
+        [
+          '0x1234512345123451234512345123451234512345',
+          '0x1234512345123451234512345123451234512345',
+        ],
+      ],
+    ]),
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "address": "0x1234512345123451234512345123451234512345",
+        "storageKeys": [
+          "0x1234512345123451234512345123451234512345",
+          "0x1234512345123451234512345123451234512345",
+        ],
+      },
+    ]
+  `)
 })

--- a/src/utils/transaction/parseTransaction.ts
+++ b/src/utils/transaction/parseTransaction.ts
@@ -66,10 +66,7 @@ export function parseTransaction<TSerialized extends TransactionSerialized>(
 function parseTransactionEIP1559(
   serializedTransaction: TransactionSerializedEIP1559,
 ): TransactionSerializableEIP1559 {
-  const transactionArray = fromRlp(
-    `0x${serializedTransaction.slice(4)}` as Hex,
-    'hex',
-  )
+  const transactionArray = toTransactionArray(serializedTransaction)
 
   const [
     chainId,
@@ -140,10 +137,7 @@ function parseTransactionEIP2930(
   serializedTransaction: TransactionSerializedEIP2930,
 ): Omit<TransactionRequestEIP2930, 'from'> &
   ({ chainId: number } | ({ chainId: number } & Signature)) {
-  const transactionArray = fromRlp(
-    `0x${serializedTransaction.slice(4)}` as Hex,
-    'hex',
-  )
+  const transactionArray = toTransactionArray(serializedTransaction)
 
   const [chainId, nonce, gasPrice, gas, to, value, data, accessList, v, r, s] =
     transactionArray
@@ -263,7 +257,11 @@ function parseTransactionLegacy(
   return transaction
 }
 
-function parseAccessList(accessList_: RecursiveArray<Hex>): AccessList {
+export function toTransactionArray(serializedTransaction: string) {
+  return fromRlp(`0x${serializedTransaction.slice(4)}` as Hex, 'hex')
+}
+
+export function parseAccessList(accessList_: RecursiveArray<Hex>): AccessList {
   const accessList: AccessList = []
   for (let i = 0; i < accessList_.length; i++) {
     const [address, storageKeys] = accessList_[i] as [Hex, Hex[]]


### PR DESCRIPTION
add parseTransactionCelo for parsing out serialized transaction types specific to celo chain.



replaces #897

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `parseTransactionCelo` function to the `viem/chains/utils` entrypoint.
- Exported `parseTransactionCelo` function from `src/chains/utils.ts`.
- Added `toTransactionArray` and `parseAccessList` functions to `src/utils/transaction/parseTransaction.ts`.
- Updated `serializeTransactionCelo` function in `src/chains/celo/serializers.ts`.
- Added `assertTransactionCIP42` function to `src/chains/celo/serializers.ts`.
- Added `parseTransactionCelo` function to `src/chains/celo/parsers.ts`.
- Updated type definitions in `src/chains/celo/types.ts`.

> The following files were skipped due to too many changes: `src/chains/celo/parsers.ts`, `src/chains/celo/parsers.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->