### PR TITLE
fix: make `value` optional for `payable` functions

### DIFF
--- a/.changeset/lazy-turtles-retire.md
+++ b/.changeset/lazy-turtles-retire.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Made `value` optional on `writeContract`/`simulateContract` for `payable` functions.

--- a/contracts/src/Payable.sol
+++ b/contracts/src/Payable.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+contract Payable {
+    function pay() public payable {}
+}

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -8,6 +8,7 @@ import erc20InvalidTransferEvent from '../../contracts/out/ERC20InvalidTransferE
 import ensAvatarTokenUri from '../../contracts/out/EnsAvatarTokenUri.sol/EnsAvatarTokenUri.json'
 import errorsExample from '../../contracts/out/ErrorsExample.sol/ErrorsExample.json'
 import offchainLookupExample from '../../contracts/out/OffchainLookupExample.sol/OffchainLookupExample.json'
+import payable from '../../contracts/out/Payable.sol/Payable.json'
 
 import { getTransactionReceipt } from '../actions/public/getTransactionReceipt.js'
 import { impersonateAccount } from '../actions/test/impersonateAccount.js'
@@ -46,6 +47,7 @@ import {
   erc20InvalidTransferEventABI,
   errorsExampleABI,
   offchainLookupExampleABI,
+  payableABI,
 } from './generated.js'
 
 export const anvilChain = {
@@ -250,6 +252,14 @@ export async function deployOffchainLookupExample({
     bytecode: offchainLookupExample.bytecode.object as Hex,
     account: accounts[0].address,
     args: [urls],
+  })
+}
+
+export async function deployPayable() {
+  return deploy({
+    abi: payableABI,
+    bytecode: payable.bytecode.object as Hex,
+    account: accounts[0].address,
   })
 }
 

--- a/src/actions/wallet/writeContract.test-d.ts
+++ b/src/actions/wallet/writeContract.test-d.ts
@@ -1,7 +1,7 @@
 import { seaportAbi } from 'abitype/test'
 import { assertType, expectTypeOf, test } from 'vitest'
 
-import { wagmiContractConfig } from '../../_test/abis.js'
+import { baycContractConfig, wagmiContractConfig } from '../../_test/abis.js'
 import { walletClientWithAccount } from '../../_test/utils.js'
 import { type WriteContractParameters, writeContract } from './writeContract.js'
 
@@ -165,5 +165,33 @@ test('eip2930', () => {
     maxFeePerGas: 0n,
     maxPriorityFeePerGas: 0n,
     type: 'eip2930',
+  })
+})
+
+test('args: value', () => {
+  // payable function
+  writeContract(walletClientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+    value: 5n,
+  })
+
+  // payable function (undefined)
+  writeContract(walletClientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'mintApe',
+    args: [69n],
+  })
+
+  // nonpayable function
+  writeContract(walletClientWithAccount, {
+    abi: baycContractConfig.abi,
+    address: '0x',
+    functionName: 'approve',
+    // @ts-expect-error
+    value: 5n,
   })
 })

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -166,7 +166,7 @@ test('GetFunctionArgs', () => {
 test('GetValue', () => {
   // payable
   type Result = GetValue<typeof seaportAbi, 'fulfillAdvancedOrder'>
-  expectTypeOf<Result>().toEqualTypeOf<{ value: bigint }>()
+  expectTypeOf<Result>().toEqualTypeOf<{ value?: bigint }>()
 
   // other
   expectTypeOf<GetValue<typeof seaportAbi, 'getOrderStatus'>>().toEqualTypeOf<{

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -73,9 +73,9 @@ export type GetValue<
   _Narrowable extends boolean = IsNarrowable<TAbi, Abi>,
 > = _Narrowable extends true
   ? TAbiFunction['stateMutability'] extends 'payable'
-    ? { value: NoUndefined<TValueType> }
+    ? { value?: NoUndefined<TValueType> }
     : TAbiFunction['payable'] extends true
-    ? { value: NoUndefined<TValueType> }
+    ? { value?: NoUndefined<TValueType> }
     : { value?: never }
   : { value?: TValueType }
 


### PR DESCRIPTION
Fixes #891.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Made the `value` parameter optional on `writeContract` and `simulateContract` functions for `payable` functions.
- Updated type definitions in `contract.test-d.ts` and `contract.ts` to reflect the optional `value` parameter.
- Added `payable` contract to `utils.ts` and `writeContract.test.ts` files.
- Added tests for the `value` parameter in `writeContract.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->