### PR TITLE
fix: websocket instantiation

### DIFF
--- a/.changeset/old-students-camp.md
+++ b/.changeset/old-students-camp.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed WebSocket instantiation in React Native environment.

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -146,17 +146,14 @@ export type Socket = WebSocket & {
 
 const sockets = /*#__PURE__*/ new Map<string, Socket>()
 
-export async function getSocket(url_: string) {
-  const url = new URL(url_)
-  const urlKey = url.toString()
-
-  let socket = sockets.get(urlKey)
+export async function getSocket(url: string) {
+  let socket = sockets.get(url)
 
   // If the socket already exists, return it.
   if (socket) return socket
 
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
-    id: urlKey,
+    id: url,
     fn: async () => {
       let WebSocket = await import('isomorphic-ws')
       // Workaround for Vite.
@@ -188,7 +185,7 @@ export async function getSocket(url_: string) {
         if (!isSubscription) cache.delete(id)
       }
       const onClose = () => {
-        sockets.delete(urlKey)
+        sockets.delete(url)
         webSocket.removeEventListener('close', onClose)
         webSocket.removeEventListener('message', onMessage)
       }
@@ -211,7 +208,7 @@ export async function getSocket(url_: string) {
         requests,
         subscriptions,
       })
-      sockets.set(urlKey, socket)
+      sockets.set(url, socket)
 
       return [socket]
     },


### PR DESCRIPTION
Fixes #711

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing the WebSocket instantiation in React Native environment. 

### Detailed summary
- Fixed WebSocket instantiation in React Native environment.
- Updated the parameter type of `getSocket` function from `url_: string` to `url: string`.
- Updated the usage of `sockets.get` and `sockets.set` functions to use the `url` parameter instead of `urlKey`.
- Updated the `id` parameter of `createBatchScheduler` function to use the `url` parameter instead of `urlKey`.
- Updated the `sockets.delete` function to use the `url` parameter instead of `urlKey`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->