### PR TITLE
fix: In the case of WalletConnect, add logic to handle when a user reject transaciton

### DIFF
--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -2,6 +2,7 @@ import type { Account } from '../../accounts/types.js'
 import type { SendTransactionParameters } from '../../actions/wallet/sendTransaction.js'
 import type { BaseError } from '../../errors/base.js'
 import { TransactionExecutionError } from '../../errors/transaction.js'
+import { UserRejectedRequestError, type ProviderRpcError } from '../../index.js'
 import type { Chain } from '../../types/chain.js'
 
 import {
@@ -24,6 +25,20 @@ export function getTransactionError(
   { docsPath, ...args }: GetTransactionErrorParameters,
 ) {
   let cause = err
+
+  /**
+   * 
+    When the user rejected the transaction after connecting the wallet through walletconnect,
+    the error code of walletconnect is 5000, not 4001, so a unification process is needed.
+    https://docs.walletconnect.com/2.0/specs/clients/sign/error-codes#rejected-caip-25
+
+    See the code in the link below.
+    https://github.com/wagmi-dev/references/blob/849d7a5d2c630c1b55f3414cea034303e84250f9/packages/connectors/src/walletConnect.ts#L159C32-L159C32
+   */
+  if (/user rejected/i.test((err as ProviderRpcError)?.message)) {
+    return new UserRejectedRequestError(err as Error)
+  }
+
   if (containsNodeError(err))
     cause = getNodeError(err, args as GetNodeErrorParameters)
   return new TransactionExecutionError(cause, {


### PR DESCRIPTION
hello. After connecting metamask through walletconnect, sending a transaction, and then canceling the transaction directly, UserRejectedRequestError was expected, but UnknownRpcError occurs as shown in the picture below.

<img width="798" alt="image" src="https://github.com/wagmi-dev/viem/assets/7166022/da0f6f54-27dd-437e-ac82-841e62b80850">


After figuring out the cause of the error, there was an issue where the error code was 5000 instead of 4001 when walletconnect rejected the transaction.
https://docs.walletconnect.com/2.0/specs/clients/sign/error-codes#rejected-caip-25

Referring to the code below, when a user reject error occurs in the walletconnect environment, a UserRejectedRequestError is raised.
https://github.com/wagmi-dev/references/blob/849d7a5d2c630c1b55f3414cea034303e84250f9/packages/connectors/src/walletConnect.ts#L159C32-L159C32

I don't know the project structure well, so it may be the direction of modification that I don't want. Feel free to edit this pull request at any time.

Thank you for making such a great project and saving me a lot of time. Thank you every time.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on handling a specific error scenario when the user rejects a transaction after connecting the wallet through WalletConnect. 

### Detailed summary
- Added import for `UserRejectedRequestError` and `ProviderRpcError`
- Added condition to check for user rejection error and return `UserRejectedRequestError`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->