### PR TITLE
Load isomorphic-ws via import rather than async import

### DIFF
--- a/.changeset/twenty-emus-build.md
+++ b/.changeset/twenty-emus-build.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Converted `isomorphic-ws` to a synchronous import.

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,4 +1,5 @@
-import type { MessageEvent, WebSocket } from 'isomorphic-ws'
+import { WebSocket } from 'isomorphic-ws'
+import type { MessageEvent } from 'isomorphic-ws'
 
 import {
   HttpRequestError,
@@ -155,7 +156,6 @@ export async function getSocket(url: string) {
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      let WebSocket = await import('isomorphic-ws')
       // Workaround for Vite.
       // https://github.com/vitejs/vite/issues/9703
       // TODO: Remove when issue is resolved.
@@ -163,11 +163,12 @@ export async function getSocket(url: string) {
         (WebSocket as unknown as { default?: typeof WebSocket }).default
           ?.constructor
       )
-        WebSocket = (WebSocket as unknown as { default: typeof WebSocket })
-          .default
-      else WebSocket = WebSocket.WebSocket
+        PatchedWebSocket = (
+          WebSocket as unknown as { default: typeof WebSocket }
+        ).default
+      else PatchedWebSocket = WebSocket.WebSocket
 
-      const webSocket = new WebSocket(url)
+      const webSocket = new PatchedWebSocket(url)
 
       // Set up a cache for incoming "synchronous" requests.
       const requests = new Map<Id, CallbackFn>()

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -156,19 +156,7 @@ export async function getSocket(url: string) {
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      let WebSocket_
-      // Workaround for Vite.
-      // https://github.com/vitejs/vite/issues/9703
-      // TODO: Remove when issue is resolved.
-      if (
-        (WebSocket as unknown as { default?: typeof WebSocket }).default
-          ?.constructor
-      )
-        WebSocket_ = (WebSocket as unknown as { default: typeof WebSocket })
-          .default
-      else WebSocket_ = WebSocket.WebSocket
-
-      const webSocket = new WebSocket_(url)
+      const webSocket = new WebSocket(url)
 
       // Set up a cache for incoming "synchronous" requests.
       const requests = new Map<Id, CallbackFn>()

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -164,9 +164,8 @@ export async function getSocket(url: string) {
         (WebSocket as unknown as { default?: typeof WebSocket }).default
           ?.constructor
       )
-        WebSocket_ = (
-          WebSocket as unknown as { default: typeof WebSocket }
-        ).default
+        WebSocket_ = (WebSocket as unknown as { default: typeof WebSocket })
+          .default
       else WebSocket_ = WebSocket.WebSocket
 
       const webSocket = new WebSocket_(url)

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -156,6 +156,7 @@ export async function getSocket(url: string) {
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
+      let PatchedWebSocket
       // Workaround for Vite.
       // https://github.com/vitejs/vite/issues/9703
       // TODO: Remove when issue is resolved.

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -156,7 +156,7 @@ export async function getSocket(url: string) {
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      let PatchedWebSocket
+      let WebSocket_
       // Workaround for Vite.
       // https://github.com/vitejs/vite/issues/9703
       // TODO: Remove when issue is resolved.
@@ -164,12 +164,12 @@ export async function getSocket(url: string) {
         (WebSocket as unknown as { default?: typeof WebSocket }).default
           ?.constructor
       )
-        PatchedWebSocket = (
+        WebSocket_ = (
           WebSocket as unknown as { default: typeof WebSocket }
         ).default
-      else PatchedWebSocket = WebSocket.WebSocket
+      else WebSocket_ = WebSocket.WebSocket
 
-      const webSocket = new PatchedWebSocket(url)
+      const webSocket = new WebSocket_(url)
 
       // Set up a cache for incoming "synchronous" requests.
       const requests = new Map<Id, CallbackFn>()

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -1,4 +1,4 @@
-import { WebSocket } from 'isomorphic-ws'
+import WebSocket from 'isomorphic-ws'
 import type { MessageEvent } from 'isomorphic-ws'
 
 import {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on converting the import of `isomorphic-ws` to a synchronous import.

### Detailed summary:
- Converted `isomorphic-ws` to a synchronous import in `viem` patch.
- Added import statements for `WebSocket` and `MessageEvent` in `rpc.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->