### PR TITLE
fix: docs code example highlight + comment typo

### DIFF
--- a/site/docs/contract/deployContract.md
+++ b/site/docs/contract/deployContract.md
@@ -65,7 +65,7 @@ export const account = privateKeyToAccount(...)
 
 ::: code-group
 
-```ts {7} [example.ts]
+```ts {8} [example.ts]
 import { deployContract } from 'viem'
 import { wagmiAbi } from './abi'
 import { account, walletClient } from './config'

--- a/src/errors/rpc.ts
+++ b/src/errors/rpc.ts
@@ -60,7 +60,7 @@ export type ProviderRpcErrorCode =
   | 4200 // Unsupported Method
   | 4900 // Disconnected
   | 4901 // Chain Disconnected
-  | 4902 // Chain Not Recongnized
+  | 4902 // Chain Not Recognized
 
 /**
  * Error subclass implementing Ethereum Provider errors per EIP-1193.


### PR DESCRIPTION
Just noticed a few things when browsing the codebase + docs, thought I'd put together a quick PR.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates an error message and adjusts a code example in the documentation.

### Detailed summary
- Updated error message "Chain Not Recongnized" to "Chain Not Recognized" in `rpc.ts`.
- Adjusted line number in code example in `deployContract.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->