### PR TITLE
fix documentation: imports for shortcut 'toHex' functions

### DIFF
--- a/site/docs/utilities/toHex.md
+++ b/site/docs/utilities/toHex.md
@@ -127,7 +127,7 @@ stringToHex('Hello World!', { size: 32 })
 Encodes a byte array to a hex value.
 
 ```ts
-import { stringToHex } from 'viem'
+import { bytesToHex } from 'viem'
 
 bytesToHex(
   new Uint8Array([72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33]),
@@ -148,11 +148,11 @@ bytesToHex(
 Encodes a boolean to a hex value.
 
 ```ts
-import { stringToHex } from 'viem'
+import { boolToHex } from 'viem'
 
-bytesToHex(true)
+boolToHex(true)
 // "0x1"
 
-bytesToHex(true, { size: 32 })
+boolToHex(true, { size: 32 })
 // "0x0000000000000000000000000000000000000000000000000000000000000001"
 ```


### PR DESCRIPTION
update/fix imports for shortcut 'toHex' functions (bytesToHex & boolToHex)

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on replacing the `stringToHex` utility function with `bytesToHex` and `boolToHex` functions in the `toHex.md` file.

### Detailed summary:
- Replaced `stringToHex` with `bytesToHex` in the import statement.
- Replaced `bytesToHex(true)` with `boolToHex(true)` in the code example.
- Replaced `bytesToHex(true, { size: 32 })` with `boolToHex(true, { size: 32 })` in the code example.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->