### PR TITLE
fix(docs): `data` -> `message`

### DIFF
--- a/site/docs/actions/wallet/signMessage.md
+++ b/site/docs/actions/wallet/signMessage.md
@@ -125,7 +125,7 @@ const signature = await walletClient.signMessage({
 })
 ```
 
-### data
+### message
 
 - **Type:** `string | { raw: Hex | ByteArray }`
 


### PR DESCRIPTION
The name of the parameter is `message` not `data`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `data` parameter to `message` in the `signMessage` function. 

### Detailed summary
- Renamed the `data` parameter to `message` in the `signMessage` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->