### PR TITLE
fix: multicall perfomance

### DIFF
--- a/.changeset/pink-beers-share.md
+++ b/.changeset/pink-beers-share.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-multicall performance improve
+Improved multicall performance.

--- a/.changeset/pink-beers-share.md
+++ b/.changeset/pink-beers-share.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+multicall performance improve

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -184,8 +184,9 @@ export async function multicall<
     ),
   )
 
+  const calls = chunkedCalls.flat()
+
   return results.flat().map(({ returnData, success }, i) => {
-    const calls = chunkedCalls.flat()
     const { callData } = calls[i]
     const { abi, address, functionName, args } = contracts[
       i


### PR DESCRIPTION
It looks like `viem` has big performance degradation because of calling `chunkedCalls.flat()` for each item from `results` in the `multicall` function. Based on the code I think we can move this `flat` out of the `map` cycle, which will significantly improve performance, especially for big multicalls.

Test scenario around 2k `balanceOf` with `batchSize: 30 * 1024`:
Flame chart before:
![image](https://github.com/wagmi-dev/viem/assets/1782530/cfcb4306-2923-4a90-9266-9ad0951bb0ec)
Flame chart after: 
![image](https://github.com/wagmi-dev/viem/assets/1782530/f2ad6f7f-9ee7-4cf1-af94-435511dbbabb)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving multicall performance. 

### Detailed summary
- Refactored code to remove redundant variable declaration.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->