### PR TITLE
Add OP Stack contracts to ChainConstants.contracts

### DIFF
--- a/.changeset/fuzzy-lions-sleep.md
+++ b/.changeset/fuzzy-lions-sleep.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Add OP Stack contracts to chain contracts type

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -37,6 +37,41 @@ export type ChainConstants = {
     ensRegistry?: ChainContract
     ensUniversalResolver?: ChainContract
     multicall3?: ChainContract
+    // L1 OP Stack Contracts
+    l1CrossDomainMessenger?: {
+      [chainId: number]: unknown
+    }
+    l1Erc721Bridge?: {
+      [chainId: number]: unknown
+    }
+    l1StandardBridge?: {
+      [chainId: number]: unknown
+    }
+    l2OutputOracle?: {
+      [chainId: number]: unknown
+    }
+    optimismMintableErc20Factory?: {
+      [chainId: number]: unknown
+    }
+    optimismPortal?: {
+      [chainId: number]: unknown
+    }
+    systemConfig?: {
+      [chainId: number]: unknown
+    }
+    systemDictator?: {
+      [chainId: number]: unknown
+    }
+    // L2 OP Stack Contracts
+    // note these are redeploys and always have the same address
+    l2CrossDomainMessenger?: Address
+    l2StandardBridge?: Address
+    optimismMintableERC20Factory?: Address
+    gasPriceOracle?: Address
+    l1Block?: Address
+    l2ToL1MessagePasser?: Address
+    l2Erc721Bridge?: Address
+    optimismMintableErc721Factory?: Address
   }
   /** ID in number form */
   id: number


### PR DESCRIPTION
This will unlock improved APIs and typing in [op-viem](https://github.com/base-org/op-viem).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding OP Stack contracts to chain contracts type. 

### Detailed summary
- Added OP Stack contracts to chain contracts type in `src/types/chain.ts`
- Added contracts for L1 OP Stack and L2 OP Stack
- Added addresses for L2 OP Stack contracts

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->