### PR TITLE
:docs: Corrects a minor typo in getContract.md

### DIFF
--- a/site/docs/contract/getContract.md
+++ b/site/docs/contract/getContract.md
@@ -87,7 +87,7 @@ export const wagmiAbi = [
 ```
 :::
 
-Using Contract Instances can make it easier to work with contracts if you don't want to pass the `abi` and `address` properites every time you perform contract actions, e.g. [`readContract`](/docs/contract/readContract.html), [`writeContract`](/docs/contract/writeContract.html), [`estimateContractGas`](/docs/contract/estimateContractGas.html), etc. Switch between the tabs below to see the difference between standalone Contract Actions and Contract Instance Actions:
+Using Contract Instances can make it easier to work with contracts if you don't want to pass the `abi` and `address` properties every time you perform contract actions, e.g. [`readContract`](/docs/contract/readContract.html), [`writeContract`](/docs/contract/writeContract.html), [`estimateContractGas`](/docs/contract/estimateContractGas.html), etc. Switch between the tabs below to see the difference between standalone Contract Actions and Contract Instance Actions:
 
 ::: code-group
 ```ts [contract-actions.ts]


### PR DESCRIPTION
Corrects a minor typo in getContract.md

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes a typo in the `getContract.md` file and improves the readability of the documentation. 

### Detailed summary
- Fixed a typo in the word "properties" in a comment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->