### PR TITLE
Correct the RPC error handling

### DIFF
--- a/src/utils/errors/getContractError.ts
+++ b/src/utils/errors/getContractError.ts
@@ -10,6 +10,7 @@ import {
 } from '../../errors/contract.js'
 
 const EXECUTION_REVERTED_ERROR_CODE = 3
+const EXECUTION_REVERTED_ERROR_CODE_NEW = -32603
 
 export function getContractError(
   err: BaseError,
@@ -41,7 +42,9 @@ export function getContractError(
   if (err instanceof AbiDecodingZeroDataError) {
     cause = new ContractFunctionZeroDataError({ functionName })
   } else if (
-    code === EXECUTION_REVERTED_ERROR_CODE &&
+    [EXECUTION_REVERTED_ERROR_CODE, EXECUTION_REVERTED_ERROR_CODE_NEW].includes(
+      code,
+    ) &&
     (data || message || shortMessage)
   ) {
     cause = new ContractFunctionRevertedError({


### PR DESCRIPTION
The error code used to detect revert is set to `3`, and it not documented where this value comes from. This does not look right, the real code should be `-32603` as per https://eips.ethereum.org/EIPS/eip-1474#error-codes.

This is a wip, published to collect feedback.

A few concerns I have here:
- we can't just use the new code, as people relying on the old code will suffer if we just drop it; checking both seems harmless though.
- this is a breaking change for those who expected the error to be `ContractFunctionExecutionError`  - after this change they may get `ContractFunctionRevertedError` where the didn't expect.
- why are there some fields that are in `ContractFunctionExecutionError` but not in `ContractFunctionRevertedError`? why is not data available at `ContractFunctionExecutionError` if it was passed but not parsed, but other params are copied there?

CC: @tonycdot

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

This PR introduces a new constant `EXECUTION_REVERTED_ERROR_CODE_NEW` and updates the `getContractError` function to handle the new error code. The changes include:
- Adding a new constant `EXECUTION_REVERTED_ERROR_CODE_NEW`
- Updating the condition in `getContractError` to include the new error code

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->