### PR TITLE
Allow for call to take account hoisting into consideration

### DIFF
--- a/.changeset/hot-donuts-look.md
+++ b/.changeset/hot-donuts-look.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+call now takes account hoisting into consideration

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -8,6 +8,7 @@ import {
   deployOffchainLookupExample,
   publicClient,
   publicClientMainnet,
+  walletClientWithAccount,
 } from '../../_test/utils.js'
 import { celo } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
@@ -29,6 +30,8 @@ const mint4bytes = '0x1249c58b'
 const mintWithParams4bytes = '0xa0712d68'
 const fourTwenty =
   '00000000000000000000000000000000000000000000000000000000000001a4'
+const sixHundred =
+  '0000000000000000000000000000000000000000000000000000000000000258'
 
 const sourceAccount = accounts[0]
 
@@ -121,6 +124,34 @@ test('args: blockNumber', async () => {
     to: wagmiContractAddress,
   })
   expect(data).toMatchInlineSnapshot('undefined')
+})
+
+describe('account hoisting', () => {
+  test('no account hoisted', async () => {
+    await expect(
+      call(publicClient, {
+        data: `${mintWithParams4bytes}${sixHundred}`,
+        to: wagmiContractAddress,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      "Execution reverted with reason: ERC721: mint to the zero address.
+
+      Raw Call Arguments:
+        to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2
+        data:  0xa0712d680000000000000000000000000000000000000000000000000000000000000258
+      
+      Details: execution reverted: ERC721: mint to the zero address
+      Version: viem@1.0.2"
+    `)
+  })
+
+  test('account hoisted', async () => {
+    const { data } = await call(walletClientWithAccount, {
+      data: `${mintWithParams4bytes}${sixHundred}`,
+      to: wagmiContractAddress,
+    })
+    expect(data).toMatchInlineSnapshot('undefined')
+  })
 })
 
 describe('errors', () => {

--- a/src/actions/public/call.ts
+++ b/src/actions/public/call.ts
@@ -89,7 +89,7 @@ export async function call<TChain extends Chain | undefined>(
   args: CallParameters<TChain>,
 ): Promise<CallReturnType> {
   const {
-    account: account_,
+    account: account_ = client.account,
     batch = Boolean(client.batch?.multicall),
     blockNumber,
     blockTag = 'latest',


### PR DESCRIPTION
When calling the `writeContract` functionality, the recommended pattern is to call `simulateContract` first beforehand.

When doing this with a client that has both the wallet and public actions tied to it along with an account hoisted to it, the `simulateContract` functionality fails when the account isn't specified for transactions that require the "from" field to be present.

After more investigation, the `simulateContract` uses `call` and `writeContract` uses `sendTransaction`, but `call` does not take the hoisted account into consideration while `sendTransaction` does.

https://github.com/wagmi-dev/viem/blob/0cbf0b881785c41834fce5e214868bfe3200dc1e/src/actions/public/call.ts#L92
https://github.com/wagmi-dev/viem/blob/0cbf0b881785c41834fce5e214868bfe3200dc1e/src/actions/wallet/sendTransaction.ts#L100

This PR updates the `call` functionality to take the hoisted account into consideration 