### PR TITLE
Fix bug regarding incorrect bigint->bytes32 conversion in hexToSignature

### DIFF
--- a/.changeset/smart-eggs-kneel.md
+++ b/.changeset/smart-eggs-kneel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed bug regarding incorrect bigint->bytes32 conversion in hexToSignature

--- a/src/utils/signature/hexToSignature.test.ts
+++ b/src/utils/signature/hexToSignature.test.ts
@@ -32,4 +32,14 @@ test('default', () => {
     ),
     v: 27n,
   })
+
+  expect(
+    hexToSignature(
+      '0x602381e57b70f1ada20bd56a806291cfc5cb5088f00f0e791510fd8b8cf05cc40dea7b983e0c7d204f3dc511b1f19a2787a5c82cd72f3bd38da58f10969907841b',
+    ),
+  ).toEqual({
+    r: '0x602381e57b70f1ada20bd56a806291cfc5cb5088f00f0e791510fd8b8cf05cc4',
+    s: '0x0dea7b983e0c7d204f3dc511b1f19a2787a5c82cd72f3bd38da58f1096990784',
+    v: 27n,
+  })
 })

--- a/src/utils/signature/hexToSignature.ts
+++ b/src/utils/signature/hexToSignature.ts
@@ -16,5 +16,5 @@ import { numberToHex } from '../../utils/encoding/toHex.js'
 export function hexToSignature(signatureHex: Hex): Signature {
   const { r, s } = secp256k1.Signature.fromCompact(signatureHex.slice(2, 130))
   const v = BigInt(`0x${signatureHex.slice(130)}`)
-  return { r: numberToHex(r), s: numberToHex(s), v }
+  return { r: numberToHex(r, { size: 32 }), s: numberToHex(s, { size: 32 }), v }
 }


### PR DESCRIPTION
The lack of `size` parameter in `numberToHex` in `hexToSignature` could cause lacking leading zeroes (see test case).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing a bug related to bigint to bytes32 conversion in the `hexToSignature` function. 

### Detailed summary
- Updated the `hexToSignature` function to correctly convert bigint values to bytes32.
- Updated the test for `hexToSignature` to include the fixed conversion.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->