### PR TITLE
feat(dogechainTestnet): Added Dogechain Testnet chain

### DIFF
--- a/src/chains/definitions/dogechainTestnet.ts
+++ b/src/chains/definitions/dogechainTestnet.ts
@@ -1,0 +1,27 @@
+import { defineChain } from '../../utils/chain.js'
+
+export const dogechainTestnet = /*#__PURE__*/ defineChain({
+  id: 568,
+  name: 'Dogechain Testnet',
+  network: 'dogechain-testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'Testnet Doge',
+    symbol: 'tDC',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc-testnet.dogechain.dog'] },
+    public: { http: ['https://rpc-testnet.dogechain.dog'] },
+  },
+  blockExplorers: {
+    etherscan: {
+      name: 'TestnetDogeChainExplorer',
+      url: 'https://explorer-testnet.dogechain.dog',
+    },
+    default: {
+      name: 'TestnetDogeChainExplorer',
+      url: 'https://explorer-testnet.dogechain.dog',
+    },
+  },
+  testnet: true,
+})


### PR DESCRIPTION
Added dogechain testnet

ENS: dimabreezy.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds the definition for the Dogechain Testnet. 

### Detailed summary
- Adds the `dogechainTestnet` definition in `src/chains/definitions/dogechainTestnet.ts`
- Defines the chain ID, name, network, native currency, RPC URLs, and block explorers for the Dogechain Testnet
- Sets the `testnet` flag to true

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->