### PR TITLE
feat: add ENS registry and universal resolver for Sepolia

### DIFF
--- a/.changeset/lucky-cycles-appear.md
+++ b/.changeset/lucky-cycles-appear.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+Added ENS Registry and ENS Universal Resolver for Sepolia.

--- a/.changeset/lucky-cycles-appear.md
+++ b/.changeset/lucky-cycles-appear.md
@@ -1,5 +1,5 @@
 ---
-"@fake-scope/fake-pkg": patch
+"viem": patch
 ---
 
 Added ENS Registry and ENS Universal Resolver for Sepolia.

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -36,6 +36,11 @@ export const sepolia = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 6507670,
     },
+    ensRegistry: { address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e' },
+    ensUniversalResolver: {
+      address: '0x21B000Fd62a880b2125A61e36a284BB757b76025',
+      blockCreated: 3914906,
+    },
   },
   testnet: true,
 })


### PR DESCRIPTION
## Description

Adding the ENS Registry and ensUniversalResolver contracts for Sepolia so they can be supported by viem and wagmi out of the box.

## Additional Information

- [x] I read the [contributing docs](/wagmi-dev/references/blob/main/.github/CONTRIBUTING.md) (if this is your first contribution)

Your ENS/address: schlabach.eth

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ENS Registry and ENS Universal Resolver for Sepolia.

### Detailed summary
- Added ENS Registry with address: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e'
- Added ENS Universal Resolver with address: '0x21B000Fd62a880b2125A61e36a284BB757b76025' and blockCreated: 3914906

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->