### PR TITLE
add support for meter/meterTestnet

### DIFF
--- a/src/chains/definitions/meter.ts
+++ b/src/chains/definitions/meter.ts
@@ -1,0 +1,22 @@
+import { defineChain } from '../../utils/chain.js'
+
+export const meter = /*#__PURE__*/ defineChain({
+  id: 82,
+  name: 'Meter',
+  network: 'meter',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'MTR',
+    symbol: 'MTR',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpc.meter.io'] },
+    public: { http: ['https://rpc.meter.io'] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'MeterScan', url: 'https://scan.meter.io' },
+    default: { name: 'MeterScan', url: 'https://scan.meter.io' },
+  },
+  contracts: {
+  },
+})

--- a/src/chains/definitions/meterTestnet.ts
+++ b/src/chains/definitions/meterTestnet.ts
@@ -1,0 +1,22 @@
+import { defineChain } from '../../utils/chain.js'
+
+export const meter = /*#__PURE__*/ defineChain({
+  id: 83,
+  name: 'Meter Testnet',
+  network: 'meter-testnet',
+  nativeCurrency: {
+    decimals: 18,
+    name: 'MTR',
+    symbol: 'MTR',
+  },
+  rpcUrls: {
+    default: { http: ['https://rpctest.meter.io'] },
+    public: { http: ['https://rpctest.meter.io'] },
+  },
+  blockExplorers: {
+    etherscan: { name: 'MeterTestnetScan', url: 'https://scan-warringstakes.meter.io' },
+    default: { name: 'MeterTestnetScan', url: 'https://scan-warringstakes.meter.io' },
+  },
+  contracts: {
+  },
+})


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for the Meter and Meter Testnet chains. 

### Detailed summary
- Added `meter.ts` and `meterTestnet.ts` files in the `src/chains/definitions` directory.
- Imported `defineChain` function from `../../utils/chain.js`.
- Defined the Meter chain with ID, name, network, native currency, RPC URLs, and block explorers.
- Defined the Meter Testnet chain with ID, name, network, native currency, RPC URLs, and block explorers.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->