### PR TITLE
refactor: remove hardcoded priority fee

### DIFF
--- a/.changeset/large-rings-provide.md
+++ b/.changeset/large-rings-provide.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed hardcoded `defaultPriorityFee` on OP Stack chains in favor of fetching it from `eth_maxPriorityFeePerGas`.

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const base = /*#__PURE__*/ defineChain(
@@ -38,7 +37,6 @@ export const base = /*#__PURE__*/ defineChain(
     },
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/definitions/baseGoerli.ts
+++ b/src/chains/definitions/baseGoerli.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const baseGoerli = /*#__PURE__*/ defineChain(
@@ -36,7 +35,6 @@ export const baseGoerli = /*#__PURE__*/ defineChain(
     sourceId: 5, // goerli
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const optimism = /*#__PURE__*/ defineChain(
@@ -42,7 +41,6 @@ export const optimism = /*#__PURE__*/ defineChain(
     },
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/definitions/optimismGoerli.ts
+++ b/src/chains/definitions/optimismGoerli.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const optimismGoerli = /*#__PURE__*/ defineChain(
@@ -43,7 +42,6 @@ export const optimismGoerli = /*#__PURE__*/ defineChain(
     testnet: true,
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/definitions/zora.ts
+++ b/src/chains/definitions/zora.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const zora = /*#__PURE__*/ defineChain(
@@ -33,7 +32,6 @@ export const zora = /*#__PURE__*/ defineChain(
     },
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/definitions/zoraTestnet.ts
+++ b/src/chains/definitions/zoraTestnet.ts
@@ -1,5 +1,4 @@
 import { defineChain } from '../../utils/chain.js'
-import { feesOptimism } from '../optimism/fees.js'
 import { formattersOptimism } from '../optimism/formatters.js'
 
 export const zoraTestnet = /*#__PURE__*/ defineChain(
@@ -37,7 +36,6 @@ export const zoraTestnet = /*#__PURE__*/ defineChain(
     testnet: true,
   },
   {
-    fees: feesOptimism,
     formatters: formattersOptimism,
   },
 )

--- a/src/chains/optimism/fees.ts
+++ b/src/chains/optimism/fees.ts
@@ -1,5 +1,0 @@
-import type { ChainFees } from '../../types/chain.js'
-
-export const feesOptimism = {
-  defaultPriorityFee: 1_000_000n, // 0.001 gwei
-} as const satisfies ChainFees


### PR DESCRIPTION
Turns out 0.001 gwei is actually an incorrect assumption for the default priority fee. It should be [0.1 gwei](https://github.com/ethereum-optimism/op-geth/pull/77/files#diff-c16c4a8c9f5ecfc12da6b841a10635af1d842c6f5aa9f0229fc817aa8aa80222R41).

As we now rely on `eth_maxPriorityFeePerGas`, we can use that to more accurately provide us with a default priority fee.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes the hardcoded `defaultPriorityFee` on OP Stack chains and fetches it from `eth_maxPriorityFeePerGas` instead.

### Detailed summary
- Removed hardcoded `defaultPriorityFee` on OP Stack chains
- Fetch `defaultPriorityFee` from `eth_maxPriorityFeePerGas`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->