### PR TITLE
feat: amend chain type to support OP Stack contracts

### DIFF
--- a/.changeset/calm-terms-bathe.md
+++ b/.changeset/calm-terms-bathe.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Amended `Chain` type to allow arbitrary `contracts` (as well as contracts that could be dependant on chain).

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -34,6 +34,8 @@ export type ChainConstants = {
   }
   /** Collection of contracts */
   contracts?: {
+    [key: string]: ChainContract | { [chainId: number]: ChainContract }
+  } & {
     ensRegistry?: ChainContract
     ensUniversalResolver?: ChainContract
     multicall3?: ChainContract


### PR DESCRIPTION
See https://github.com/wagmi-dev/viem/pull/1088.

This PR enables downstream consumers of viem (ie. `op-viem`) to add their own contracts onto chains.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on amending the `Chain` type to allow arbitrary `contracts` that can be dependent on the chain.

### Detailed summary
- Amended `Chain` type to allow arbitrary `contracts` (as well as contracts that could be dependent on chain).

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->