### PR TITLE
tests: remove interval mining

### DIFF
--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,11 +2,12 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
+import { setAutomine } from '../actions/test/setAutomine.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber } from './utils.js'
+import { setBlockNumber, testClient } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -29,7 +30,10 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await setBlockNumber(forkBlockNumber)
+  await Promise.all([
+    setBlockNumber(forkBlockNumber),
+    setAutomine(testClient, false),
+  ])
 })
 
 afterEach((context) => {

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,13 +2,11 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
-import { setAutomine } from '../actions/test/setAutomine.js'
-import { setIntervalMining } from '../actions/test/setIntervalMining.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber, testClient } from './utils.js'
+import { setBlockNumber } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -31,11 +29,7 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await Promise.all([
-    setBlockNumber(forkBlockNumber),
-    setAutomine(testClient, false),
-    setIntervalMining(testClient, { interval: 1 }),
-  ])
+  await setBlockNumber(forkBlockNumber)
 })
 
 afterEach((context) => {

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -6,8 +6,11 @@ import { getBlock } from '../public/getBlock.js'
 
 import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
+import { setIntervalMining } from './setIntervalMining.js'
 
 test('removes block timestamp interval', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   let interval = 86400
   await expect(
     setBlockTimestampInterval(testClient, { interval }),

--- a/src/actions/test/setNextBlockTimestamp.test.ts
+++ b/src/actions/test/setNextBlockTimestamp.test.ts
@@ -1,13 +1,15 @@
 import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setNextBlockTimestamp } from './setNextBlockTimestamp.js'
 
 test('sets block timestamp interval', async () => {
+  await mine(testClient, { blocks: 1 })
+
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
@@ -16,7 +18,9 @@ test('sets block timestamp interval', async () => {
       timestamp: block1.timestamp + 86400n,
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)
 })

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -6,6 +6,8 @@ import { localWsUrl } from '../../_test/constants.js'
 import { localhost } from '../../chains/index.js'
 import { wait } from '../../utils/wait.js'
 
+import { testClient } from '../../_test/utils.js'
+import { setIntervalMining } from '../../test.js'
 import { type WebSocketTransport, webSocket } from './webSocket.js'
 
 test('default', () => {
@@ -141,6 +143,8 @@ test('errors: rpc error', async () => {
 })
 
 test('subscribe', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   const transport = webSocket(localWsUrl, {
     key: 'jsonRpc',
     name: 'JSON RPC',


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added `setIntervalMining` import in multiple test files.
- Added `await setIntervalMining(testClient, { interval: 1 })` in `removeBlockTimestampInterval.test.ts`, `webSocket.test.ts`, and `setNextBlockTimestamp.test.ts`.
- Added `await mine(testClient, { blocks: 1 })` in `setNextBlockTimestamp.test.ts`.
- Removed `import { setIntervalMining } from '../actions/test/setIntervalMining.js'` in `setup.ts`.
- Removed `import { wait } from '../../utils/wait.js'` in `setNextBlockTimestamp.test.ts`.
- Added `import { mine } from './mine.js'` in `setNextBlockTimestamp.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->