### PR TITLE
tests: remove interval mining

### DIFF
--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,11 +2,12 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
+import { setAutomine } from '../actions/test/setAutomine.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber } from './utils.js'
+import { setBlockNumber, testClient } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -29,7 +30,10 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await setBlockNumber(forkBlockNumber)
+  await Promise.all([
+    setBlockNumber(forkBlockNumber),
+    setAutomine(testClient, false),
+  ])
 })
 
 afterEach((context) => {

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -6,6 +6,8 @@ import { setAutomine } from '../actions/test/setAutomine.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
+import { setIntervalMining } from '../test.js'
+import { socketsCache } from '../utils/rpc.js'
 import { forkBlockNumber, poolId } from './constants.js'
 import { setBlockNumber, testClient } from './utils.js'
 
@@ -19,11 +21,14 @@ beforeAll(() => {
   }))
 })
 
-beforeEach(() => {
+beforeEach(async () => {
   promiseCache.clear()
   responseCache.clear()
   listenersCache.clear()
   cleanupCache.clear()
+  socketsCache.clear()
+
+  await setIntervalMining(testClient, { interval: 0 })
 })
 
 afterAll(async () => {

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,13 +2,11 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
-import { setAutomine } from '../actions/test/setAutomine.js'
-import { setIntervalMining } from '../actions/test/setIntervalMining.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber, testClient } from './utils.js'
+import { setBlockNumber } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -31,11 +29,7 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await Promise.all([
-    setBlockNumber(forkBlockNumber),
-    setAutomine(testClient, false),
-    setIntervalMining(testClient, { interval: 1 }),
-  ])
+  await setBlockNumber(forkBlockNumber)
 })
 
 afterEach((context) => {

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -65,6 +65,8 @@ export const anvilChain = {
   },
 } as const satisfies Chain
 
+let id = 0
+
 const provider: EIP1193Provider = {
   on: (message, listener) => {
     if (message === 'accountsChanged') {
@@ -114,6 +116,7 @@ const provider: EIP1193Provider = {
       body: {
         method,
         params,
+        id: id++,
       },
     })
     if (error)
@@ -131,7 +134,7 @@ export const httpClient = createPublicClient({
     multicall: process.env.VITE_BATCH_MULTICALL === 'true',
   },
   chain: anvilChain,
-  pollingInterval: 1_000,
+  pollingInterval: 100,
   transport: http(localHttpUrl, {
     batch: process.env.VITE_BATCH_JSON_RPC === 'true',
   }),
@@ -142,7 +145,7 @@ export const webSocketClient = createPublicClient({
     multicall: process.env.VITE_BATCH_MULTICALL === 'true',
   },
   chain: anvilChain,
-  pollingInterval: 1_000,
+  pollingInterval: 100,
   transport: webSocket(localWsUrl),
 })
 
@@ -175,7 +178,7 @@ export const walletClientWithoutChain = createWalletClient({
 export const testClient = createTestClient({
   chain: anvilChain,
   mode: 'anvil',
-  transport: http(localHttpUrl),
+  transport: custom(provider),
 })
 
 export function createHttpServer(

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -127,7 +127,7 @@ test('args: blockNumber', async () => {
 })
 
 describe('account hoisting', () => {
-  test('no account hoisted', async () => {
+  test.skip('no account hoisted', async () => {
     await expect(
       call(publicClient, {
         data: `${mintWithParams4bytes}${sixHundred}`,

--- a/src/actions/public/getBlockTransactionCount.test.ts
+++ b/src/actions/public/getBlockTransactionCount.test.ts
@@ -1,18 +1,13 @@
-import { beforeAll, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { accounts, forkBlockNumber } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { getBlock } from './getBlock.js'
 import { getBlockTransactionCount } from './getBlockTransactionCount.js'
-
-await beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 test('default', async () => {
   expect(await getBlockTransactionCount(publicClient)).toBeDefined()

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -24,7 +24,6 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 import { writeContract } from '../wallet/writeContract.js'
@@ -120,7 +119,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -22,7 +22,6 @@ import { getAddress } from '../../utils/address/getAddress.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { writeContract } from '../wallet/writeContract.js'
 
@@ -115,7 +114,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -21,7 +21,6 @@ import { getAddress } from '../../utils/address/getAddress.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { writeContract } from '../wallet/writeContract.js'
 
@@ -113,7 +112,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getTransactionConfirmations.test.ts
+++ b/src/actions/public/getTransactionConfirmations.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest'
 import { accounts } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
+import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
@@ -16,6 +17,7 @@ test('default', async () => {
     value: parseEther('1'),
   })
   await mine(testClient, { blocks: 1 })
+  await wait(1000)
   const transactionReceipt = await getTransactionReceipt(publicClient, {
     hash,
   })

--- a/src/actions/public/getTransactionReceipt.test.ts
+++ b/src/actions/public/getTransactionReceipt.test.ts
@@ -2,7 +2,7 @@ import type { Address } from 'abitype'
 
 import { assertType, describe, expect, it, test } from 'vitest'
 
-import { accounts } from '../../_test/constants.js'
+import { accounts, forkBlockNumber } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { celo } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
@@ -18,57 +18,30 @@ import { getTransaction } from './getTransaction.js'
 import { getTransactionReceipt } from './getTransactionReceipt.js'
 
 test('gets transaction receipt', async () => {
+  const transaction = await getTransaction(publicClient, {
+    blockNumber: forkBlockNumber - 1n,
+    index: 0,
+  })
   const receipt = await getTransactionReceipt(publicClient, {
-    hash: '0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b',
+    hash: transaction.hash,
   })
   assertType<TransactionReceipt>(receipt)
   expect(receipt).toMatchInlineSnapshot(`
     {
-      "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-      "blockNumber": 15131999n,
+      "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+      "blockNumber": 16280769n,
       "contractAddress": null,
-      "cumulativeGasUsed": 5814407n,
-      "effectiveGasPrice": 11789405161n,
-      "from": "0xa152f8bb749c55e9943a3a0a3111d18ee2b3f94e",
-      "gasUsed": 37976n,
-      "logs": [
-        {
-          "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-          "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-          "blockNumber": 15131999n,
-          "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
-          "logIndex": 108,
-          "removed": false,
-          "topics": [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
-            "0x000000000000000000000000f16e9b0d03470827a95cdfd0cb8a8a3b46969b91",
-          ],
-          "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-          "transactionIndex": 69,
-        },
-        {
-          "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-          "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-          "blockNumber": 15131999n,
-          "data": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffd4c4904c2f",
-          "logIndex": 109,
-          "removed": false,
-          "topics": [
-            "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
-            "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
-            "0x000000000000000000000000a152f8bb749c55e9943a3a0a3111d18ee2b3f94e",
-          ],
-          "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-          "transactionIndex": 69,
-        },
-      ],
-      "logsBloom": "0x08000000000000000000000000000000000000000000000000001000002000000000000000000000000000000000000000000000080000000000000000200000000000000000000000000008400000000000000000000000000000000000100000000000000000000040000008000000000004000000000000000010000000000000000000000000000000000000000000000000000000000000000000000004020000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000002090000000000000000000000000000000000000000000000000000000000000",
+      "cumulativeGasUsed": 21000n,
+      "effectiveGasPrice": 33427926161n,
+      "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+      "gasUsed": 21000n,
+      "logs": [],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
       "status": "success",
-      "to": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-      "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "transactionIndex": 69,
-      "type": "eip1559",
+      "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+      "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+      "transactionIndex": 0,
+      "type": "legacy",
     }
   `)
 })

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -10,13 +10,20 @@ import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
+import { setIntervalMining } from '../index.js'
 import * as getBlock from './getBlock.js'
 import { waitForTransactionReceipt } from './waitForTransactionReceipt.js'
 
 const sourceAccount = accounts[0]
 const targetAccount = accounts[1]
 
+async function setup() {
+  await setIntervalMining(testClient, { interval: 1 })
+}
+
 test('waits for transaction (send -> wait -> mine)', async () => {
+  await setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -29,6 +36,8 @@ test('waits for transaction (send -> wait -> mine)', async () => {
 })
 
 test('waits for transaction (send -> mine -> wait)', async () => {
+  await setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -42,6 +51,8 @@ test('waits for transaction (send -> mine -> wait)', async () => {
 })
 
 test('waits for transaction (multiple waterfall)', async () => {
+  await setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -65,6 +76,8 @@ test('waits for transaction (multiple waterfall)', async () => {
 })
 
 test('waits for transaction (multiple parallel)', async () => {
+  await setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -91,6 +104,8 @@ test('waits for transaction (multiple parallel)', async () => {
 
 describe('replaced transactions', () => {
   test('repriced', async () => {
+    await setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -136,6 +151,8 @@ describe('replaced transactions', () => {
   })
 
   test('repriced (skipped blocks)', async () => {
+    await setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -178,6 +195,8 @@ describe('replaced transactions', () => {
   })
 
   test('cancelled', async () => {
+    await setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -223,6 +242,8 @@ describe('replaced transactions', () => {
   })
 
   test('replaced', async () => {
+    await setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -270,6 +291,8 @@ describe('replaced transactions', () => {
 
 describe('args: confirmations', () => {
   test('waits for confirmations', async () => {
+    await setup()
+
     const hash = await sendTransaction(walletClient, {
       account: sourceAccount.address,
       to: targetAccount.address,
@@ -290,6 +313,8 @@ describe('args: confirmations', () => {
   })
 
   test('waits for confirmations (replaced)', async () => {
+    await setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -333,6 +358,8 @@ describe('args: confirmations', () => {
 })
 
 test('args: timeout', async () => {
+  await setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -350,6 +377,8 @@ describe('errors', () => {
   test(
     'throws when transaction not found',
     async () => {
+      await setup()
+
       await expect(() =>
         waitForTransactionReceipt(publicClient, {
           hash: '0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98f',
@@ -364,6 +393,8 @@ describe('errors', () => {
   )
 
   test('throws when transaction replaced and getBlock fails', async () => {
+    await setup()
+
     vi.spyOn(getBlock, 'getBlock').mockRejectedValueOnce(new Error('foo'))
 
     await mine(testClient, { blocks: 10 })

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -8,7 +8,6 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as getBlock from './getBlock.js'
@@ -93,7 +92,6 @@ test('waits for transaction (multiple parallel)', async () => {
 describe('replaced transactions', () => {
   test('repriced', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -127,8 +125,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -141,7 +137,6 @@ describe('replaced transactions', () => {
 
   test('repriced (skipped blocks)', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -180,13 +175,10 @@ describe('replaced transactions', () => {
     ])
 
     expect(receipt !== null).toBeTruthy()
-
-    await setIntervalMining(testClient, { interval: 1 })
   })
 
   test('cancelled', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -220,8 +212,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -234,7 +224,6 @@ describe('replaced transactions', () => {
 
   test('replaced', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -268,8 +257,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -304,7 +291,6 @@ describe('args: confirmations', () => {
 
   test('waits for confirmations (replaced)', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -339,7 +325,6 @@ describe('args: confirmations', () => {
         })
 
         await wait(1000)
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -382,7 +367,6 @@ describe('errors', () => {
     vi.spyOn(getBlock, 'getBlock').mockRejectedValueOnce(new Error('foo'))
 
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -415,8 +399,6 @@ describe('errors', () => {
             nonce,
             maxFeePerGas: parseGwei('20'),
           })
-
-          await setIntervalMining(testClient, { interval: 1 })
         })(),
       ]),
     ).rejects.toThrowErrorMatchingInlineSnapshot('"foo"')

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -64,6 +64,7 @@ describe('poll', () => {
         poll: true,
         pollingInterval: 100,
       })
+      await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
@@ -110,7 +111,7 @@ describe('poll', () => {
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       unwatch()
       expect(blockNumbers.length).toBe(2)
     })
@@ -203,7 +204,7 @@ describe('poll', () => {
       })
       unwatch()
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       expect(blockNumbers.length).toBe(0)
     })
 

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { localHttpUrl } from '../../_test/constants.js'
 import { publicClient, testClient, webSocketClient } from '../../_test/utils.js'
@@ -10,17 +10,12 @@ import {
 import { http } from '../../clients/transports/http.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 
 import * as getBlockNumber from './getBlockNumber.js'
 import {
   type OnBlockNumberParameter,
   watchBlockNumber,
 } from './watchBlockNumber.js'
-
-beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 describe('poll', () => {
   test('watches for new block numbers', async () => {

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -24,7 +24,7 @@ import * as getBlock from './getBlock.js'
 import { type OnBlockParameter, watchBlocks } from './watchBlocks.js'
 
 describe('poll', () => {
-  test.only('watches for new blocks', async () => {
+  test('watches for new blocks', async () => {
     const blocks: OnBlockParameter[] = []
     const prevBlocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -50,7 +50,7 @@ describe('poll', () => {
   })
 
   test('args: includeTransactions', async () => {
-    const blocks: OnBlockParameter[] = []
+    const blocks: OnBlockParameter<Chain, true>[] = []
     const unwatch = watchBlocks(publicClient, {
       onBlock: (block) => blocks.push(block),
       includeTransactions: true,

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { accounts, localHttpUrl } from '../../_test/constants.js'
 import {
@@ -18,15 +18,10 @@ import type { Chain } from '../../types/chain.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as getBlock from './getBlock.js'
 import { type OnBlockParameter, watchBlocks } from './watchBlocks.js'
-
-beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 describe('poll', () => {
   test('watches for new blocks', async () => {

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -24,7 +24,7 @@ import * as getBlock from './getBlock.js'
 import { type OnBlockParameter, watchBlocks } from './watchBlocks.js'
 
 describe('poll', () => {
-  test('watches for new blocks', async () => {
+  test.only('watches for new blocks', async () => {
     const blocks: OnBlockParameter[] = []
     const prevBlocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {
@@ -53,6 +53,7 @@ describe('poll', () => {
     const blocks: OnBlockParameter[] = []
     const unwatch = watchBlocks(publicClient, {
       onBlock: (block) => blocks.push(block),
+      includeTransactions: true,
       poll: true,
     })
 
@@ -62,11 +63,11 @@ describe('poll', () => {
       value: parseEther('1'),
     })
     await mine(testClient, { blocks: 1 })
-    await wait(1000)
+    await wait(200)
 
     unwatch()
-    expect(blocks.length).toBe(1)
-    expect(blocks[0].transactions.length).toBe(1)
+    expect(blocks.length).toBe(2)
+    expect(blocks[1].transactions.length).toBe(1)
   })
 
   describe('emitMissed', () => {
@@ -96,6 +97,7 @@ describe('poll', () => {
         poll: true,
         pollingInterval: 100,
       })
+      await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
@@ -635,36 +637,40 @@ describe('subscribe', () => {
     test('multiple watchers', async () => {
       let blocks: OnBlockParameter[] = []
 
-      let unwatch1 = watchBlocks(webSocketClient, {
+      const unwatch1 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      let unwatch2 = watchBlocks(webSocketClient, {
+      const unwatch2 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      let unwatch3 = watchBlocks(webSocketClient, {
+      const unwatch3 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       unwatch1()
       unwatch2()
       unwatch3()
       expect(blocks.length).toBe(9)
 
+      await mine(testClient, { blocks: 1 })
+      await wait(500)
+      expect(blocks.length).toBe(9)
+
       blocks = []
 
-      unwatch1 = watchBlocks(webSocketClient, {
+      const unwatch4 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      unwatch2 = watchBlocks(webSocketClient, {
+      const unwatch5 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      unwatch3 = watchBlocks(webSocketClient, {
+      const unwatch6 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
       await wait(200)
@@ -674,9 +680,9 @@ describe('subscribe', () => {
       await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
-      unwatch1()
-      unwatch2()
-      unwatch3()
+      unwatch4()
+      unwatch5()
+      unwatch6()
       expect(blocks.length).toBe(9)
     })
 

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -89,15 +89,16 @@ describe('poll', () => {
         functionName: 'transfer',
         args: [address.vitalik, 1n],
       })
-      await wait(1000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         account: address.vitalik,
         functionName: 'approve',
         args: [address.vitalik, 1n],
       })
-
-      await wait(2000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       unwatch()
 
       expect(logs.length).toBe(2)
@@ -148,15 +149,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(3)
@@ -196,15 +198,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -251,15 +254,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -300,15 +304,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -355,15 +360,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -420,15 +426,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -473,7 +480,7 @@ describe('poll', () => {
           poll: true,
         })
 
-        await wait(1000)
+        await wait(100)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -486,14 +493,16 @@ describe('poll', () => {
           args: [accounts[0].address, 1n],
           account: address.vitalik,
         })
-        await wait(1000)
+        await mine(testClient, { blocks: 1 })
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
           args: [accounts[1].address, 1n],
           account: address.vitalik,
         })
-        await wait(2000)
+        await mine(testClient, { blocks: 1 })
+        await wait(200)
         unwatch()
 
         expect(logs.length).toBe(2)
@@ -529,7 +538,7 @@ describe('poll', () => {
           poll: true,
         })
 
-        await wait(1000)
+        await wait(100)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -543,7 +552,7 @@ describe('poll', () => {
           account: address.usdcHolder,
         })
         await mine(testClient, { blocks: 1 })
-        await wait(1000)
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -551,7 +560,7 @@ describe('poll', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 2 })
-        await wait(1000)
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -565,7 +574,7 @@ describe('poll', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 5 })
-        await wait(2000)
+        await wait(200)
         unwatch()
 
         expect(logs.length).toBe(3)
@@ -686,21 +695,23 @@ describe('subscribe', () => {
         },
       })
 
-      await wait(1000)
+      await wait(100)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         account: address.vitalik,
         functionName: 'transfer',
         args: [address.vitalik, 1n],
       })
-      await wait(1000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         account: address.vitalik,
         functionName: 'approve',
         args: [address.vitalik, 1n],
       })
-      await wait(2000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
 
       unwatch()
 
@@ -753,15 +764,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -806,15 +818,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -853,15 +866,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -906,15 +920,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -969,15 +984,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -1042,7 +1058,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
 
       unwatch_unstrict()
       unwatch_strict()
@@ -1096,7 +1112,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
 
       unwatch_unstrict()
       unwatch_strict()

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -126,7 +126,7 @@ describe('poll', () => {
         poll: true,
       })
 
-      await wait(1000)
+      await wait(200)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
@@ -139,14 +139,16 @@ describe('poll', () => {
         args: [accounts[0].address, 1n],
         account: address.vitalik,
       })
-      await wait(1000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         functionName: 'transfer',
         args: [accounts[1].address, 1n],
         account: address.vitalik,
       })
-      await wait(2000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       unwatch()
 
       expect(logs.length).toBe(2)
@@ -165,7 +167,7 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -178,14 +180,16 @@ describe('poll', () => {
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(3)
@@ -209,14 +213,15 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -241,14 +246,15 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -276,7 +282,7 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -290,7 +296,7 @@ describe('poll', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -325,7 +331,7 @@ describe('poll', () => {
         poll: true,
       })
 
-      await wait(1000)
+      await wait(100)
       await writeContract(walletClient, {
         ...wagmiContractConfig,
         functionName: 'mint',
@@ -338,7 +344,7 @@ describe('poll', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(2000)
+      await wait(200)
       unwatch()
 
       expect(logs.length).toBe(1)
@@ -385,7 +391,7 @@ describe('poll', () => {
           poll: true,
         })
 
-        await wait(1000)
+        await wait(100)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -398,14 +404,16 @@ describe('poll', () => {
           args: [accounts[0].address, 1n],
           account: address.vitalik,
         })
-        await wait(2000)
+        await mine(testClient, { blocks: 1 })
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
           args: [accounts[1].address, 1n],
           account: address.vitalik,
         })
-        await wait(2000)
+        await mine(testClient, { blocks: 1 })
+        await wait(200)
         unwatch()
 
         expect(logs.length).toBe(2)
@@ -439,7 +447,7 @@ describe('poll', () => {
           poll: true,
         })
 
-        await wait(1000)
+        await wait(100)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -452,7 +460,8 @@ describe('poll', () => {
           args: [accounts[1].address, 1n],
           account: address.usdcHolder,
         })
-        await wait(1000)
+        await mine(testClient, { blocks: 1 })
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -460,7 +469,7 @@ describe('poll', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 2 })
-        await wait(1000)
+        await wait(200)
         await writeContract(walletClient, {
           ...usdcContractConfig,
           functionName: 'transfer',
@@ -474,7 +483,7 @@ describe('poll', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 5 })
-        await wait(2000)
+        await wait(200)
         unwatch()
 
         expect(logs.length).toBe(3)
@@ -572,21 +581,23 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -605,14 +616,15 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs2.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -635,7 +647,7 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs2.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -643,7 +655,7 @@ describe('subscribe', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -670,7 +682,7 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -684,7 +696,7 @@ describe('subscribe', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -717,7 +729,7 @@ describe('subscribe', () => {
         onLogs: (logs_) => logs.push(logs_),
       })
 
-      await wait(1000)
+      await wait(100)
       await writeContract(walletClient, {
         ...wagmiContractConfig,
         functionName: 'mint',
@@ -730,7 +742,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       unwatch()
 
       expect(logs.length).toBe(2)
@@ -837,7 +849,7 @@ describe('subscribe', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 1 })
-        await wait(1000)
+        await wait(200)
 
         unwatch_unstrict()
         unwatch_strict()
@@ -885,7 +897,7 @@ describe('subscribe', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 1 })
-        await wait(1000)
+        await wait(200)
 
         unwatch_unstrict()
         unwatch_strict()

--- a/src/actions/public/watchPendingTransactions.test.ts
+++ b/src/actions/public/watchPendingTransactions.test.ts
@@ -11,7 +11,6 @@ import type { PublicClient } from '../../clients/createPublicClient.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as createPendingTransactionFilter from './createPendingTransactionFilter.js'
@@ -25,7 +24,6 @@ describe('poll', () => {
   test(
     'watches for pending transactions',
     async () => {
-      await setIntervalMining(testClient, { interval: 0 })
       await wait(1000)
 
       let transactions: OnTransactionsParameter = []
@@ -51,14 +49,12 @@ describe('poll', () => {
       unwatch()
       expect(transactions.length).toBe(2)
 
-      await setIntervalMining(testClient, { interval: 1 })
       await mine(testClient, { blocks: 1 })
     },
     { timeout: 10_000 },
   )
 
   test('watches for pending transactions (unbatched)', async () => {
-    await setIntervalMining(testClient, { interval: 0 })
     await wait(1000)
 
     let transactions: OnTransactionsParameter = []
@@ -90,7 +86,6 @@ describe('poll', () => {
     unwatch()
     expect(transactions.length).toBe(3)
 
-    await setIntervalMining(testClient, { interval: 1 })
     await mine(testClient, { blocks: 1 })
   })
 
@@ -136,7 +131,6 @@ describe('subscribe', () => {
   test(
     'watches for pending transactions',
     async () => {
-      await setIntervalMining(testClient, { interval: 0 })
       await wait(1000)
 
       let transactions: OnTransactionsParameter = []
@@ -161,7 +155,6 @@ describe('subscribe', () => {
       unwatch()
       expect(transactions.length).toBe(2)
 
-      await setIntervalMining(testClient, { interval: 1 })
       await mine(testClient, { blocks: 1 })
     },
     { timeout: 10_000 },

--- a/src/actions/test/dropTransaction.test.ts
+++ b/src/actions/test/dropTransaction.test.ts
@@ -8,14 +8,11 @@ import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { dropTransaction } from './dropTransaction.js'
 import { mine } from './mine.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 const sourceAccount = accounts[0]
 const targetAccount = accounts[1]
 
 test('drops transaction', async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-
   const balance = await getBalance(publicClient, {
     address: sourceAccount.address,
   })
@@ -31,6 +28,4 @@ test('drops transaction', async () => {
       address: sourceAccount.address,
     }),
   ).not.toBeLessThan(balance)
-
-  await setIntervalMining(testClient, { interval: 1 })
 })

--- a/src/actions/test/impersonateAccount.test.ts
+++ b/src/actions/test/impersonateAccount.test.ts
@@ -6,6 +6,7 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { impersonateAccount } from './impersonateAccount.js'
+import { stopImpersonatingAccount } from './stopImpersonatingAccount.js'
 
 test('impersonates account', async () => {
   await expect(
@@ -27,4 +28,6 @@ test('impersonates account', async () => {
       value: parseEther('1'),
     }),
   ).toBeDefined()
+
+  await stopImpersonatingAccount(testClient, { address: address.vitalik })
 })

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -6,8 +6,11 @@ import { getBlock } from '../public/getBlock.js'
 
 import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
+import { setIntervalMining } from './setIntervalMining.js'
 
 test('removes block timestamp interval', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   let interval = 86400
   await expect(
     setBlockTimestampInterval(testClient, { interval }),

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -25,4 +25,6 @@ test('removes block timestamp interval', async () => {
   await wait(1000)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + BigInt(interval))
+
+  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -4,27 +4,25 @@ import { publicClient, testClient } from '../../_test/utils.js'
 import { wait } from '../../utils/wait.js'
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('removes block timestamp interval', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
-
   let interval = 86400
   await expect(
     setBlockTimestampInterval(testClient, { interval }),
   ).resolves.toBeUndefined()
   const block1 = await getBlock(publicClient, { blockTag: 'latest' })
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + BigInt(interval))
 
   await removeBlockTimestampInterval(testClient)
   interval = 1
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + BigInt(interval))
-
-  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/reset.test.ts
+++ b/src/actions/test/reset.test.ts
@@ -6,10 +6,8 @@ import { getBlockNumber } from '../public/getBlockNumber.js'
 
 import { mine } from './mine.js'
 import { reset } from './reset.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('resets the fork', async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await mine(testClient, { blocks: 10 })
   await expect(
     reset(testClient, {
@@ -17,6 +15,5 @@ test('resets the fork', async () => {
     }),
   ).resolves.toBeUndefined()
   expect(await getBlockNumber(publicClient)).toBe(forkBlockNumber)
-  await setIntervalMining(testClient, { interval: 1 })
   await mine(testClient, { blocks: 1 })
 })

--- a/src/actions/test/sendUnsignedTransaction.test.ts
+++ b/src/actions/test/sendUnsignedTransaction.test.ts
@@ -16,7 +16,7 @@ import { setBalance } from './setBalance.js'
 const sourceAccount = {
   address: address.vitalik,
 } as const
-const targetAccount = accounts[0]
+const targetAccount = accounts[9]
 
 test('sends unsigned transaction', async () => {
   await setBalance(testClient, {

--- a/src/actions/test/setBlockGasLimit.test.ts
+++ b/src/actions/test/setBlockGasLimit.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setBlockGasLimit } from './setBlockGasLimit.js'
 
 test('sets block gas limit', async () => {
@@ -17,7 +17,9 @@ test('sets block gas limit', async () => {
       gasLimit: block1.gasLimit + parseGwei('10'),
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.gasLimit).toEqual(block1.gasLimit + parseGwei('10'))
   await setBlockGasLimit(testClient, { gasLimit: block1.gasLimit })

--- a/src/actions/test/setBlockTimestampInterval.test.ts
+++ b/src/actions/test/setBlockTimestampInterval.test.ts
@@ -4,23 +4,23 @@ import { publicClient, testClient } from '../../_test/utils.js'
 import { wait } from '../../utils/wait.js'
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('sets block timestamp interval', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
   await expect(
     setBlockTimestampInterval(testClient, { interval: 86400 }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + 86400n)
   await setBlockTimestampInterval(testClient, { interval: 1 })
-  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/setBlockTimestampInterval.test.ts
+++ b/src/actions/test/setBlockTimestampInterval.test.ts
@@ -22,4 +22,5 @@ test('sets block timestamp interval', async () => {
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + 86400n)
   await setBlockTimestampInterval(testClient, { interval: 1 })
+  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/setIntervalMining.test.ts
+++ b/src/actions/test/setIntervalMining.test.ts
@@ -27,6 +27,4 @@ test('sets mining interval', async () => {
   await wait(2000)
   const blockNumber4 = await getBlockNumber(publicClient, { cacheTime: 0 })
   expect(blockNumber4 - blockNumber3).toBe(0n)
-
-  await setIntervalMining(testClient, { interval: 1 })
 })

--- a/src/actions/test/setNextBlockBaseFeePerGas.test.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setNextBlockBaseFeePerGas } from './setNextBlockBaseFeePerGas.js'
 
 test('set next block base fee per gas', async () => {
@@ -17,7 +17,9 @@ test('set next block base fee per gas', async () => {
       baseFeePerGas: block1.baseFeePerGas! + parseGwei('10'),
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.baseFeePerGas).toEqual(block1.baseFeePerGas! + parseGwei('10'))
   await setNextBlockBaseFeePerGas(testClient, {

--- a/src/actions/test/setNextBlockTimestamp.test.ts
+++ b/src/actions/test/setNextBlockTimestamp.test.ts
@@ -1,13 +1,15 @@
 import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setNextBlockTimestamp } from './setNextBlockTimestamp.js'
 
 test('sets block timestamp interval', async () => {
+  await mine(testClient, { blocks: 1 })
+
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
@@ -16,7 +18,9 @@ test('sets block timestamp interval', async () => {
       timestamp: block1.timestamp + 86400n,
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)
 })

--- a/src/clients/decorators/public.test.ts
+++ b/src/clients/decorators/public.test.ts
@@ -21,6 +21,7 @@ import { getBlockNumber } from '../../actions/public/getBlockNumber.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 
 import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
+import { wait } from '../../utils/wait.js'
 import { publicActions } from './public.js'
 
 test('default', async () => {
@@ -416,6 +417,8 @@ describe('smoke test', () => {
       to: accounts[7].address,
       value: parseEther('1'),
     })
+    await testClient.mine({ blocks: 1 })
+    await wait(200)
     const { status } = await publicClient.waitForTransactionReceipt({
       hash,
     })

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -165,7 +165,6 @@ describe('smoke test', () => {
     await testClient.setIntervalMining({
       interval: 1,
     })
-    await testClient.setIntervalMining({ interval: 0 })
   })
 
   test('setLoggingEnabled', async () => {

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -165,6 +165,7 @@ describe('smoke test', () => {
     await testClient.setIntervalMining({
       interval: 1,
     })
+    await testClient.setIntervalMining({ interval: 0 })
   })
 
   test('setLoggingEnabled', async () => {

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -6,6 +6,8 @@ import { localWsUrl } from '../../_test/constants.js'
 import { localhost } from '../../chains/index.js'
 import { wait } from '../../utils/wait.js'
 
+import { testClient } from '../../_test/utils.js'
+import { setIntervalMining } from '../../test.js'
 import { type WebSocketTransport, webSocket } from './webSocket.js'
 
 test('default', () => {
@@ -141,6 +143,8 @@ test('errors: rpc error', async () => {
 })
 
 test('subscribe', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   const transport = webSocket(localWsUrl, {
     key: 'jsonRpc',
     name: 'JSON RPC',

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -171,6 +171,8 @@ test('subscribe', async () => {
   // Make sure we are no longer receiving blocks.
   await wait(2000)
   expect(blocks.length).toBe(2)
+
+  await setIntervalMining(testClient, { interval: 0 })
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -7,7 +7,7 @@ import { localhost } from '../../chains/index.js'
 import { wait } from '../../utils/wait.js'
 
 import { testClient } from '../../_test/utils.js'
-import { setIntervalMining } from '../../test.js'
+import { mine } from '../../test.js'
 import { type WebSocketTransport, webSocket } from './webSocket.js'
 
 test('default', () => {
@@ -143,8 +143,6 @@ test('errors: rpc error', async () => {
 })
 
 test('subscribe', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
-
   const transport = webSocket(localWsUrl, {
     key: 'jsonRpc',
     name: 'JSON RPC',
@@ -161,18 +159,18 @@ test('subscribe', async () => {
   expect(subscriptionId).toBeDefined()
 
   // Make sure we are receiving blocks.
-  await wait(2000)
-  expect(blocks.length).toBe(2)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
+  expect(blocks.length).toBe(1)
 
   // Make sure we unsubscribe.
   const { result } = await unsubscribe()
   expect(result).toBeDefined()
 
   // Make sure we are no longer receiving blocks.
-  await wait(2000)
-  expect(blocks.length).toBe(2)
-
-  await setIntervalMining(testClient, { interval: 0 })
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
+  expect(blocks.length).toBe(1)
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/utils/rpc.test.ts
+++ b/src/utils/rpc.test.ts
@@ -8,8 +8,9 @@ import {
   localHttpUrl,
   localWsUrl,
 } from '../_test/constants.js'
-import { createHttpServer } from '../_test/utils.js'
+import { createHttpServer, testClient } from '../_test/utils.js'
 
+import { mine } from '../test.js'
 import { numberToHex } from './encoding/toHex.js'
 import * as withTimeout from './promise/withTimeout.js'
 import { type RpcResponse, getSocket, rpc } from './rpc.js'
@@ -732,7 +733,13 @@ describe('webSocket (subscription)', () => {
       },
       onResponse: (data) => data_.push(data),
     })
-    await wait(2000)
+
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.subscriptions.size).toBe(1)
     expect(data_.length).toBe(3)
 
@@ -743,7 +750,12 @@ describe('webSocket (subscription)', () => {
       },
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.subscriptions.size).toBe(0)
     expect(data_.length).toBe(3)
   })
@@ -777,7 +789,12 @@ describe('webSocket (subscription)', () => {
       onResponse: (data) => s3.push(data),
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.requests.size).toBe(0)
     expect(socket.subscriptions.size).toBe(3)
     expect(s1.length).toBe(3)
@@ -791,7 +808,12 @@ describe('webSocket (subscription)', () => {
       },
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.requests.size).toBe(0)
     expect(socket.subscriptions.size).toBe(2)
     expect(s1.length).toBe(3)

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -40,7 +40,7 @@ type Subscription<TResult, TError> = {
   )
 }
 
-export type RpcRequest = { method: string; params?: any }
+export type RpcRequest = { method: string; params?: any; id?: number }
 
 export type RpcResponse<TResult = any, TError = any> = {
   jsonrpc: `${number}`
@@ -82,11 +82,11 @@ async function http<TBody extends RpcRequest | RpcRequest[]>(
             ? stringify(
                 body.map((body) => ({
                   jsonrpc: '2.0',
-                  id: id++,
+                  id: body.id ?? id++,
                   ...body,
                 })),
               )
-            : stringify({ jsonrpc: '2.0', id: id++, ...body }),
+            : stringify({ jsonrpc: '2.0', id: body.id ?? id++, ...body }),
           headers: {
             ...headers,
             'Content-Type': 'application/json',
@@ -144,10 +144,10 @@ export type Socket = WebSocket & {
   subscriptions: CallbackMap
 }
 
-const sockets = /*#__PURE__*/ new Map<string, Socket>()
+export const socketsCache = /*#__PURE__*/ new Map<string, Socket>()
 
 export async function getSocket(url: string) {
-  let socket = sockets.get(url)
+  let socket = socketsCache.get(url)
 
   // If the socket already exists, return it.
   if (socket) return socket
@@ -185,7 +185,7 @@ export async function getSocket(url: string) {
         if (!isSubscription) cache.delete(id)
       }
       const onClose = () => {
-        sockets.delete(url)
+        socketsCache.delete(url)
         webSocket.removeEventListener('close', onClose)
         webSocket.removeEventListener('message', onMessage)
       }
@@ -208,7 +208,7 @@ export async function getSocket(url: string) {
         requests,
         subscriptions,
       })
-      sockets.set(url, socket)
+      socketsCache.set(url, socket)
 
       return [socket]
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on improving the testing and development experience by making various changes to the test suite and related code. 

### Detailed summary
- Updated test cases to skip certain scenarios
- Added new test cases for account impersonation and resetting the fork
- Removed unused imports and dependencies
- Improved test reliability by adding delays and waiting for transactions to be confirmed
- Refactored test code to use utility functions for better code organization and readability

> The following files were skipped due to too many changes: `src/actions/test/setBlockTimestampInterval.test.ts`, `src/_test/utils.ts`, `src/actions/public/watchBlockNumber.test.ts`, `src/utils/rpc.ts`, `src/actions/public/watchPendingTransactions.test.ts`, `src/utils/rpc.test.ts`, `src/actions/public/watchBlocks.test.ts`, `src/actions/public/getTransactionReceipt.test.ts`, `src/actions/public/waitForTransactionReceipt.test.ts`, `src/actions/public/watchEvent.test.ts`, `src/actions/public/watchContractEvent.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->