### PR TITLE
tests: remove interval mining; update vitest

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         cache: pnpm
-        node-version: 18
+        node-version: 20
 
     - name: Set up foundry
       uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,9 +10,6 @@ jobs:
   bench:
     name: Benchmark
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        transport-mode: ['http', 'webSocket']
 
     steps:
       - name: Clone repository
@@ -27,7 +24,6 @@ jobs:
           VITE_ANVIL_BLOCK_NUMBER: ${{ vars.VITE_ANVIL_BLOCK_NUMBER }}
           VITE_ANVIL_BLOCK_TIME: ${{ vars.VITE_ANVIL_BLOCK_TIME }}
           VITE_ANVIL_FORK_URL: ${{ secrets.VITE_ANVIL_FORK_URL }}
-          VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}
 
       - name: Report benchmarks
         run: pnpm bun ./.github/scripts/bench.ts

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -77,6 +77,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 3
       matrix:
         transport-mode: ['http', 'webSocket']
         shard: [1, 2, 3]
@@ -95,13 +96,14 @@ jobs:
       - name: Run tests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 20
+          timeout_minutes: 10
           max_attempts: 3
           command: pnpm test:ci --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
         env:
           VITE_ANVIL_BLOCK_NUMBER: ${{ vars.VITE_ANVIL_BLOCK_NUMBER }}
           VITE_ANVIL_BLOCK_TIME: ${{ vars.VITE_ANVIL_BLOCK_TIME }}
           VITE_ANVIL_FORK_URL: ${{ secrets.VITE_ANVIL_FORK_URL }}
+          VITE_BATCH_MULTICALL: ${{ matrix.multicall }}
           VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}
 
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -78,14 +78,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        transport-mode: ['http', 'webSocket']
         shard: [1, 2, 3]
         total-shards: [3]
-        transport-mode: ['http', 'webSocket']
-        include:
-          - batch-multicall: 'false'
-          - batch-multicall: 'true'
-            transport-mode: 'http'
-
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
@@ -100,14 +95,13 @@ jobs:
       - name: Run tests
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 30
+          timeout_minutes: 20
           max_attempts: 3
           command: pnpm test:ci --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
         env:
           VITE_ANVIL_BLOCK_NUMBER: ${{ vars.VITE_ANVIL_BLOCK_NUMBER }}
           VITE_ANVIL_BLOCK_TIME: ${{ vars.VITE_ANVIL_BLOCK_TIME }}
           VITE_ANVIL_FORK_URL: ${{ secrets.VITE_ANVIL_FORK_URL }}
-          VITE_BATCH_MULTICALL: ${{ matrix.batch-multicall }}
           VITE_NETWORK_TRANSPORT_MODE: ${{ matrix.transport-mode }}
 
       - name: Upload coverage reports to Codecov

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "size": "size-limit",
     "test": "vitest dev",
     "test:cov": "vitest dev --coverage",
-    "test:ci": "CI=true vitest --coverage",
+    "test:ci": "CI=true vitest --coverage --retry=3 --bail=1",
     "test:typecheck": "SKIP_GLOBAL_SETUP=true vitest typecheck",
     "test:ui": "vitest dev --ui",
     "typecheck": "tsc --noEmit"
@@ -116,39 +116,17 @@
   },
   "typesVersions": {
     "*": {
-      "abi": [
-        "./dist/types/abi.d.ts"
-      ],
-      "accounts": [
-        "./dist/types/accounts/index.d.ts"
-      ],
-      "actions": [
-        "./dist/types/actions/index.d.ts"
-      ],
-      "chains": [
-        "./dist/types/chains.d.ts"
-      ],
-      "contract": [
-        "./dist/types/contract.d.ts"
-      ],
-      "ens": [
-        "./dist/types/ens.d.ts"
-      ],
-      "public": [
-        "./dist/types/public.d.ts"
-      ],
-      "test": [
-        "./dist/types/test.d.ts"
-      ],
-      "utils": [
-        "./dist/types/utils/index.d.ts"
-      ],
-      "wallet": [
-        "./dist/types/wallet.d.ts"
-      ],
-      "window": [
-        "./dist/types/window.d.ts"
-      ]
+      "abi": ["./dist/types/abi.d.ts"],
+      "accounts": ["./dist/types/accounts/index.d.ts"],
+      "actions": ["./dist/types/actions/index.d.ts"],
+      "chains": ["./dist/types/chains.d.ts"],
+      "contract": ["./dist/types/contract.d.ts"],
+      "ens": ["./dist/types/ens.d.ts"],
+      "public": ["./dist/types/public.d.ts"],
+      "test": ["./dist/types/test.d.ts"],
+      "utils": ["./dist/types/utils/index.d.ts"],
+      "wallet": ["./dist/types/wallet.d.ts"],
+      "window": ["./dist/types/window.d.ts"]
     }
   },
   "peerDependencies": {
@@ -179,8 +157,8 @@
     "@size-limit/preset-big-lib": "^8.2.4",
     "@types/fs-extra": "^9.0.13",
     "@viem/anvil": "0.0.5",
-    "@vitest/coverage-c8": "^0.30.1",
-    "@vitest/ui": "^0.30.1",
+    "@vitest/coverage-v8": "^0.34.3",
+    "@vitest/ui": "^0.34.3",
     "@wagmi/cli": "^0.1.6",
     "bun": "^0.5.9",
     "ethers": "^5.7.2",
@@ -191,27 +169,18 @@
     "size-limit": "^8.2.4",
     "typescript": "5.0.4",
     "vite": "^4.4.2",
-    "vitest": "~0.30.1"
+    "vitest": "~0.34.3"
   },
   "license": "MIT",
   "repository": "wagmi-dev/viem",
-  "authors": [
-    "awkweb.eth",
-    "jxom.eth"
-  ],
+  "authors": ["awkweb.eth", "jxom.eth"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "eth",
-    "ethereum",
-    "dapps",
-    "wallet",
-    "web3"
-  ],
+  "keywords": ["eth", "ethereum", "dapps", "wallet", "web3"],
   "size-limit": [
     {
       "name": "viem (cjs)",
@@ -264,9 +233,7 @@
       "viem": "workspace:*"
     },
     "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search"
-      ]
+      "ignoreMissing": ["@algolia/client-search"]
     },
     "patchedDependencies": {
       "vitepress@1.0.0-beta.4": "patches/vitepress@1.0.0-beta.4.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,12 +64,12 @@ importers:
       '@viem/anvil':
         specifier: 0.0.5
         version: 0.0.5
-      '@vitest/coverage-c8':
-        specifier: ^0.30.1
-        version: 0.30.1(vitest@0.30.1)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       '@vitest/ui':
-        specifier: ^0.30.1
-        version: 0.30.1
+        specifier: ^0.34.3
+        version: 0.34.3(vitest@0.34.3)
       '@wagmi/cli':
         specifier: ^0.1.6
         version: 0.1.6(typescript@5.0.4)
@@ -99,10 +99,10 @@ importers:
         version: 5.0.4
       vite:
         specifier: ^4.4.2
-        version: 4.4.2(@types/node@18.16.3)
+        version: 4.4.2(@types/node@20.4.9)
       vitest:
-        specifier: ~0.30.1
-        version: 0.30.1(@vitest/ui@0.30.1)
+        specifier: ~0.34.3
+        version: 0.34.3(@vitest/ui@0.34.3)
 
   examples/_template:
     dependencies:
@@ -608,6 +608,14 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.14
+    dev: true
+
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.18
     dev: true
 
   /@babel/code-frame@7.18.6:
@@ -1909,6 +1917,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jridgewell/gen-mapping@0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -2201,6 +2216,10 @@ packages:
       '@scure/base': 1.1.1
     dev: false
 
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
   /@sitespeed.io/tracium@0.3.3:
     resolution: {integrity: sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==}
     engines: {node: '>=8'}
@@ -2335,10 +2354,6 @@ packages:
     resolution: {integrity: sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==}
     dev: true
 
-  /@types/node@18.16.3:
-    resolution: {integrity: sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==}
-    dev: true
-
   /@types/node@20.4.9:
     resolution: {integrity: sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==}
     dev: true
@@ -2431,66 +2446,78 @@ packages:
       vue: 3.3.4
     dev: true
 
-  /@vitest/coverage-c8@0.30.1(vitest@0.30.1):
-    resolution: {integrity: sha512-/Wa3dtSuckpdngAmiCwowaEXXgJkqPrtfvrs9HTB9QoEfNbZWPu4E4cjEn4lJZb4qcGf4fxFtUA2f9DnDNAzBA==}
+  /@vitest/coverage-v8@0.34.3(vitest@0.34.3):
+    resolution: {integrity: sha512-bNjP0RHe8UxdklCigZlk6FVCNbOiqVjWnpZJ1zKixpvb7YHSaZiN/w+mzpvXIoqyxyePzKC+L+G1oj7SB20PJw==}
     peerDependencies:
-      vitest: '>=0.30.0 <1'
+      vitest: '>=0.32.0 <1'
     dependencies:
-      c8: 7.13.0
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.5
+      magic-string: 0.30.3
       picocolors: 1.0.0
-      std-env: 3.3.2
-      vitest: 0.30.1(@vitest/ui@0.30.1)
+      std-env: 3.4.3
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.1.0
+      vitest: 0.34.3(@vitest/ui@0.34.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /@vitest/expect@0.30.1:
-    resolution: {integrity: sha512-c3kbEtN8XXJSeN81iDGq29bUzSjQhjES2WR3aColsS4lPGbivwLtas4DNUe0jD9gg/FYGIteqOenfU95EFituw==}
+  /@vitest/expect@0.34.3:
+    resolution: {integrity: sha512-F8MTXZUYRBVsYL1uoIft1HHWhwDbSzwAU9Zgh8S6WFC3YgVb4AnFV2GXO3P5Em8FjEYaZtTnQYoNwwBrlOMXgg==}
     dependencies:
-      '@vitest/spy': 0.30.1
-      '@vitest/utils': 0.30.1
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
       chai: 4.3.7
     dev: true
 
-  /@vitest/runner@0.30.1:
-    resolution: {integrity: sha512-W62kT/8i0TF1UBCNMRtRMOBWJKRnNyv9RrjIgdUryEe0wNpGZvvwPDLuzYdxvgSckzjp54DSpv1xUbv4BQ0qVA==}
+  /@vitest/runner@0.34.3:
+    resolution: {integrity: sha512-lYNq7N3vR57VMKMPLVvmJoiN4bqwzZ1euTW+XXYH5kzr3W/+xQG3b41xJn9ChJ3AhYOSoweu974S1V3qDcFESA==}
     dependencies:
-      '@vitest/utils': 0.30.1
-      concordance: 5.0.4
+      '@vitest/utils': 0.34.3
       p-limit: 4.0.0
-      pathe: 1.1.0
+      pathe: 1.1.1
     dev: true
 
-  /@vitest/snapshot@0.30.1:
-    resolution: {integrity: sha512-fJZqKrE99zo27uoZA/azgWyWbFvM1rw2APS05yB0JaLwUIg9aUtvvnBf4q7JWhEcAHmSwbrxKFgyBUga6tq9Tw==}
+  /@vitest/snapshot@0.34.3:
+    resolution: {integrity: sha512-QyPaE15DQwbnIBp/yNJ8lbvXTZxS00kRly0kfFgAD5EYmCbYcA+1EEyRalc93M0gosL/xHeg3lKAClIXYpmUiQ==}
     dependencies:
-      magic-string: 0.30.0
-      pathe: 1.1.0
-      pretty-format: 27.5.1
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      pretty-format: 29.6.3
     dev: true
 
-  /@vitest/spy@0.30.1:
-    resolution: {integrity: sha512-YfJeIf37GvTZe04ZKxzJfnNNuNSmTEGnla2OdL60C8od16f3zOfv9q9K0nNii0NfjDJRt/CVN/POuY5/zTS+BA==}
+  /@vitest/spy@0.34.3:
+    resolution: {integrity: sha512-N1V0RFQ6AI7CPgzBq9kzjRdPIgThC340DGjdKdPSE8r86aUSmeliTUgkTqLSgtEwWWsGfBQ+UetZWhK0BgJmkQ==}
     dependencies:
-      tinyspy: 2.1.0
+      tinyspy: 2.1.1
     dev: true
 
-  /@vitest/ui@0.30.1:
-    resolution: {integrity: sha512-Izz4ElDmdvX02KImSC2nCJI6CsGo9aETbKqxli55M0rbbPPAMtF0zDcJIqgEP5V6Y+4Ysf6wvsjLbLCTnaBvKw==}
+  /@vitest/ui@0.34.3(vitest@0.34.3):
+    resolution: {integrity: sha512-iNcOQ0xML9znOReiwpKJrTLSj5zFxmveD3VCxIJNqnsaMYpONSbSiiJLC1Y1dYlkmiHylp+ElNcUZYIMWdxRvA==}
+    peerDependencies:
+      vitest: '>=0.30.1 <1'
     dependencies:
-      '@vitest/utils': 0.30.1
-      fast-glob: 3.2.12
-      fflate: 0.7.4
+      '@vitest/utils': 0.34.3
+      fast-glob: 3.3.1
+      fflate: 0.8.0
       flatted: 3.2.7
-      pathe: 1.1.0
+      pathe: 1.1.1
       picocolors: 1.0.0
       sirv: 2.0.3
+      vitest: 0.34.3(@vitest/ui@0.34.3)
     dev: true
 
-  /@vitest/utils@0.30.1:
-    resolution: {integrity: sha512-/c8Xv2zUVc+rnNt84QF0Y0zkfxnaGhp87K2dYJMLtLOIckPzuxLVzAtFCicGFdB4NeBHNzTRr1tNn7rCtQcWFA==}
+  /@vitest/utils@0.34.3:
+    resolution: {integrity: sha512-kiSnzLG6m/tiT0XEl4U2H8JDBjFtwVlaE8I3QfGiMFR0QvnRDfYfdP3YvTBWM/6iJDAyaPY6yVQiCTUc7ZzTHA==}
     dependencies:
-      concordance: 5.0.4
+      diff-sequences: 29.6.3
       loupe: 2.3.6
-      pretty-format: 27.5.1
+      pretty-format: 29.6.3
     dev: true
 
   /@vue/compiler-core@3.2.45:
@@ -2972,6 +2999,12 @@ packages:
     hasBin: true
     dev: true
 
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
   /acorn@8.8.2:
     resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
@@ -3171,10 +3204,6 @@ packages:
       readable-stream: 3.6.0
     dev: true
 
-  /blueimp-md5@2.19.0:
-    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
-    dev: true
-
   /bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
     dev: true
@@ -3282,25 +3311,6 @@ packages:
   /bytes-iec@3.1.1:
     resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
     engines: {node: '>= 0.8'}
-    dev: true
-
-  /c8@7.13.0:
-    resolution: {integrity: sha512-/NL4hQTv1gBL6J6ei80zu3IiTrmePDKXKXOTLpHvcIWZTVYQlDhVWjjWvkhICylE8EwwnMVzDZugCvdx0/DIIA==}
-    engines: {node: '>=10.12.0'}
-    hasBin: true
-    dependencies:
-      '@bcoe/v8-coverage': 0.2.3
-      '@istanbuljs/schema': 0.1.3
-      find-up: 5.0.0
-      foreground-child: 2.0.0
-      istanbul-lib-coverage: 3.2.0
-      istanbul-lib-report: 3.0.0
-      istanbul-reports: 3.1.5
-      rimraf: 3.0.2
-      test-exclude: 6.0.0
-      v8-to-istanbul: 9.1.0
-      yargs: 16.2.0
-      yargs-parser: 20.2.9
     dev: true
 
   /cac@6.7.14:
@@ -3508,20 +3518,6 @@ packages:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: true
 
-  /concordance@5.0.4:
-    resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
-    engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
-    dependencies:
-      date-time: 3.1.0
-      esutils: 2.0.3
-      fast-diff: 1.2.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      md5-hex: 3.0.1
-      semver: 7.5.0
-      well-known-symbols: 2.0.0
-    dev: true
-
   /constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
@@ -3614,13 +3610,6 @@ packages:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
 
-  /date-time@3.1.0:
-    resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
-    engines: {node: '>=6'}
-    dependencies:
-      time-zone: 1.0.0
-    dev: true
-
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -3707,6 +3696,11 @@ packages:
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /dir-glob@3.0.1:
@@ -4169,11 +4163,6 @@ packages:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
     dev: true
 
-  /esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /ethers@5.7.2:
     resolution: {integrity: sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==}
     dependencies:
@@ -4318,12 +4307,19 @@ packages:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
 
-  /fast-diff@1.2.0:
-    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
-    dev: true
-
   /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
+
+  /fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4357,8 +4353,8 @@ packages:
       web-streams-polyfill: 3.2.1
     dev: true
 
-  /fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  /fflate@0.8.0:
+    resolution: {integrity: sha512-FAdS4qMuFjsJj6XHbBaZeXOgaypXp8iw/Tpyuq/w3XA41jjLHT8NPA+n7czH/DDhdncq0nAyDZmPeWXh2qmdIg==}
     dev: true
 
   /fill-range@7.0.1:
@@ -4422,14 +4418,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: true
-
-  /foreground-child@2.0.0:
-    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      cross-spawn: 7.0.3
-      signal-exit: 3.0.7
     dev: true
 
   /formdata-polyfill@4.0.10:
@@ -4958,13 +4946,24 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /istanbul-lib-report@3.0.0:
-    resolution: {integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==}
-    engines: {node: '>=8'}
+  /istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
     dependencies:
       istanbul-lib-coverage: 3.2.0
-      make-dir: 3.1.0
+      make-dir: 4.0.0
       supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.0
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /istanbul-reports@3.1.5:
@@ -4972,7 +4971,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       html-escaper: 2.0.2
-      istanbul-lib-report: 3.0.0
+      istanbul-lib-report: 3.0.1
     dev: true
 
   /jest-worker@27.5.1:
@@ -4986,11 +4985,6 @@ packages:
 
   /js-sha3@0.8.0:
     resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
-    dev: true
-
-  /js-string-escape@1.0.1:
-    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
-    engines: {node: '>= 0.8'}
     dev: true
 
   /js-tokens@4.0.0:
@@ -5111,10 +5105,6 @@ packages:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
 
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
-
   /log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
@@ -5186,11 +5176,18 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
+  /magic-string@0.30.3:
+    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+    engines: {node: '>=12'}
     dependencies:
-      semver: 6.3.0
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.5.4
     dev: true
 
   /map-obj@1.0.1:
@@ -5205,13 +5202,6 @@ packages:
 
   /mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
-    dev: true
-
-  /md5-hex@3.0.1:
-    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
-    engines: {node: '>=8'}
-    dependencies:
-      blueimp-md5: 2.19.0
     dev: true
 
   /meow@6.1.1:
@@ -5332,13 +5322,13 @@ packages:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
     dev: true
 
-  /mlly@1.2.0:
-    resolution: {integrity: sha512-+c7A3CV0KGdKcylsI6khWyts/CYrGTrRVo4R/I7u/cUsy0Conxa6LUhiEzVKIw14lc2L5aiO4+SeVe4TeGRKww==}
+  /mlly@1.4.1:
+    resolution: {integrity: sha512-SCDs78Q2o09jiZiE2WziwVBEqXQ02XkGdUy45cbJf+BpYRIjArXRJ1Wbowxkb+NaM9DWvS3UC9GiO/6eqvQ/pg==}
     dependencies:
-      acorn: 8.8.2
-      pathe: 1.1.0
+      acorn: 8.10.0
+      pathe: 1.1.1
       pkg-types: 1.0.3
-      ufo: 1.1.1
+      ufo: 1.3.0
     dev: true
 
   /mrmime@1.0.1:
@@ -5651,6 +5641,10 @@ packages:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
+
   /pathval@1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -5689,8 +5683,8 @@ packages:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
       jsonc-parser: 3.2.0
-      mlly: 1.2.0
-      pathe: 1.1.0
+      mlly: 1.4.1
+      pathe: 1.1.1
     dev: true
 
   /postcss-import@14.1.0(postcss@8.4.19):
@@ -5807,13 +5801,13 @@ packages:
     hasBin: true
     dev: true
 
-  /pretty-format@27.5.1:
-    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+  /pretty-format@29.6.3:
+    resolution: {integrity: sha512-ZsBgjVhFAj5KeK+nHfF1305/By3lechHQSMWCTl8iHSbfOm2TN5nHEtFc/+W7fAyUeCs2n5iow72gld4gW0xDw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      ansi-regex: 5.0.1
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
-      react-is: 17.0.2
+      react-is: 18.2.0
     dev: true
 
   /progress@2.0.3:
@@ -5894,8 +5888,8 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-is@17.0.2:
-    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
   /react-refresh@0.14.0:
@@ -6121,8 +6115,8 @@ packages:
       lru-cache: 6.0.0
     dev: true
 
-  /semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -6314,8 +6308,8 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
-  /std-env@3.3.2:
-    resolution: {integrity: sha512-uUZI65yrV2Qva5gqE0+A7uVAvO40iPo6jGhs7s8keRfHCmtg+uB2X6EiLGCI9IgL1J17xGhvoOqSz79lzICPTA==}
+  /std-env@3.4.3:
+    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
 
   /stream-transform@2.1.3:
@@ -6394,7 +6388,7 @@ packages:
   /strip-literal@1.0.1:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
     dev: true
 
   /supports-color@5.5.0:
@@ -6540,22 +6534,17 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
-  /time-zone@1.0.0:
-    resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
-    engines: {node: '>=4'}
-    dev: true
-
   /tinybench@2.5.0:
     resolution: {integrity: sha512-kRwSG8Zx4tjF9ZiyH4bhaebu+EDz1BOx9hOigYHlUW4xxI/wKIUQUqo018UlU4ar6ATPBsaMrdbKZ+tmPdohFA==}
     dev: true
 
-  /tinypool@0.4.0:
-    resolution: {integrity: sha512-2ksntHOKf893wSAH4z/+JbPpi92esw8Gn9N2deXX+B0EO92hexAVI9GIZZPx7P5aYo5KULfeOSt3kMOmSOy6uA==}
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /tinyspy@2.1.0:
-    resolution: {integrity: sha512-7eORpyqImoOvkQJCSkL0d0mB4NHHIFAy4b1u8PHdDa7SjGS2njzl6/lyGoZLm+eyYEtlUmFGE0rFj66SWxZgQQ==}
+  /tinyspy@2.1.1:
+    resolution: {integrity: sha512-XPJL2uSzcOyBMky6OFrusqWlzfFrXtE0hPuMgW8A2HmaqrPo4ZQHRN/V0QXN3FSjKxpsbRrFc5LI7KOwBsT1/w==}
     engines: {node: '>=14.0.0'}
     dev: true
 
@@ -6650,8 +6639,8 @@ packages:
     engines: {node: '>=12.20'}
     hasBin: true
 
-  /ufo@1.1.1:
-    resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
+  /ufo@1.3.0:
+    resolution: {integrity: sha512-bRn3CsoojyNStCZe0BG0Mt4Nr/4KF+rhFlnNXybgqt5pXHNFRlqinSoQaTrGyzE4X8aHplSb+TorH+COin9Yxw==}
     dev: true
 
   /unbox-primitive@1.0.2:
@@ -6738,17 +6727,17 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.30.1(@types/node@18.16.3):
-    resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
+  /vite-node@0.34.3(@types/node@20.4.9):
+    resolution: {integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
-      mlly: 1.2.0
-      pathe: 1.1.0
+      mlly: 1.4.1
+      pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.2(@types/node@18.16.3)
+      vite: 4.4.2(@types/node@20.4.9)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6828,7 +6817,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.4.2(@types/node@18.16.3):
+  /vite@4.4.2(@types/node@20.4.9):
     resolution: {integrity: sha512-zUcsJN+UvdSyHhYa277UHhiJ3iq4hUBwHavOpsNUGsTgjBeoBlK8eDt+iT09pBq0h9/knhG/SPrZiM7cGmg7NA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6856,7 +6845,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.16.3
+      '@types/node': 20.4.9
       esbuild: 0.18.11
       postcss: 8.4.25
       rollup: 3.26.2
@@ -6909,8 +6898,8 @@ packages:
     dev: true
     patched: true
 
-  /vitest@0.30.1(@vitest/ui@0.30.1):
-    resolution: {integrity: sha512-y35WTrSTlTxfMLttgQk4rHcaDkbHQwDP++SNwPb+7H8yb13Q3cu2EixrtHzF27iZ8v0XCciSsLg00RkPAzB/aA==}
+  /vitest@0.34.3(@vitest/ui@0.34.3):
+    resolution: {integrity: sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
     peerDependencies:
@@ -6942,30 +6931,28 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.16.3
-      '@vitest/expect': 0.30.1
-      '@vitest/runner': 0.30.1
-      '@vitest/snapshot': 0.30.1
-      '@vitest/spy': 0.30.1
-      '@vitest/ui': 0.30.1
-      '@vitest/utils': 0.30.1
-      acorn: 8.8.2
+      '@types/node': 20.4.9
+      '@vitest/expect': 0.34.3
+      '@vitest/runner': 0.34.3
+      '@vitest/snapshot': 0.34.3
+      '@vitest/spy': 0.34.3
+      '@vitest/ui': 0.34.3(vitest@0.34.3)
+      '@vitest/utils': 0.34.3
+      acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
-      concordance: 5.0.4
       debug: 4.3.4
       local-pkg: 0.4.3
-      magic-string: 0.30.0
-      pathe: 1.1.0
+      magic-string: 0.30.3
+      pathe: 1.1.1
       picocolors: 1.0.0
-      source-map: 0.6.1
-      std-env: 3.3.2
+      std-env: 3.4.3
       strip-literal: 1.0.1
       tinybench: 2.5.0
-      tinypool: 0.4.0
-      vite: 4.4.2(@types/node@18.16.3)
-      vite-node: 0.30.1(@types/node@18.16.3)
+      tinypool: 0.7.0
+      vite: 4.4.2(@types/node@20.4.9)
+      vite-node: 0.34.3(@types/node@20.4.9)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -7086,11 +7073,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
-
-  /well-known-symbols@2.0.0:
-    resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
-    engines: {node: '>=6'}
     dev: true
 
   /whatwg-url@5.0.0:
@@ -7259,11 +7241,6 @@ packages:
       decamelize: 1.2.0
     dev: true
 
-  /yargs-parser@20.2.9:
-    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
-    engines: {node: '>=10'}
-    dev: true
-
   /yargs-parser@21.0.1:
     resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
     engines: {node: '>=12'}
@@ -7284,19 +7261,6 @@ packages:
       which-module: 2.0.0
       y18n: 4.0.3
       yargs-parser: 18.1.3
-    dev: true
-
-  /yargs@16.2.0:
-    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
-    engines: {node: '>=10'}
-    dependencies:
-      cliui: 7.0.4
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 20.2.9
     dev: true
 
   /yargs@17.5.1:

--- a/src/_test/globalSetup.ts
+++ b/src/_test/globalSetup.ts
@@ -1,6 +1,6 @@
 import { startProxy } from '@viem/anvil'
 
-import { blockTime, forkBlockNumber, forkUrl } from './constants.js'
+import { forkBlockNumber, forkUrl } from './constants.js'
 
 export default async function () {
   if (process.env.SKIP_GLOBAL_SETUP) {
@@ -29,7 +29,7 @@ export default async function () {
     options: {
       forkUrl,
       forkBlockNumber,
-      blockTime,
+      noMining: true,
     },
   })
 }

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,11 +2,12 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
+import { setAutomine } from '../actions/test/setAutomine.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber } from './utils.js'
+import { setBlockNumber, testClient } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -29,7 +30,10 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await setBlockNumber(forkBlockNumber)
+  await Promise.all([
+    setBlockNumber(forkBlockNumber),
+    setAutomine(testClient, false),
+  ])
 })
 
 afterEach((context) => {

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,10 +2,11 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
-import { setAutomine } from '../actions/test/setAutomine.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
+import { setIntervalMining } from '../test.js'
+import { socketsCache } from '../utils/rpc.js'
 import { forkBlockNumber, poolId } from './constants.js'
 import { setBlockNumber, testClient } from './utils.js'
 
@@ -19,21 +20,21 @@ beforeAll(() => {
   }))
 })
 
-beforeEach(() => {
+beforeEach(async () => {
   promiseCache.clear()
   responseCache.clear()
   listenersCache.clear()
   cleanupCache.clear()
+  socketsCache.clear()
+
+  await setIntervalMining(testClient, { interval: 0 })
 })
 
 afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await Promise.all([
-    setBlockNumber(forkBlockNumber),
-    setAutomine(testClient, false),
-  ])
+  await setBlockNumber(forkBlockNumber)
 })
 
 afterEach((context) => {

--- a/src/_test/setup.ts
+++ b/src/_test/setup.ts
@@ -2,13 +2,11 @@ import { fetchLogs } from '@viem/anvil'
 
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest'
 
-import { setAutomine } from '../actions/test/setAutomine.js'
-import { setIntervalMining } from '../actions/test/setIntervalMining.js'
 import { cleanupCache, listenersCache } from '../utils/observe.js'
 import { promiseCache, responseCache } from '../utils/promise/withCache.js'
 
 import { forkBlockNumber, poolId } from './constants.js'
-import { setBlockNumber, testClient } from './utils.js'
+import { setBlockNumber } from './utils.js'
 
 beforeAll(() => {
   vi.mock('../errors/utils.ts', () => ({
@@ -31,11 +29,7 @@ afterAll(async () => {
   vi.restoreAllMocks()
 
   // Reset the anvil instance to the same state it was in before the tests started.
-  await Promise.all([
-    setBlockNumber(forkBlockNumber),
-    setAutomine(testClient, false),
-    setIntervalMining(testClient, { interval: 1 }),
-  ])
+  await setBlockNumber(forkBlockNumber)
 })
 
 afterEach((context) => {

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -65,6 +65,8 @@ export const anvilChain = {
   },
 } as const satisfies Chain
 
+let id = 0
+
 const provider: EIP1193Provider = {
   on: (message, listener) => {
     if (message === 'accountsChanged') {
@@ -114,6 +116,7 @@ const provider: EIP1193Provider = {
       body: {
         method,
         params,
+        id: id++,
       },
     })
     if (error)
@@ -131,7 +134,7 @@ export const httpClient = createPublicClient({
     multicall: process.env.VITE_BATCH_MULTICALL === 'true',
   },
   chain: anvilChain,
-  pollingInterval: 1_000,
+  pollingInterval: 100,
   transport: http(localHttpUrl, {
     batch: process.env.VITE_BATCH_JSON_RPC === 'true',
   }),
@@ -142,7 +145,7 @@ export const webSocketClient = createPublicClient({
     multicall: process.env.VITE_BATCH_MULTICALL === 'true',
   },
   chain: anvilChain,
-  pollingInterval: 1_000,
+  pollingInterval: 100,
   transport: webSocket(localWsUrl),
 })
 
@@ -175,7 +178,7 @@ export const walletClientWithoutChain = createWalletClient({
 export const testClient = createTestClient({
   chain: anvilChain,
   mode: 'anvil',
-  transport: http(localHttpUrl),
+  transport: custom(provider),
 })
 
 export function createHttpServer(

--- a/src/actions/getContract.test-d.ts
+++ b/src/actions/getContract.test-d.ts
@@ -309,18 +309,16 @@ test('with and without wallet client `account`', () => {
     walletClient: walletClientWithoutAccount,
   })
 
-  expectTypeOf(contractWithAccount.write.approve).parameters.toEqualTypeOf<
-    [
-      args: readonly [`0x${string}`, bigint],
-      options?: { account?: Account | Address },
-    ]
-  >()
-  expectTypeOf(contractWithoutAccount.write.approve).parameters.toEqualTypeOf<
-    [
-      args: readonly [`0x${string}`, bigint],
-      options: { account: Account | Address },
-    ]
-  >()
+  expectTypeOf(contractWithAccount.write.approve)
+    .parameter(1)
+    .extract<{ account?: Account | Address }>()
+    // @ts-expect-error
+    .toBeNever()
+  expectTypeOf(contractWithoutAccount.write.approve)
+    .parameter(1)
+    .extract<{ account: Account | Address }>()
+    // @ts-expect-error
+    .toBeNever()
 })
 
 test('with and without wallet client `chain`', () => {
@@ -335,15 +333,16 @@ test('with and without wallet client `chain`', () => {
     walletClient: walletClientWithoutChain,
   })
 
-  expectTypeOf(contractWithChain.write.approve).parameters.toEqualTypeOf<
-    [args: readonly [`0x${string}`, bigint], params?: { chain?: Chain | null }]
-  >()
-  expectTypeOf(contractWithoutChain.write.approve).parameters.toEqualTypeOf<
-    [
-      args: readonly [`0x${string}`, bigint],
-      params: { chain: Chain | null | undefined },
-    ]
-  >()
+  expectTypeOf(contractWithChain.write.approve)
+    .parameter(1)
+    .extract<{ chain?: Chain | null }>()
+    // @ts-expect-error
+    .toBeNever()
+  expectTypeOf(contractWithoutChain.write.approve)
+    .parameter(1)
+    .extract<{ chain: Chain | null | undefined }>()
+    // @ts-expect-error
+    .toBeNever()
 })
 
 test('no read functions', () => {

--- a/src/actions/getContract.test.ts
+++ b/src/actions/getContract.test.ts
@@ -3,7 +3,7 @@ import type { AbiEvent } from 'abitype'
 import { describe, expect, test } from 'vitest'
 
 import { wagmiContractConfig } from '../_test/abis.js'
-import { accounts } from '../_test/constants.js'
+import { accounts, forkBlockNumber } from '../_test/constants.js'
 import {
   publicClient,
   walletClient,
@@ -43,7 +43,7 @@ test('createEventFilter', async () => {
         from: accounts[0].address,
       },
       {
-        fromBlock: 10_000n,
+        fromBlock: forkBlockNumber - 5n,
       },
     ),
   ).resolves.toBeDefined()

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -127,7 +127,7 @@ test('args: blockNumber', async () => {
 })
 
 describe('account hoisting', () => {
-  test('no account hoisted', async () => {
+  test.skip('no account hoisted', async () => {
     await expect(
       call(publicClient, {
         data: `${mintWithParams4bytes}${sixHundred}`,

--- a/src/actions/public/getBlock.test-d.ts
+++ b/src/actions/public/getBlock.test-d.ts
@@ -5,6 +5,7 @@ import { optimism } from '../../chains/index.js'
 import { http, createPublicClient } from '../../index.js'
 import type { Hash, Hex } from '../../types/misc.js'
 import type { Transaction } from '../../types/transaction.js'
+import type { Prettify } from '../../types/utils.js'
 import { getBlock } from './getBlock.js'
 
 test('includeTransactions = false', async () => {
@@ -18,7 +19,7 @@ test('includeTransactions = false', async () => {
 test('includeTransactions = true', async () => {
   const block = await getBlock(publicClient, { includeTransactions: true })
   expectTypeOf(block.transactions).toEqualTypeOf<
-    Transaction<bigint, number, false>[]
+    Prettify<Transaction<bigint, number, false>>[]
   >()
 })
 
@@ -43,7 +44,7 @@ test('blockTag = "pending" & includeTransactions = true', async () => {
   expectTypeOf(block.nonce).toEqualTypeOf<null>()
   expectTypeOf(block.number).toEqualTypeOf<null>()
   expectTypeOf(block.transactions).toEqualTypeOf<
-    Transaction<bigint, number, true>[]
+    Prettify<Transaction<bigint, number, true>>[]
   >()
   expectTypeOf(block.transactions[0].blockHash).toEqualTypeOf<null>()
   expectTypeOf(block.transactions[0].blockNumber).toEqualTypeOf<null>()

--- a/src/actions/public/getBlockTransactionCount.test.ts
+++ b/src/actions/public/getBlockTransactionCount.test.ts
@@ -1,18 +1,13 @@
-import { beforeAll, expect, test } from 'vitest'
+import { expect, test } from 'vitest'
 
 import { accounts, forkBlockNumber } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { getBlock } from './getBlock.js'
 import { getBlockTransactionCount } from './getBlockTransactionCount.js'
-
-await beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 test('default', async () => {
   expect(await getBlockTransactionCount(publicClient)).toBeDefined()

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -24,7 +24,6 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 import { writeContract } from '../wallet/writeContract.js'
@@ -120,7 +119,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -22,7 +22,6 @@ import { getAddress } from '../../utils/address/getAddress.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { writeContract } from '../wallet/writeContract.js'
 
@@ -115,7 +114,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -21,7 +21,6 @@ import { getAddress } from '../../utils/address/getAddress.js'
 import { impersonateAccount } from '../test/impersonateAccount.js'
 import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { stopImpersonatingAccount } from '../test/stopImpersonatingAccount.js'
 import { writeContract } from '../wallet/writeContract.js'
 
@@ -113,7 +112,6 @@ const event = {
 } as const
 
 beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await impersonateAccount(testClient, {
     address: address.vitalik,
   })

--- a/src/actions/public/getTransaction.test.ts
+++ b/src/actions/public/getTransaction.test.ts
@@ -11,6 +11,7 @@ import { mine } from '../test/mine.js'
 import { setBalance } from '../test/setBalance.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
+import { wait } from '../../utils/wait.js'
 import { getBlock } from './getBlock.js'
 import { getTransaction } from './getTransaction.js'
 
@@ -90,7 +91,7 @@ test('gets transaction (eip2930)', async () => {
     account: sourceAccount.address,
     to: targetAccount.address,
     value: parseEther('1'),
-    gasPrice: BigInt(block.baseFeePerGas ?? 0),
+    gasPrice: BigInt((block.baseFeePerGas ?? 0n) * 2n),
   })
 
   const transaction = await getTransaction(publicClient, {
@@ -304,6 +305,7 @@ describe('args: blockTag', () => {
     })
 
     await mine(testClient, { blocks: 1 })
+    await wait(200)
 
     const transaction = await getTransaction(publicClient, {
       blockTag: 'latest',

--- a/src/actions/public/getTransactionConfirmations.test.ts
+++ b/src/actions/public/getTransactionConfirmations.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest'
 import { accounts } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
+import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
@@ -16,6 +17,7 @@ test('default', async () => {
     value: parseEther('1'),
   })
   await mine(testClient, { blocks: 1 })
+  await wait(1000)
   const transactionReceipt = await getTransactionReceipt(publicClient, {
     hash,
   })

--- a/src/actions/public/getTransactionReceipt.test.ts
+++ b/src/actions/public/getTransactionReceipt.test.ts
@@ -2,7 +2,7 @@ import type { Address } from 'abitype'
 
 import { assertType, describe, expect, it, test } from 'vitest'
 
-import { accounts } from '../../_test/constants.js'
+import { accounts, forkBlockNumber } from '../../_test/constants.js'
 import { publicClient, testClient, walletClient } from '../../_test/utils.js'
 import { celo } from '../../chains/index.js'
 import { createPublicClient } from '../../clients/createPublicClient.js'
@@ -13,62 +13,36 @@ import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
+import { wait } from '../../utils/wait.js'
 import { getBlock } from './getBlock.js'
 import { getTransaction } from './getTransaction.js'
 import { getTransactionReceipt } from './getTransactionReceipt.js'
 
 test('gets transaction receipt', async () => {
+  const transaction = await getTransaction(publicClient, {
+    blockNumber: forkBlockNumber - 1n,
+    index: 0,
+  })
   const receipt = await getTransactionReceipt(publicClient, {
-    hash: '0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b',
+    hash: transaction.hash,
   })
   assertType<TransactionReceipt>(receipt)
   expect(receipt).toMatchInlineSnapshot(`
     {
-      "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-      "blockNumber": 15131999n,
+      "blockHash": "0xb932f77cf770d1d1c8f861153eec1e990f5d56b6ffdb4ac06aef3cca51ef37d4",
+      "blockNumber": 16280769n,
       "contractAddress": null,
-      "cumulativeGasUsed": 5814407n,
-      "effectiveGasPrice": 11789405161n,
-      "from": "0xa152f8bb749c55e9943a3a0a3111d18ee2b3f94e",
-      "gasUsed": 37976n,
-      "logs": [
-        {
-          "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-          "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-          "blockNumber": 15131999n,
-          "data": "0x0000000000000000000000000000000000000000000000000000002b3b6fb3d0",
-          "logIndex": 108,
-          "removed": false,
-          "topics": [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
-            "0x000000000000000000000000f16e9b0d03470827a95cdfd0cb8a8a3b46969b91",
-          ],
-          "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-          "transactionIndex": 69,
-        },
-        {
-          "address": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-          "blockHash": "0x89644bbd5c8d682a2e9611170e6c1f02573d866d286f006cbf517eec7254ec2d",
-          "blockNumber": 15131999n,
-          "data": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffd4c4904c2f",
-          "logIndex": 109,
-          "removed": false,
-          "topics": [
-            "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
-            "0x000000000000000000000000a00f99bc38b1ecda1fd70eaa1cd31d576a9f46b0",
-            "0x000000000000000000000000a152f8bb749c55e9943a3a0a3111d18ee2b3f94e",
-          ],
-          "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-          "transactionIndex": 69,
-        },
-      ],
-      "logsBloom": "0x08000000000000000000000000000000000000000000000000001000002000000000000000000000000000000000000000000000080000000000000000200000000000000000000000000008400000000000000000000000000000000000100000000000000000000040000008000000000004000000000000000010000000000000000000000000000000000000000000000000000000000000000000000004020000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000002090000000000000000000000000000000000000000000000000000000000000",
+      "cumulativeGasUsed": 21000n,
+      "effectiveGasPrice": 33427926161n,
+      "from": "0x043022ef9fca1066024d19d681e2ccf44ff90de3",
+      "gasUsed": 21000n,
+      "logs": [],
+      "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
       "status": "success",
-      "to": "0x15d4c048f83bd7e37d49ea4c83a07267ec4203da",
-      "transactionHash": "0xa4b1f606b66105fa45cb5db23d2f6597075701e7f0e2367f4e6a39d17a8cf98b",
-      "transactionIndex": 69,
-      "type": "eip1559",
+      "to": "0x318a5fb4f1604fc46375a1db9a9018b6e423b345",
+      "transactionHash": "0xbf7d27700d053765c9638d3b9d39eb3c56bfc48377583e8be483d61f9f18a871",
+      "transactionIndex": 0,
+      "type": "legacy",
     }
   `)
 })
@@ -137,6 +111,7 @@ describe('e2e', () => {
       }),
     ).rejects.toThrowError('Transaction receipt with hash')
     await mine(testClient, { blocks: 1 })
+    await wait(500)
 
     const {
       blockHash,

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -8,7 +8,6 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as getBlock from './getBlock.js'
@@ -93,7 +92,6 @@ test('waits for transaction (multiple parallel)', async () => {
 describe('replaced transactions', () => {
   test('repriced', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -127,8 +125,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -141,7 +137,6 @@ describe('replaced transactions', () => {
 
   test('repriced (skipped blocks)', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -180,13 +175,10 @@ describe('replaced transactions', () => {
     ])
 
     expect(receipt !== null).toBeTruthy()
-
-    await setIntervalMining(testClient, { interval: 1 })
   })
 
   test('cancelled', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -220,8 +212,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -234,7 +224,6 @@ describe('replaced transactions', () => {
 
   test('replaced', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -268,8 +257,6 @@ describe('replaced transactions', () => {
           nonce,
           maxFeePerGas: parseGwei('20'),
         })
-
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -304,7 +291,6 @@ describe('args: confirmations', () => {
 
   test('waits for confirmations (replaced)', async () => {
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -339,7 +325,6 @@ describe('args: confirmations', () => {
         })
 
         await wait(1000)
-        await setIntervalMining(testClient, { interval: 1 })
       })(),
     ])
 
@@ -382,7 +367,6 @@ describe('errors', () => {
     vi.spyOn(getBlock, 'getBlock').mockRejectedValueOnce(new Error('foo'))
 
     await mine(testClient, { blocks: 10 })
-    await setIntervalMining(testClient, { interval: 0 })
 
     const nonce = hexToNumber(
       (await publicClient.request({
@@ -415,8 +399,6 @@ describe('errors', () => {
             nonce,
             maxFeePerGas: parseGwei('20'),
           })
-
-          await setIntervalMining(testClient, { interval: 1 })
         })(),
       ]),
     ).rejects.toThrowErrorMatchingInlineSnapshot('"foo"')

--- a/src/actions/public/waitForTransactionReceipt.test.ts
+++ b/src/actions/public/waitForTransactionReceipt.test.ts
@@ -10,13 +10,20 @@ import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
+import { setIntervalMining } from '../index.js'
 import * as getBlock from './getBlock.js'
 import { waitForTransactionReceipt } from './waitForTransactionReceipt.js'
 
 const sourceAccount = accounts[0]
 const targetAccount = accounts[1]
 
+async function setup() {
+  await setIntervalMining(testClient, { interval: 1 })
+}
+
 test('waits for transaction (send -> wait -> mine)', async () => {
+  setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -29,6 +36,8 @@ test('waits for transaction (send -> wait -> mine)', async () => {
 })
 
 test('waits for transaction (send -> mine -> wait)', async () => {
+  setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -42,6 +51,8 @@ test('waits for transaction (send -> mine -> wait)', async () => {
 })
 
 test('waits for transaction (multiple waterfall)', async () => {
+  setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -65,6 +76,8 @@ test('waits for transaction (multiple waterfall)', async () => {
 })
 
 test('waits for transaction (multiple parallel)', async () => {
+  setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -91,6 +104,8 @@ test('waits for transaction (multiple parallel)', async () => {
 
 describe('replaced transactions', () => {
   test('repriced', async () => {
+    setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -136,6 +151,8 @@ describe('replaced transactions', () => {
   })
 
   test('repriced (skipped blocks)', async () => {
+    setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -178,6 +195,8 @@ describe('replaced transactions', () => {
   })
 
   test('cancelled', async () => {
+    setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -223,6 +242,8 @@ describe('replaced transactions', () => {
   })
 
   test('replaced', async () => {
+    setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -270,6 +291,8 @@ describe('replaced transactions', () => {
 
 describe('args: confirmations', () => {
   test('waits for confirmations', async () => {
+    setup()
+
     const hash = await sendTransaction(walletClient, {
       account: sourceAccount.address,
       to: targetAccount.address,
@@ -290,6 +313,8 @@ describe('args: confirmations', () => {
   })
 
   test('waits for confirmations (replaced)', async () => {
+    setup()
+
     await mine(testClient, { blocks: 10 })
 
     const nonce = hexToNumber(
@@ -333,6 +358,8 @@ describe('args: confirmations', () => {
 })
 
 test('args: timeout', async () => {
+  setup()
+
   const hash = await sendTransaction(walletClient, {
     account: sourceAccount.address,
     to: targetAccount.address,
@@ -364,6 +391,8 @@ describe('errors', () => {
   )
 
   test('throws when transaction replaced and getBlock fails', async () => {
+    setup()
+
     vi.spyOn(getBlock, 'getBlock').mockRejectedValueOnce(new Error('foo'))
 
     await mine(testClient, { blocks: 10 })

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -64,6 +64,7 @@ describe('poll', () => {
         poll: true,
         pollingInterval: 100,
       })
+      await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
@@ -110,7 +111,7 @@ describe('poll', () => {
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       unwatch()
       expect(blockNumbers.length).toBe(2)
     })
@@ -203,7 +204,7 @@ describe('poll', () => {
       })
       unwatch()
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       expect(blockNumbers.length).toBe(0)
     })
 

--- a/src/actions/public/watchBlockNumber.test.ts
+++ b/src/actions/public/watchBlockNumber.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { localHttpUrl } from '../../_test/constants.js'
 import { publicClient, testClient, webSocketClient } from '../../_test/utils.js'
@@ -10,17 +10,12 @@ import {
 import { http } from '../../clients/transports/http.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 
 import * as getBlockNumber from './getBlockNumber.js'
 import {
   type OnBlockNumberParameter,
   watchBlockNumber,
 } from './watchBlockNumber.js'
-
-beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 describe('poll', () => {
   test('watches for new block numbers', async () => {

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { accounts, localHttpUrl } from '../../_test/constants.js'
 import {
@@ -18,15 +18,10 @@ import type { Chain } from '../../types/chain.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as getBlock from './getBlock.js'
 import { type OnBlockParameter, watchBlocks } from './watchBlocks.js'
-
-beforeAll(async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-})
 
 describe('poll', () => {
   test('watches for new blocks', async () => {

--- a/src/actions/public/watchBlocks.test.ts
+++ b/src/actions/public/watchBlocks.test.ts
@@ -50,9 +50,10 @@ describe('poll', () => {
   })
 
   test('args: includeTransactions', async () => {
-    const blocks: OnBlockParameter[] = []
+    const blocks: OnBlockParameter<Chain, true>[] = []
     const unwatch = watchBlocks(publicClient, {
       onBlock: (block) => blocks.push(block),
+      includeTransactions: true,
       poll: true,
     })
 
@@ -62,11 +63,12 @@ describe('poll', () => {
       value: parseEther('1'),
     })
     await mine(testClient, { blocks: 1 })
-    await wait(1000)
+    await wait(200)
 
     unwatch()
-    expect(blocks.length).toBe(1)
-    expect(blocks[0].transactions.length).toBe(1)
+    expect(
+      typeof blocks[blocks.length - 1].transactions[0] === 'object',
+    ).toBeTruthy()
   })
 
   describe('emitMissed', () => {
@@ -96,6 +98,7 @@ describe('poll', () => {
         poll: true,
         pollingInterval: 100,
       })
+      await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
       await mine(testClient, { blocks: 1 })
@@ -635,36 +638,40 @@ describe('subscribe', () => {
     test('multiple watchers', async () => {
       let blocks: OnBlockParameter[] = []
 
-      let unwatch1 = watchBlocks(webSocketClient, {
+      const unwatch1 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      let unwatch2 = watchBlocks(webSocketClient, {
+      const unwatch2 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      let unwatch3 = watchBlocks(webSocketClient, {
+      const unwatch3 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       await mine(testClient, { blocks: 1 })
-      await wait(200)
+      await wait(500)
       unwatch1()
       unwatch2()
       unwatch3()
       expect(blocks.length).toBe(9)
 
+      await mine(testClient, { blocks: 1 })
+      await wait(500)
+      expect(blocks.length).toBe(9)
+
       blocks = []
 
-      unwatch1 = watchBlocks(webSocketClient, {
+      const unwatch4 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      unwatch2 = watchBlocks(webSocketClient, {
+      const unwatch5 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
-      unwatch3 = watchBlocks(webSocketClient, {
+      const unwatch6 = watchBlocks(webSocketClient, {
         onBlock: (block) => blocks.push(block),
       })
       await wait(200)
@@ -674,9 +681,9 @@ describe('subscribe', () => {
       await wait(200)
       await mine(testClient, { blocks: 1 })
       await wait(200)
-      unwatch1()
-      unwatch2()
-      unwatch3()
+      unwatch4()
+      unwatch5()
+      unwatch6()
       expect(blocks.length).toBe(9)
     })
 

--- a/src/actions/public/watchContractEvent.test.ts
+++ b/src/actions/public/watchContractEvent.test.ts
@@ -52,79 +52,76 @@ beforeAll(async () => {
 })
 
 describe('poll', () => {
-  test(
-    'default',
-    async () => {
-      const logs: WatchContractEventOnLogsParameter<
-        typeof usdcContractConfig.abi
-      >[] = []
+  test('default', async () => {
+    const logs: WatchContractEventOnLogsParameter<
+      typeof usdcContractConfig.abi
+    >[] = []
 
-      const unwatch = watchContractEvent(publicClient, {
-        abi: usdcContractConfig.abi,
-        onLogs: (logs_) => {
-          assertType<typeof logs_[0]['args']>({
-            owner: '0x',
-            spender: '0x',
-            value: 0n,
-          })
-          assertType<typeof logs_[0]['args']>({
-            from: '0x',
-            to: '0x',
-            value: 0n,
-          })
-          logs.push(logs_)
-        },
-        poll: true,
-      })
+    const unwatch = watchContractEvent(publicClient, {
+      abi: usdcContractConfig.abi,
+      onLogs: (logs_) => {
+        assertType<typeof logs_[0]['args']>({
+          owner: '0x',
+          spender: '0x',
+          value: 0n,
+        })
+        assertType<typeof logs_[0]['args']>({
+          from: '0x',
+          to: '0x',
+          value: 0n,
+        })
+        logs.push(logs_)
+      },
+      poll: true,
+    })
 
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        account: address.vitalik,
-        functionName: 'transfer',
-        args: [address.vitalik, 1n],
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        account: address.vitalik,
-        functionName: 'transfer',
-        args: [address.vitalik, 1n],
-      })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        account: address.vitalik,
-        functionName: 'approve',
-        args: [address.vitalik, 1n],
-      })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'transfer',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      account: address.vitalik,
+      functionName: 'approve',
+      args: [address.vitalik, 1n],
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
+    unwatch()
 
-      await wait(2000)
-      unwatch()
+    expect(logs.length).toBe(2)
+    expect(logs[0].length).toBe(2)
+    expect(logs[1].length).toBe(1)
 
-      expect(logs.length).toBe(2)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-
-      expect(logs[0][0].args).toEqual({
-        from: getAddress(address.vitalik),
-        to: getAddress(address.vitalik),
-        value: 1n,
-      })
-      expect(logs[0][0].eventName).toEqual('Transfer')
-      expect(logs[0][1].args).toEqual({
-        from: getAddress(address.vitalik),
-        to: getAddress(address.vitalik),
-        value: 1n,
-      })
-      expect(logs[0][1].eventName).toEqual('Transfer')
-      expect(logs[1][0].args).toEqual({
-        owner: getAddress(address.vitalik),
-        spender: getAddress(address.vitalik),
-        value: 1n,
-      })
-      expect(logs[1][0].eventName).toEqual('Approval')
-    },
-    { retry: 3 },
-  )
+    expect(logs[0][0].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(address.vitalik),
+      value: 1n,
+    })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][1].args).toEqual({
+      from: getAddress(address.vitalik),
+      to: getAddress(address.vitalik),
+      value: 1n,
+    })
+    expect(logs[0][1].eventName).toEqual('Transfer')
+    expect(logs[1][0].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(address.vitalik),
+      value: 1n,
+    })
+    expect(logs[1][0].eventName).toEqual('Approval')
+  })
 
   test('args: batch', async () => {
     const logs: WatchContractEventOnLogsParameter[] = []
@@ -148,15 +145,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(3)
@@ -196,15 +194,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -251,15 +250,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -300,15 +300,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -355,15 +356,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -420,15 +422,16 @@ describe('poll', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -449,134 +452,122 @@ describe('poll', () => {
   })
 
   describe('`getLogs` fallback', () => {
-    test(
-      'falls back to `getLogs` if `createContractEventFilter` throws',
-      async () => {
-        // TODO: Something weird going on where the `getFilterChanges` spy is taking
-        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-        await wait(1)
-        const getFilterChangesSpy = vi.spyOn(
-          getFilterChanges,
-          'getFilterChanges',
-        )
-        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-        vi.spyOn(
-          createContractEventFilter,
-          'createContractEventFilter',
-        ).mockRejectedValueOnce(new Error('foo'))
+    test('falls back to `getLogs` if `createContractEventFilter` throws', async () => {
+      // TODO: Something weird going on where the `getFilterChanges` spy is taking
+      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+      await wait(1)
+      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
+      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+      vi.spyOn(
+        createContractEventFilter,
+        'createContractEventFilter',
+      ).mockRejectedValueOnce(new Error('foo'))
 
-        const logs: WatchContractEventOnLogsParameter[] = []
+      const logs: WatchContractEventOnLogsParameter[] = []
 
-        const unwatch = watchContractEvent(publicClient, {
-          abi: usdcContractConfig.abi,
-          onLogs: (logs_) => logs.push(logs_),
-          poll: true,
-        })
+      const unwatch = watchContractEvent(publicClient, {
+        abi: usdcContractConfig.abi,
+        onLogs: (logs_) => logs.push(logs_),
+        poll: true,
+      })
 
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[1].address, 1n],
-          account: address.vitalik,
-        })
-        await wait(2000)
-        unwatch()
+      await wait(100)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[1].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      unwatch()
 
-        expect(logs.length).toBe(2)
-        expect(logs[0].length).toBe(2)
-        expect(logs[1].length).toBe(1)
-        expect(getFilterChangesSpy).toBeCalledTimes(0)
-        expect(getLogsSpy).toBeCalled()
-      },
-      { retry: 3 },
-    )
+      expect(logs.length).toBe(2)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+      expect(getFilterChangesSpy).toBeCalledTimes(0)
+      expect(getLogsSpy).toBeCalled()
+    })
 
-    test(
-      'missed blocks',
-      async () => {
-        // TODO: Something weird going on where the `getFilterChanges` spy is taking
-        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-        await wait(1)
-        const getFilterChangesSpy = vi.spyOn(
-          getFilterChanges,
-          'getFilterChanges',
-        )
-        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-        vi.spyOn(
-          createContractEventFilter,
-          'createContractEventFilter',
-        ).mockRejectedValueOnce(new Error('foo'))
+    test('missed blocks', async () => {
+      // TODO: Something weird going on where the `getFilterChanges` spy is taking
+      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+      await wait(1)
+      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
+      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+      vi.spyOn(
+        createContractEventFilter,
+        'createContractEventFilter',
+      ).mockRejectedValueOnce(new Error('foo'))
 
-        const logs: WatchContractEventOnLogsParameter[] = []
+      const logs: WatchContractEventOnLogsParameter[] = []
 
-        const unwatch = watchContractEvent(publicClient, {
-          abi: usdcContractConfig.abi,
-          onLogs: (logs_) => logs.push(logs_),
-          poll: true,
-        })
+      const unwatch = watchContractEvent(publicClient, {
+        abi: usdcContractConfig.abi,
+        onLogs: (logs_) => logs.push(logs_),
+        poll: true,
+      })
 
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[1].address, 1n],
-          account: address.usdcHolder,
-        })
-        await mine(testClient, { blocks: 1 })
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await mine(testClient, { blocks: 2 })
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await mine(testClient, { blocks: 5 })
-        await wait(2000)
-        unwatch()
+      await wait(100)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[1].address, 1n],
+        account: address.usdcHolder,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 2 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 5 })
+      await wait(200)
+      unwatch()
 
-        expect(logs.length).toBe(3)
-        expect(logs[0].length).toBe(2)
-        expect(logs[1].length).toBe(1)
-        expect(logs[2].length).toBe(2)
-        expect(getFilterChangesSpy).toBeCalledTimes(0)
-        expect(getLogsSpy).toBeCalled()
-      },
-      { retry: 3 },
-    )
+      expect(logs.length).toBe(3)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+      expect(logs[2].length).toBe(2)
+      expect(getFilterChangesSpy).toBeCalledTimes(0)
+      expect(getLogsSpy).toBeCalled()
+    })
   })
 
   describe('errors', () => {
@@ -602,27 +593,23 @@ describe('poll', () => {
       unwatch()
     })
 
-    test(
-      'handles error thrown from filter changes',
-      async () => {
-        vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-          new Error('bar'),
-        )
+    test('handles error thrown from filter changes', async () => {
+      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+        new Error('bar'),
+      )
 
-        let unwatch: () => void = () => null
-        const error = await new Promise((resolve) => {
-          unwatch = watchContractEvent(publicClient, {
-            ...usdcContractConfig,
-            onLogs: () => null,
-            onError: resolve,
-            poll: true,
-          })
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchContractEvent(publicClient, {
+          ...usdcContractConfig,
+          onLogs: () => null,
+          onError: resolve,
+          poll: true,
         })
-        expect(error).toMatchInlineSnapshot('[Error: bar]')
-        unwatch()
-      },
-      { retry: 3 },
-    )
+      })
+      expect(error).toMatchInlineSnapshot('[Error: bar]')
+      unwatch()
+    })
 
     test('re-initializes the filter if the active filter uninstalls', async () => {
       const filterCreator = vi.spyOn(
@@ -686,21 +673,23 @@ describe('subscribe', () => {
         },
       })
 
-      await wait(1000)
+      await wait(100)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         account: address.vitalik,
         functionName: 'transfer',
         args: [address.vitalik, 1n],
       })
-      await wait(1000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
       await writeContract(walletClient, {
         ...usdcContractConfig,
         account: address.vitalik,
         functionName: 'approve',
         args: [address.vitalik, 1n],
       })
-      await wait(2000)
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
 
       unwatch()
 
@@ -753,15 +742,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [address.vitalik, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -806,15 +796,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -853,15 +844,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -906,15 +898,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -969,15 +962,16 @@ describe('subscribe', () => {
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       account: address.vitalik,
       functionName: 'approve',
       args: [address.vitalik, 1n],
     })
-
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -1042,7 +1036,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
 
       unwatch_unstrict()
       unwatch_strict()
@@ -1096,7 +1090,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
 
       unwatch_unstrict()
       unwatch_strict()

--- a/src/actions/public/watchEvent.test.ts
+++ b/src/actions/public/watchEvent.test.ts
@@ -116,45 +116,43 @@ beforeAll(async () => {
 })
 
 describe('poll', () => {
-  test(
-    'default',
-    async () => {
-      const logs: WatchEventOnLogsParameter[] = []
+  test('default', async () => {
+    const logs: WatchEventOnLogsParameter[] = []
 
-      const unwatch = watchEvent(publicClient, {
-        onLogs: (logs_) => logs.push(logs_),
-        poll: true,
-      })
+    const unwatch = watchEvent(publicClient, {
+      onLogs: (logs_) => logs.push(logs_),
+      poll: true,
+    })
 
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[0].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'transfer',
-        args: [accounts[1].address, 1n],
-        account: address.vitalik,
-      })
-      await wait(2000)
-      unwatch()
+    await wait(200)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[0].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'transfer',
+      args: [accounts[1].address, 1n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
+    unwatch()
 
-      expect(logs.length).toBe(2)
-      expect(logs[0].length).toBe(2)
-      expect(logs[1].length).toBe(1)
-    },
-    { retry: 3 },
-  )
+    expect(logs.length).toBe(2)
+    expect(logs[0].length).toBe(2)
+    expect(logs[1].length).toBe(1)
+  })
 
   test('args: batch', async () => {
     const logs: WatchEventOnLogsParameter[] = []
@@ -165,7 +163,7 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -178,14 +176,16 @@ describe('poll', () => {
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(3)
@@ -209,14 +209,15 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -241,14 +242,15 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -276,7 +278,7 @@ describe('poll', () => {
       poll: true,
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -290,7 +292,7 @@ describe('poll', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(1)
@@ -311,181 +313,166 @@ describe('poll', () => {
     })
   })
 
-  test(
-    'args: events',
-    async () => {
-      const logs: WatchEventOnLogsParameter<
-        undefined,
-        [typeof event.transfer, typeof event.approval]
-      >[] = []
+  test('args: events', async () => {
+    const logs: WatchEventOnLogsParameter<
+      undefined,
+      [typeof event.transfer, typeof event.approval]
+    >[] = []
 
-      const unwatch = watchEvent(publicClient, {
-        events: [event.transfer, event.approval],
-        onLogs: (logs_) => logs.push(logs_),
-        poll: true,
-      })
+    const unwatch = watchEvent(publicClient, {
+      events: [event.transfer, event.approval],
+      onLogs: (logs_) => logs.push(logs_),
+      poll: true,
+    })
 
-      await wait(1000)
-      await writeContract(walletClient, {
-        ...wagmiContractConfig,
-        functionName: 'mint',
-        account: address.vitalik,
-      })
-      await writeContract(walletClient, {
-        ...usdcContractConfig,
-        functionName: 'approve',
-        args: [accounts[1].address, 2n],
-        account: address.vitalik,
-      })
-      await mine(testClient, { blocks: 1 })
-      await wait(2000)
-      unwatch()
+    await wait(100)
+    await writeContract(walletClient, {
+      ...wagmiContractConfig,
+      functionName: 'mint',
+      account: address.vitalik,
+    })
+    await writeContract(walletClient, {
+      ...usdcContractConfig,
+      functionName: 'approve',
+      args: [accounts[1].address, 2n],
+      account: address.vitalik,
+    })
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
+    unwatch()
 
-      expect(logs.length).toBe(1)
-      expect(logs[0].length).toBe(2)
+    expect(logs.length).toBe(1)
+    expect(logs[0].length).toBe(2)
 
-      expect(logs[0][0].eventName).toEqual('Transfer')
-      expect(logs[0][0].args).toEqual({
-        from: address.burn,
-        to: getAddress(address.vitalik),
-      })
+    expect(logs[0][0].eventName).toEqual('Transfer')
+    expect(logs[0][0].args).toEqual({
+      from: address.burn,
+      to: getAddress(address.vitalik),
+    })
 
-      expect(logs[0][1].eventName).toEqual('Approval')
-      expect(logs[0][1].args).toEqual({
-        owner: getAddress(address.vitalik),
-        spender: getAddress(accounts[1].address),
-        value: 2n,
-      })
-    },
-    { retry: 3 },
-  )
+    expect(logs[0][1].eventName).toEqual('Approval')
+    expect(logs[0][1].args).toEqual({
+      owner: getAddress(address.vitalik),
+      spender: getAddress(accounts[1].address),
+      value: 2n,
+    })
+  })
 
   test.todo('args: args')
 
   describe('`getLogs` fallback', () => {
-    test(
-      'falls back to `getLogs` if `createEventFilter` throws',
-      async () => {
-        // Something weird going on where the `getFilterChanges` spy is taking
-        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-        await wait(1)
-        const getFilterChangesSpy = vi.spyOn(
-          getFilterChanges,
-          'getFilterChanges',
-        )
-        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-        vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
-          new Error('foo'),
-        )
+    test('falls back to `getLogs` if `createEventFilter` throws', async () => {
+      // Something weird going on where the `getFilterChanges` spy is taking
+      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+      await wait(1)
+      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
+      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+      vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
+        new Error('foo'),
+      )
 
-        const logs: WatchEventOnLogsParameter[] = []
+      const logs: WatchEventOnLogsParameter[] = []
 
-        const unwatch = watchEvent(publicClient, {
-          onLogs: (logs_) => logs.push(logs_),
-          poll: true,
-        })
+      const unwatch = watchEvent(publicClient, {
+        onLogs: (logs_) => logs.push(logs_),
+        poll: true,
+      })
 
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await wait(2000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[1].address, 1n],
-          account: address.vitalik,
-        })
-        await wait(2000)
-        unwatch()
+      await wait(100)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[1].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      unwatch()
 
-        expect(logs.length).toBe(2)
-        expect(logs[0].length).toBe(2)
-        expect(logs[1].length).toBe(1)
-        expect(getFilterChangesSpy).toBeCalledTimes(0)
-        expect(getLogsSpy).toBeCalled()
-      },
-      { retry: 3 },
-    )
+      expect(logs.length).toBe(2)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+      expect(getFilterChangesSpy).toBeCalledTimes(0)
+      expect(getLogsSpy).toBeCalled()
+    })
 
-    test(
-      'missed blocks',
-      async () => {
-        // Something weird going on where the `getFilterChanges` spy is taking
-        // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
-        await wait(1)
-        const getFilterChangesSpy = vi.spyOn(
-          getFilterChanges,
-          'getFilterChanges',
-        )
-        const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
-        vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
-          new Error('foo'),
-        )
+    test('missed blocks', async () => {
+      // Something weird going on where the `getFilterChanges` spy is taking
+      // results of the previous test. This `wait` fixes it. ¯\_(ツ)_/¯
+      await wait(1)
+      const getFilterChangesSpy = vi.spyOn(getFilterChanges, 'getFilterChanges')
+      const getLogsSpy = vi.spyOn(getLogs, 'getLogs')
+      vi.spyOn(createEventFilter, 'createEventFilter').mockRejectedValueOnce(
+        new Error('foo'),
+      )
 
-        const logs: WatchEventOnLogsParameter[] = []
+      const logs: WatchEventOnLogsParameter[] = []
 
-        const unwatch = watchEvent(publicClient, {
-          onLogs: (logs_) => logs.push(logs_),
-          poll: true,
-        })
+      const unwatch = watchEvent(publicClient, {
+        onLogs: (logs_) => logs.push(logs_),
+        poll: true,
+      })
 
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[0].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[1].address, 1n],
-          account: address.usdcHolder,
-        })
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await mine(testClient, { blocks: 2 })
-        await wait(1000)
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await writeContract(walletClient, {
-          ...usdcContractConfig,
-          functionName: 'transfer',
-          args: [accounts[2].address, 1n],
-          account: address.vitalik,
-        })
-        await mine(testClient, { blocks: 5 })
-        await wait(2000)
-        unwatch()
+      await wait(100)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[0].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[1].address, 1n],
+        account: address.usdcHolder,
+      })
+      await mine(testClient, { blocks: 1 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 2 })
+      await wait(200)
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await writeContract(walletClient, {
+        ...usdcContractConfig,
+        functionName: 'transfer',
+        args: [accounts[2].address, 1n],
+        account: address.vitalik,
+      })
+      await mine(testClient, { blocks: 5 })
+      await wait(200)
+      unwatch()
 
-        expect(logs.length).toBe(3)
-        expect(logs[0].length).toBe(2)
-        expect(logs[1].length).toBe(1)
-        expect(logs[2].length).toBe(2)
-        expect(getFilterChangesSpy).toBeCalledTimes(0)
-        expect(getLogsSpy).toBeCalled()
-      },
-      { retry: 3 },
-    )
+      expect(logs.length).toBe(3)
+      expect(logs[0].length).toBe(2)
+      expect(logs[1].length).toBe(1)
+      expect(logs[2].length).toBe(2)
+      expect(getFilterChangesSpy).toBeCalledTimes(0)
+      expect(getLogsSpy).toBeCalled()
+    })
   })
 
   describe('errors', () => {
@@ -509,26 +496,22 @@ describe('poll', () => {
       unwatch()
     })
 
-    test(
-      'handles error thrown from filter changes',
-      async () => {
-        vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
-          new Error('bar'),
-        )
+    test('handles error thrown from filter changes', async () => {
+      vi.spyOn(getFilterChanges, 'getFilterChanges').mockRejectedValueOnce(
+        new Error('bar'),
+      )
 
-        let unwatch: () => void = () => null
-        const error = await new Promise((resolve) => {
-          unwatch = watchEvent(publicClient, {
-            onLogs: () => null,
-            onError: resolve,
-            poll: true,
-          })
+      let unwatch: () => void = () => null
+      const error = await new Promise((resolve) => {
+        unwatch = watchEvent(publicClient, {
+          onLogs: () => null,
+          onError: resolve,
+          poll: true,
         })
-        expect(error).toMatchInlineSnapshot('[Error: bar]')
-        unwatch()
-      },
-      { retry: 3 },
-    )
+      })
+      expect(error).toMatchInlineSnapshot('[Error: bar]')
+      unwatch()
+    })
 
     test('re-initializes the filter if the active filter uninstalls', async () => {
       const filterCreator = vi.spyOn(createEventFilter, 'createEventFilter')
@@ -572,21 +555,23 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(1000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[1].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -605,14 +590,15 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs2.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
       args: [accounts[0].address, 1n],
       account: address.vitalik,
     })
-    await wait(2000)
+    await mine(testClient, { blocks: 1 })
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -635,7 +621,7 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs2.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -643,7 +629,7 @@ describe('subscribe', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
     unwatch2()
 
@@ -670,7 +656,7 @@ describe('subscribe', () => {
       onLogs: (logs_) => logs.push(logs_),
     })
 
-    await wait(1000)
+    await wait(100)
     await writeContract(walletClient, {
       ...usdcContractConfig,
       functionName: 'transfer',
@@ -684,7 +670,7 @@ describe('subscribe', () => {
       account: address.vitalik,
     })
     await mine(testClient, { blocks: 1 })
-    await wait(2000)
+    await wait(200)
     unwatch()
 
     expect(logs.length).toBe(2)
@@ -717,7 +703,7 @@ describe('subscribe', () => {
         onLogs: (logs_) => logs.push(logs_),
       })
 
-      await wait(1000)
+      await wait(100)
       await writeContract(walletClient, {
         ...wagmiContractConfig,
         functionName: 'mint',
@@ -730,7 +716,7 @@ describe('subscribe', () => {
         account: address.vitalik,
       })
       await mine(testClient, { blocks: 1 })
-      await wait(1000)
+      await wait(200)
       unwatch()
 
       expect(logs.length).toBe(2)
@@ -837,7 +823,7 @@ describe('subscribe', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 1 })
-        await wait(1000)
+        await wait(200)
 
         unwatch_unstrict()
         unwatch_strict()
@@ -885,7 +871,7 @@ describe('subscribe', () => {
           account: address.vitalik,
         })
         await mine(testClient, { blocks: 1 })
-        await wait(1000)
+        await wait(200)
 
         unwatch_unstrict()
         unwatch_strict()

--- a/src/actions/public/watchPendingTransactions.test.ts
+++ b/src/actions/public/watchPendingTransactions.test.ts
@@ -11,7 +11,6 @@ import type { PublicClient } from '../../clients/createPublicClient.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 import { wait } from '../../utils/wait.js'
 import { mine } from '../test/mine.js'
-import { setIntervalMining } from '../test/setIntervalMining.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import * as createPendingTransactionFilter from './createPendingTransactionFilter.js'
@@ -25,7 +24,6 @@ describe('poll', () => {
   test(
     'watches for pending transactions',
     async () => {
-      await setIntervalMining(testClient, { interval: 0 })
       await wait(1000)
 
       let transactions: OnTransactionsParameter = []
@@ -51,14 +49,12 @@ describe('poll', () => {
       unwatch()
       expect(transactions.length).toBe(2)
 
-      await setIntervalMining(testClient, { interval: 1 })
       await mine(testClient, { blocks: 1 })
     },
     { timeout: 10_000 },
   )
 
   test('watches for pending transactions (unbatched)', async () => {
-    await setIntervalMining(testClient, { interval: 0 })
     await wait(1000)
 
     let transactions: OnTransactionsParameter = []
@@ -90,7 +86,6 @@ describe('poll', () => {
     unwatch()
     expect(transactions.length).toBe(3)
 
-    await setIntervalMining(testClient, { interval: 1 })
     await mine(testClient, { blocks: 1 })
   })
 
@@ -136,7 +131,6 @@ describe('subscribe', () => {
   test(
     'watches for pending transactions',
     async () => {
-      await setIntervalMining(testClient, { interval: 0 })
       await wait(1000)
 
       let transactions: OnTransactionsParameter = []
@@ -161,7 +155,6 @@ describe('subscribe', () => {
       unwatch()
       expect(transactions.length).toBe(2)
 
-      await setIntervalMining(testClient, { interval: 1 })
       await mine(testClient, { blocks: 1 })
     },
     { timeout: 10_000 },

--- a/src/actions/test/dropTransaction.test.ts
+++ b/src/actions/test/dropTransaction.test.ts
@@ -8,14 +8,11 @@ import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { dropTransaction } from './dropTransaction.js'
 import { mine } from './mine.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 const sourceAccount = accounts[0]
 const targetAccount = accounts[1]
 
 test('drops transaction', async () => {
-  await setIntervalMining(testClient, { interval: 0 })
-
   const balance = await getBalance(publicClient, {
     address: sourceAccount.address,
   })
@@ -31,6 +28,4 @@ test('drops transaction', async () => {
       address: sourceAccount.address,
     }),
   ).not.toBeLessThan(balance)
-
-  await setIntervalMining(testClient, { interval: 1 })
 })

--- a/src/actions/test/impersonateAccount.test.ts
+++ b/src/actions/test/impersonateAccount.test.ts
@@ -6,6 +6,7 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { sendTransaction } from '../wallet/sendTransaction.js'
 
 import { impersonateAccount } from './impersonateAccount.js'
+import { stopImpersonatingAccount } from './stopImpersonatingAccount.js'
 
 test('impersonates account', async () => {
   await expect(
@@ -27,4 +28,6 @@ test('impersonates account', async () => {
       value: parseEther('1'),
     }),
   ).toBeDefined()
+
+  await stopImpersonatingAccount(testClient, { address: address.vitalik })
 })

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -6,8 +6,11 @@ import { getBlock } from '../public/getBlock.js'
 
 import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
+import { setIntervalMining } from './setIntervalMining.js'
 
 test('removes block timestamp interval', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   let interval = 86400
   await expect(
     setBlockTimestampInterval(testClient, { interval }),

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -25,4 +25,6 @@ test('removes block timestamp interval', async () => {
   await wait(1000)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + BigInt(interval))
+
+  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/removeBlockTimestampInterval.test.ts
+++ b/src/actions/test/removeBlockTimestampInterval.test.ts
@@ -4,27 +4,25 @@ import { publicClient, testClient } from '../../_test/utils.js'
 import { wait } from '../../utils/wait.js'
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { removeBlockTimestampInterval } from './removeBlockTimestampInterval.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('removes block timestamp interval', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
-
   let interval = 86400
   await expect(
     setBlockTimestampInterval(testClient, { interval }),
   ).resolves.toBeUndefined()
   const block1 = await getBlock(publicClient, { blockTag: 'latest' })
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + BigInt(interval))
 
   await removeBlockTimestampInterval(testClient)
   interval = 1
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + BigInt(interval))
-
-  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/reset.test.ts
+++ b/src/actions/test/reset.test.ts
@@ -6,10 +6,8 @@ import { getBlockNumber } from '../public/getBlockNumber.js'
 
 import { mine } from './mine.js'
 import { reset } from './reset.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('resets the fork', async () => {
-  await setIntervalMining(testClient, { interval: 0 })
   await mine(testClient, { blocks: 10 })
   await expect(
     reset(testClient, {
@@ -17,6 +15,5 @@ test('resets the fork', async () => {
     }),
   ).resolves.toBeUndefined()
   expect(await getBlockNumber(publicClient)).toBe(forkBlockNumber)
-  await setIntervalMining(testClient, { interval: 1 })
   await mine(testClient, { blocks: 1 })
 })

--- a/src/actions/test/sendUnsignedTransaction.test.ts
+++ b/src/actions/test/sendUnsignedTransaction.test.ts
@@ -16,7 +16,7 @@ import { setBalance } from './setBalance.js'
 const sourceAccount = {
   address: address.vitalik,
 } as const
-const targetAccount = accounts[0]
+const targetAccount = accounts[9]
 
 test('sends unsigned transaction', async () => {
   await setBalance(testClient, {

--- a/src/actions/test/setBlockGasLimit.test.ts
+++ b/src/actions/test/setBlockGasLimit.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setBlockGasLimit } from './setBlockGasLimit.js'
 
 test('sets block gas limit', async () => {
@@ -17,7 +17,9 @@ test('sets block gas limit', async () => {
       gasLimit: block1.gasLimit + parseGwei('10'),
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.gasLimit).toEqual(block1.gasLimit + parseGwei('10'))
   await setBlockGasLimit(testClient, { gasLimit: block1.gasLimit })

--- a/src/actions/test/setBlockTimestampInterval.test.ts
+++ b/src/actions/test/setBlockTimestampInterval.test.ts
@@ -4,23 +4,23 @@ import { publicClient, testClient } from '../../_test/utils.js'
 import { wait } from '../../utils/wait.js'
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setBlockTimestampInterval } from './setBlockTimestampInterval.js'
-import { setIntervalMining } from './setIntervalMining.js'
 
 test('sets block timestamp interval', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
   await expect(
     setBlockTimestampInterval(testClient, { interval: 86400 }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)
-  await wait(1000)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + 86400n)
   await setBlockTimestampInterval(testClient, { interval: 1 })
-  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/setBlockTimestampInterval.test.ts
+++ b/src/actions/test/setBlockTimestampInterval.test.ts
@@ -22,4 +22,5 @@ test('sets block timestamp interval', async () => {
   const block3 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block3.timestamp).toEqual(block2.timestamp + 86400n)
   await setBlockTimestampInterval(testClient, { interval: 1 })
+  await setIntervalMining(testClient, { interval: 0 })
 })

--- a/src/actions/test/setIntervalMining.test.ts
+++ b/src/actions/test/setIntervalMining.test.ts
@@ -27,6 +27,4 @@ test('sets mining interval', async () => {
   await wait(2000)
   const blockNumber4 = await getBlockNumber(publicClient, { cacheTime: 0 })
   expect(blockNumber4 - blockNumber3).toBe(0n)
-
-  await setIntervalMining(testClient, { interval: 1 })
 })

--- a/src/actions/test/setNextBlockBaseFeePerGas.test.ts
+++ b/src/actions/test/setNextBlockBaseFeePerGas.test.ts
@@ -2,10 +2,10 @@ import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setNextBlockBaseFeePerGas } from './setNextBlockBaseFeePerGas.js'
 
 test('set next block base fee per gas', async () => {
@@ -17,7 +17,9 @@ test('set next block base fee per gas', async () => {
       baseFeePerGas: block1.baseFeePerGas! + parseGwei('10'),
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.baseFeePerGas).toEqual(block1.baseFeePerGas! + parseGwei('10'))
   await setNextBlockBaseFeePerGas(testClient, {

--- a/src/actions/test/setNextBlockTimestamp.test.ts
+++ b/src/actions/test/setNextBlockTimestamp.test.ts
@@ -1,13 +1,15 @@
 import { expect, test } from 'vitest'
 
 import { publicClient, testClient } from '../../_test/utils.js'
-import { wait } from '../../utils/wait.js'
 
 import { getBlock } from '../public/getBlock.js'
 
+import { mine } from './mine.js'
 import { setNextBlockTimestamp } from './setNextBlockTimestamp.js'
 
 test('sets block timestamp interval', async () => {
+  await mine(testClient, { blocks: 1 })
+
   const block1 = await getBlock(publicClient, {
     blockTag: 'latest',
   })
@@ -16,7 +18,9 @@ test('sets block timestamp interval', async () => {
       timestamp: block1.timestamp + 86400n,
     }),
   ).resolves.toBeUndefined()
-  await wait(1000)
+
+  await mine(testClient, { blocks: 1 })
+
   const block2 = await getBlock(publicClient, { blockTag: 'latest' })
   expect(block2.timestamp).toEqual(block1.timestamp + 86400n)
 })

--- a/src/actions/wallet/getAddresses.test.ts
+++ b/src/actions/wallet/getAddresses.test.ts
@@ -5,7 +5,9 @@ import { walletClient } from '../../_test/utils.js'
 import { getAddresses } from './getAddresses.js'
 
 test('default', async () => {
-  expect(await getAddresses(walletClient!)).toMatchInlineSnapshot(`
+  expect(
+    (await getAddresses(walletClient!)).slice(0, 10),
+  ).toMatchInlineSnapshot(`
     [
       "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
       "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -213,14 +213,16 @@ describe('prepareTransactionRequest', () => {
   test('args: gasPrice (on chain w/ block.baseFeePerGas)', async () => {
     await setup()
 
-    expect(
-      await prepareTransactionRequest(walletClient, {
+    const { nonce: _nonce, ...request } = await prepareTransactionRequest(
+      walletClient,
+      {
         account: privateKeyToAccount(sourceAccount.privateKey),
         to: targetAccount.address,
         gasPrice: parseGwei('10'),
         value: parseEther('1'),
-      }),
-    ).toMatchInlineSnapshot(`
+      },
+    )
+    expect(request).toMatchInlineSnapshot(`
       {
         "account": {
           "address": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
@@ -234,7 +236,6 @@ describe('prepareTransactionRequest', () => {
         "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
         "gas": 21000n,
         "gasPrice": 10000000000n,
-        "nonce": 375,
         "to": "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
         "type": "legacy",
         "value": 1000000000000000000n,
@@ -416,21 +417,9 @@ describe('prepareTransactionRequest', () => {
         maxFeePerGas: parseGwei('20'),
         value: parseEther('1'),
       }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`
-      "Cannot specify both a \`gasPrice\` and a \`maxFeePerGas\`/\`maxPriorityFeePerGas\`.
-      Use \`maxFeePerGas\`/\`maxPriorityFeePerGas\` for EIP-1559 compatible networks, and \`gasPrice\` for others.
-
-      Estimate Gas Arguments:
-        from:                  0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-        to:                    0x70997970c51812dc3a010c7d01b50e0d17dc79c8
-        value:                 1 ETH
-        gasPrice:              10 gwei
-        maxFeePerGas:          20 gwei
-        maxPriorityFeePerGas:  18.5 gwei
-        nonce:                 375
-
-      Version: viem@1.0.2"
-    `)
+    ).rejects.toThrowError(
+      'Cannot specify both a `gasPrice` and a `maxFeePerGas`/`maxPriorityFeePerGas`.',
+    )
   })
 
   test('args: gasPrice + maxPriorityFeePerGas', async () => {

--- a/src/actions/wallet/sendTransaction.test.ts
+++ b/src/actions/wallet/sendTransaction.test.ts
@@ -317,7 +317,7 @@ describe('args: gasPrice', () => {
         account: sourceAccount.address,
         to: targetAccount.address,
         value: parseEther('1'),
-        gasPrice: BigInt(block.baseFeePerGas ?? 0),
+        gasPrice: BigInt((block.baseFeePerGas ?? 0n) * 2n),
       }),
     ).toBeDefined()
 
@@ -386,7 +386,7 @@ describe('args: maxFeePerGas', () => {
       account: sourceAccount.address,
       to: targetAccount.address,
       value: parseEther('1'),
-      maxFeePerGas: BigInt(block.baseFeePerGas ?? 0),
+      maxFeePerGas: BigInt((block.baseFeePerGas ?? 0n) * 2n),
     })
     expect(hash).toBeDefined()
 
@@ -400,7 +400,9 @@ describe('args: maxFeePerGas', () => {
     ).toBeLessThan(sourceAccount.balance)
 
     const transaction = await getTransaction(publicClient, { hash })
-    expect(transaction.maxFeePerGas).toBe(block.baseFeePerGas!)
+    expect(transaction.maxFeePerGas).toBe(
+      BigInt((block.baseFeePerGas ?? 0n) * 2n),
+    )
   })
 
   test('errors when account has insufficient funds', async () => {

--- a/src/actions/wallet/signTransaction.test.ts
+++ b/src/actions/wallet/signTransaction.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import { accounts, localHttpUrl } from '../../_test/constants.js'
-import { walletClient } from '../../_test/utils.js'
+import { testClient, walletClient } from '../../_test/utils.js'
 import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
 import { celo, mainnet } from '../../chains/index.js'
 import {
@@ -13,6 +13,7 @@ import {
   createWalletClient,
   parseGwei,
 } from '../../index.js'
+import { mine } from '../index.js'
 import { prepareTransactionRequest } from './prepareTransactionRequest.js'
 import { signTransaction } from './signTransaction.js'
 
@@ -52,12 +53,16 @@ describe('eip1559', () => {
   })
 
   test('w/ prepareTransactionRequest', async () => {
+    await mine(testClient, { blocks: 1 })
+
     const request_1 = await prepareTransactionRequest(walletClient, {
       account: privateKeyToAccount(sourceAccount.privateKey),
       value: 1n,
     })
     const signature_1 = await signTransaction(walletClient, request_1)
     expect(signature_1.match(/^0x02/)).toBeTruthy()
+
+    await mine(testClient, { blocks: 1 })
 
     const request_2 = await prepareTransactionRequest(walletClient, {
       account: privateKeyToAccount(sourceAccount.privateKey),
@@ -187,6 +192,7 @@ describe('eip2930', () => {
   })
 
   test('w/ prepareTransactionRequest', async () => {
+    await mine(testClient, { blocks: 1 })
     const request = await prepareTransactionRequest(walletClient, {
       account: privateKeyToAccount(sourceAccount.privateKey),
       value: 1n,
@@ -275,6 +281,7 @@ describe('legacy', () => {
   })
 
   test('w/ prepareTransactionRequest', async () => {
+    await mine(testClient, { blocks: 1 })
     const request = await prepareTransactionRequest(walletClient, {
       account: privateKeyToAccount(sourceAccount.privateKey),
       value: 1n,

--- a/src/clients/decorators/public.test.ts
+++ b/src/clients/decorators/public.test.ts
@@ -21,6 +21,7 @@ import { getBlockNumber } from '../../actions/public/getBlockNumber.js'
 import { parseEther } from '../../utils/unit/parseEther.js'
 
 import { privateKeyToAccount } from '../../accounts/privateKeyToAccount.js'
+import { wait } from '../../utils/wait.js'
 import { publicActions } from './public.js'
 
 test('default', async () => {
@@ -416,6 +417,8 @@ describe('smoke test', () => {
       to: accounts[7].address,
       value: parseEther('1'),
     })
+    await testClient.mine({ blocks: 1 })
+    await wait(200)
     const { status } = await publicClient.waitForTransactionReceipt({
       hash,
     })

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -165,7 +165,9 @@ describe('smoke test', () => {
     await testClient.setIntervalMining({
       interval: 1,
     })
-    await testClient.setIntervalMining({ interval: 0 })
+    await testClient.setIntervalMining({
+      interval: 0,
+    })
   })
 
   test('setLoggingEnabled', async () => {

--- a/src/clients/decorators/test.test.ts
+++ b/src/clients/decorators/test.test.ts
@@ -165,6 +165,7 @@ describe('smoke test', () => {
     await testClient.setIntervalMining({
       interval: 1,
     })
+    await testClient.setIntervalMining({ interval: 0 })
   })
 
   test('setLoggingEnabled', async () => {

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -6,6 +6,8 @@ import { localWsUrl } from '../../_test/constants.js'
 import { localhost } from '../../chains/index.js'
 import { wait } from '../../utils/wait.js'
 
+import { testClient } from '../../_test/utils.js'
+import { setIntervalMining } from '../../test.js'
 import { type WebSocketTransport, webSocket } from './webSocket.js'
 
 test('default', () => {
@@ -141,6 +143,8 @@ test('errors: rpc error', async () => {
 })
 
 test('subscribe', async () => {
+  await setIntervalMining(testClient, { interval: 1 })
+
   const transport = webSocket(localWsUrl, {
     key: 'jsonRpc',
     name: 'JSON RPC',

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -171,6 +171,8 @@ test('subscribe', async () => {
   // Make sure we are no longer receiving blocks.
   await wait(2000)
   expect(blocks.length).toBe(2)
+
+  await setIntervalMining(testClient, { interval: 0 })
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/clients/transports/webSocket.test.ts
+++ b/src/clients/transports/webSocket.test.ts
@@ -7,7 +7,7 @@ import { localhost } from '../../chains/index.js'
 import { wait } from '../../utils/wait.js'
 
 import { testClient } from '../../_test/utils.js'
-import { setIntervalMining } from '../../test.js'
+import { mine } from '../../test.js'
 import { type WebSocketTransport, webSocket } from './webSocket.js'
 
 test('default', () => {
@@ -143,8 +143,6 @@ test('errors: rpc error', async () => {
 })
 
 test('subscribe', async () => {
-  await setIntervalMining(testClient, { interval: 1 })
-
   const transport = webSocket(localWsUrl, {
     key: 'jsonRpc',
     name: 'JSON RPC',
@@ -161,18 +159,18 @@ test('subscribe', async () => {
   expect(subscriptionId).toBeDefined()
 
   // Make sure we are receiving blocks.
-  await wait(2000)
-  expect(blocks.length).toBe(2)
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
+  expect(blocks.length).toBe(1)
 
   // Make sure we unsubscribe.
   const { result } = await unsubscribe()
   expect(result).toBeDefined()
 
   // Make sure we are no longer receiving blocks.
-  await wait(2000)
-  expect(blocks.length).toBe(2)
-
-  await setIntervalMining(testClient, { interval: 0 })
+  await mine(testClient, { blocks: 1 })
+  await wait(200)
+  expect(blocks.length).toBe(1)
 })
 
 test('throws on bogus subscription', async () => {

--- a/src/types/contract.test-d.ts
+++ b/src/types/contract.test-d.ts
@@ -21,10 +21,13 @@ import type {
   LogTopicType,
 } from './contract.js'
 import type { Hex } from './misc.js'
+import type { Prettify } from './utils.js'
 
 test('ContractFunctionConfig', async () => {
-  type Result = ContractFunctionConfig<typeof seaportAbi, 'getOrderStatus'>
-  //   ^?
+  type Result = Prettify<
+    ContractFunctionConfig<typeof seaportAbi, 'getOrderStatus'>
+    //   ^?
+  >
   expectTypeOf<Result>().toEqualTypeOf<{
     abi: typeof seaportAbi
     address: ResolvedConfig['AddressType']

--- a/src/types/utils.test-d.ts
+++ b/src/types/utils.test-d.ts
@@ -6,6 +6,7 @@ import type {
   IsNever,
   IsUndefined,
   Or,
+  Prettify,
   RequiredBy,
 } from './utils.js'
 
@@ -53,6 +54,6 @@ test('Or', () => {
 
 test('RequiredBy', () => {
   expectTypeOf<
-    RequiredBy<{ a?: number; b?: string; c: boolean }, 'a' | 'c'>
+    Prettify<RequiredBy<{ a?: number; b?: string; c: boolean }, 'a' | 'c'>>
   >().toEqualTypeOf<{ a: number; b?: string; c: boolean }>()
 })

--- a/src/utils/poll.test.ts
+++ b/src/utils/poll.test.ts
@@ -14,7 +14,7 @@ test('polls on a given interval', async () => {
     },
   )
 
-  await wait(500)
+  await wait(450)
   expect(items).toMatchInlineSnapshot(`
     [
       "wagmi",

--- a/src/utils/rpc.test.ts
+++ b/src/utils/rpc.test.ts
@@ -8,8 +8,9 @@ import {
   localHttpUrl,
   localWsUrl,
 } from '../_test/constants.js'
-import { createHttpServer } from '../_test/utils.js'
+import { createHttpServer, testClient } from '../_test/utils.js'
 
+import { mine } from '../test.js'
 import { numberToHex } from './encoding/toHex.js'
 import * as withTimeout from './promise/withTimeout.js'
 import { type RpcResponse, getSocket, rpc } from './rpc.js'
@@ -732,7 +733,13 @@ describe('webSocket (subscription)', () => {
       },
       onResponse: (data) => data_.push(data),
     })
-    await wait(2000)
+
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.subscriptions.size).toBe(1)
     expect(data_.length).toBe(3)
 
@@ -743,7 +750,12 @@ describe('webSocket (subscription)', () => {
       },
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.subscriptions.size).toBe(0)
     expect(data_.length).toBe(3)
   })
@@ -777,7 +789,12 @@ describe('webSocket (subscription)', () => {
       onResponse: (data) => s3.push(data),
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.requests.size).toBe(0)
     expect(socket.subscriptions.size).toBe(3)
     expect(s1.length).toBe(3)
@@ -791,7 +808,12 @@ describe('webSocket (subscription)', () => {
       },
     })
 
-    await wait(2000)
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+    await mine(testClient, { blocks: 1 })
+    await wait(100)
+
     expect(socket.requests.size).toBe(0)
     expect(socket.subscriptions.size).toBe(2)
     expect(s1.length).toBe(3)

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -40,7 +40,7 @@ type Subscription<TResult, TError> = {
   )
 }
 
-export type RpcRequest = { method: string; params?: any }
+export type RpcRequest = { method: string; params?: any; id?: number }
 
 export type RpcResponse<TResult = any, TError = any> = {
   jsonrpc: `${number}`
@@ -82,11 +82,11 @@ async function http<TBody extends RpcRequest | RpcRequest[]>(
             ? stringify(
                 body.map((body) => ({
                   jsonrpc: '2.0',
-                  id: id++,
+                  id: body.id ?? id++,
                   ...body,
                 })),
               )
-            : stringify({ jsonrpc: '2.0', id: id++, ...body }),
+            : stringify({ jsonrpc: '2.0', id: body.id ?? id++, ...body }),
           headers: {
             ...headers,
             'Content-Type': 'application/json',
@@ -144,10 +144,10 @@ export type Socket = WebSocket & {
   subscriptions: CallbackMap
 }
 
-const sockets = /*#__PURE__*/ new Map<string, Socket>()
+export const socketsCache = /*#__PURE__*/ new Map<string, Socket>()
 
 export async function getSocket(url: string) {
-  let socket = sockets.get(url)
+  let socket = socketsCache.get(url)
 
   // If the socket already exists, return it.
   if (socket) return socket
@@ -185,7 +185,7 @@ export async function getSocket(url: string) {
         if (!isSubscription) cache.delete(id)
       }
       const onClose = () => {
-        sockets.delete(url)
+        socketsCache.delete(url)
         webSocket.removeEventListener('close', onClose)
         webSocket.removeEventListener('message', onMessage)
       }
@@ -208,7 +208,7 @@ export async function getSocket(url: string) {
         requests,
         subscriptions,
       })
-      sockets.set(url, socket)
+      socketsCache.set(url, socket)
 
       return [socket]
     },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on optimizing code performance and fixing minor issues. 

### Detailed summary:
- Updated `wait` function in `poll.test.ts` for better timing accuracy.
- Modified `setIntervalMining` function in `testClient` to accept an interval of 0 in `setIntervalMining.test.ts`.
- Updated `node-version` to 20 in `install-dependencies/action.yml`.
- Skipped a test in `call.test.ts` to improve test coverage.
- Updated `globalSetup.ts` to remove unnecessary imports and set `noMining` to true.
- Added `Prettify` type in `utils.test-d.ts`.
- Added `forkBlockNumber` import in `getContract.test.ts`.
- Added `stopImpersonatingAccount` import in `impersonateAccount.test.ts`.
- Added `Prettify` type import in `contract.test-d.ts`.
- Added `wait` import in `public.test.ts`.
- Removed `VITE_NETWORK_TRANSPORT_MODE` from `bench.yml`.
- Updated `getLogs.test.ts`, `getFilterLogs.test.ts`, `getTransactionConfirmations.test.ts`, `reset.test.ts`, `getFilterChanges.test.ts`, `dropTransaction.test.ts`, `getTransaction.test.ts`, `getBlockTransactionCount.test.ts`, `setBlockGasLimit.test.ts`, `setNextBlockTimestamp.test.ts`, and `setNextBlockBaseFeePerGas.test.ts` to include `mine` and `wait` functions for better testing and timing accuracy.

> The following files were skipped due to too many changes: `src/actions/test/setNextBlockBaseFeePerGas.test.ts`, `src/actions/wallet/sendTransaction.test.ts`, `src/clients/transports/webSocket.test.ts`, `.github/workflows/verify.yml`, `src/actions/test/removeBlockTimestampInterval.test.ts`, `src/actions/test/setBlockTimestampInterval.test.ts`, `src/_test/utils.ts`, `src/actions/public/getBlock.test-d.ts`, `src/_test/setup.ts`, `src/actions/public/watchBlockNumber.test.ts`, `src/utils/rpc.ts`, `src/actions/getContract.test-d.ts`, `src/actions/public/watchPendingTransactions.test.ts`, `src/actions/wallet/prepareTransactionRequest.test.ts`, `src/utils/rpc.test.ts`, `src/actions/wallet/signTransaction.test.ts`, `package.json`, `src/actions/public/watchBlocks.test.ts`, `src/actions/public/getTransactionReceipt.test.ts`, `src/actions/public/waitForTransactionReceipt.test.ts`, `src/actions/public/watchEvent.test.ts`, `src/actions/public/watchContractEvent.test.ts`, `pnpm-lock.yaml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->