### PR TITLE
refactor: node errors

### DIFF
--- a/.changeset/big-spies-call.md
+++ b/.changeset/big-spies-call.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where non-standard "user rejected" errors where being coalesced into an `UnknownNodeError`.

--- a/src/actions/public/call.test.ts
+++ b/src/actions/public/call.test.ts
@@ -595,7 +595,7 @@ describe('batch call', () => {
           },
         },
         {
-          "reason": [CallExecutionError: An error occurred.
+          "reason": [CallExecutionError: Execution reverted for an unknown reason.
 
       Raw Call Arguments:
         to:    0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2

--- a/src/errors/node.test.ts
+++ b/src/errors/node.test.ts
@@ -240,8 +240,6 @@ test('UnknownNodeError', () => {
   expect(error).toMatchInlineSnapshot(`
     [UnknownNodeError: An error occurred while executing: foo
 
-    Version: viem@1.0.2
-
     Version: viem@1.0.2]
   `)
 })

--- a/src/errors/node.ts
+++ b/src/errors/node.ts
@@ -216,7 +216,7 @@ export class UnknownNodeError extends BaseError {
   override name = 'UnknownNodeError'
 
   constructor({ cause }: { cause?: BaseError }) {
-    super(`An error occurred while executing: ${cause?.message}`, {
+    super(`An error occurred while executing: ${cause?.shortMessage}`, {
       cause,
     })
   }

--- a/src/utils/errors/getCallError.ts
+++ b/src/utils/errors/getCallError.ts
@@ -1,13 +1,10 @@
 import type { CallParameters } from '../../actions/public/call.js'
 import type { BaseError } from '../../errors/base.js'
 import { CallExecutionError } from '../../errors/contract.js'
+import { UnknownNodeError } from '../../errors/node.js'
 import type { Chain } from '../../types/chain.js'
 
-import {
-  type GetNodeErrorParameters,
-  containsNodeError,
-  getNodeError,
-} from './getNodeError.js'
+import { type GetNodeErrorParameters, getNodeError } from './getNodeError.js'
 
 export function getCallError(
   err: BaseError,
@@ -19,9 +16,8 @@ export function getCallError(
     docsPath?: string
   },
 ) {
-  let cause = err
-  if (containsNodeError(err))
-    cause = getNodeError(err, args as GetNodeErrorParameters)
+  let cause = getNodeError(err, args as GetNodeErrorParameters)
+  if (cause instanceof UnknownNodeError) cause = err
   return new CallExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/errors/getEstimateGasError.ts
+++ b/src/utils/errors/getEstimateGasError.ts
@@ -2,13 +2,10 @@ import type { Account } from '../../accounts/types.js'
 import type { EstimateGasParameters } from '../../actions/public/estimateGas.js'
 import type { BaseError } from '../../errors/base.js'
 import { EstimateGasExecutionError } from '../../errors/estimateGas.js'
+import { UnknownNodeError } from '../../errors/node.js'
 import type { Chain } from '../../types/chain.js'
 
-import {
-  type GetNodeErrorParameters,
-  containsNodeError,
-  getNodeError,
-} from './getNodeError.js'
+import { type GetNodeErrorParameters, getNodeError } from './getNodeError.js'
 
 export function getEstimateGasError(
   err: BaseError,
@@ -21,9 +18,8 @@ export function getEstimateGasError(
     docsPath?: string
   },
 ) {
-  let cause = err
-  if (containsNodeError(err))
-    cause = getNodeError(err, args as GetNodeErrorParameters)
+  let cause = getNodeError(err, args as GetNodeErrorParameters)
+  if (cause instanceof UnknownNodeError) cause = err
   return new EstimateGasExecutionError(cause, {
     docsPath,
     ...args,

--- a/src/utils/errors/getNodeError.test.ts
+++ b/src/utils/errors/getNodeError.test.ts
@@ -309,7 +309,7 @@ test('Unknown node error', () => {
     account: address.vitalik,
   })
   expect(result).toMatchInlineSnapshot(`
-    [UnknownNodeError: An error occurred while executing: oh no
+    [UnknownNodeError: An error occurred while executing: Transaction creation failed.
 
     Details: oh no
     Version: viem@1.0.2]

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -41,7 +41,7 @@ export function getNodeError(err: BaseError, args: GetNodeErrorParameters) {
       cause: err,
       message: executionRevertedError.details,
     })
-  } else if (message.match(ExecutionRevertedError.nodeMessage))
+  } else if (ExecutionRevertedError.nodeMessage.test(message))
     return new ExecutionRevertedError({
       cause: err,
       message: err.details,

--- a/src/utils/errors/getNodeError.ts
+++ b/src/utils/errors/getNodeError.ts
@@ -1,5 +1,5 @@
 import type { SendTransactionParameters } from '../../actions/wallet/sendTransaction.js'
-import type { BaseError } from '../../errors/base.js'
+import { BaseError } from '../../errors/base.js'
 import {
   ExecutionRevertedError,
   FeeCapTooHighError,
@@ -31,8 +31,22 @@ export function containsNodeError(err: BaseError) {
 export type GetNodeErrorParameters = Partial<SendTransactionParameters<any>>
 
 export function getNodeError(err: BaseError, args: GetNodeErrorParameters) {
-  const message = err.details.toLowerCase()
-  if (FeeCapTooHighError.nodeMessage.test(message))
+  const message = (err.details || '').toLowerCase()
+
+  const executionRevertedError = err.walk(
+    (e) => (e as { code: number }).code === ExecutionRevertedError.code,
+  )
+  if (executionRevertedError instanceof BaseError) {
+    return new ExecutionRevertedError({
+      cause: err,
+      message: executionRevertedError.details,
+    })
+  } else if (message.match(ExecutionRevertedError.nodeMessage))
+    return new ExecutionRevertedError({
+      cause: err,
+      message: err.details,
+    })
+  else if (FeeCapTooHighError.nodeMessage.test(message))
     return new FeeCapTooHighError({
       cause: err,
       maxFeePerGas: args?.maxFeePerGas,
@@ -62,16 +76,7 @@ export function getNodeError(err: BaseError, args: GetNodeErrorParameters) {
       maxFeePerGas: args?.maxFeePerGas,
       maxPriorityFeePerGas: args?.maxPriorityFeePerGas,
     })
-  else if (
-    message.match(ExecutionRevertedError.nodeMessage) ||
-    ('code' in (err.cause as BaseError) &&
-      (err.cause as { code: number })?.code === ExecutionRevertedError.code)
-  )
-    return new ExecutionRevertedError({
-      cause: err,
-      message: (err.cause as BaseError).details || err.details,
-    })
   return new UnknownNodeError({
-    cause: (err.cause as BaseError).cause as BaseError,
+    cause: err,
   })
 }

--- a/src/utils/errors/getTransactionError.test.ts
+++ b/src/utils/errors/getTransactionError.test.ts
@@ -4,7 +4,10 @@ import { address } from '../../_test/constants.js'
 import { parseAccount } from '../../accounts/utils/parseAccount.js'
 import { BaseError } from '../../errors/base.js'
 import { RpcRequestError } from '../../errors/request.js'
-import { TransactionRejectedRpcError } from '../../errors/rpc.js'
+import {
+  InvalidInputRpcError,
+  TransactionRejectedRpcError,
+} from '../../errors/rpc.js'
 import { parseEther } from '../unit/parseEther.js'
 import { parseGwei } from '../unit/parseGwei.js'
 
@@ -364,8 +367,35 @@ test('Unknown node error', () => {
     account: parseAccount(address.vitalik),
   })
   expect(result).toMatchInlineSnapshot(`
-    [TransactionExecutionError: An error occurred while executing: oh no
+    [TransactionExecutionError: Transaction creation failed.
 
+    URL: http://localhost
+    Request body: {}
+     
+    Request Arguments:
+      from:  0xd8da6bf26964af9d7eed9e03e53415d37aa96045
+
+    Details: oh no
+    Version: viem@1.0.2]
+  `)
+
+  const error2 = new InvalidInputRpcError(
+    new RpcRequestError({
+      body: {},
+      error: { code: -32000, message: 'oh no' },
+      url: '',
+    }),
+  )
+  const result2 = getTransactionError(error2, {
+    account: parseAccount(address.vitalik),
+  })
+  expect(result2).toMatchInlineSnapshot(`
+    [TransactionExecutionError: Missing or invalid parameters.
+    Double check you have provided the correct parameters.
+
+    URL: http://localhost
+    Request body: {}
+     
     Request Arguments:
       from:  0xd8da6bf26964af9d7eed9e03e53415d37aa96045
 

--- a/src/utils/errors/getTransactionError.ts
+++ b/src/utils/errors/getTransactionError.ts
@@ -1,14 +1,11 @@
 import type { Account } from '../../accounts/types.js'
 import type { SendTransactionParameters } from '../../actions/wallet/sendTransaction.js'
 import type { BaseError } from '../../errors/base.js'
+import { UnknownNodeError } from '../../errors/node.js'
 import { TransactionExecutionError } from '../../errors/transaction.js'
 import type { Chain } from '../../types/chain.js'
 
-import {
-  type GetNodeErrorParameters,
-  containsNodeError,
-  getNodeError,
-} from './getNodeError.js'
+import { type GetNodeErrorParameters, getNodeError } from './getNodeError.js'
 
 export type GetTransactionErrorParameters = Omit<
   SendTransactionParameters,
@@ -23,9 +20,8 @@ export function getTransactionError(
   err: BaseError,
   { docsPath, ...args }: GetTransactionErrorParameters,
 ) {
-  let cause = err
-  if (containsNodeError(err))
-    cause = getNodeError(err, args as GetNodeErrorParameters)
+  let cause = getNodeError(err, args as GetNodeErrorParameters)
+  if (cause instanceof UnknownNodeError) cause = err
   return new TransactionExecutionError(cause, {
     docsPath,
     ...args,


### PR DESCRIPTION
Fixes #1101

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed an issue where non-standard "user rejected" errors were being coalesced into an `UnknownNodeError`.
- Updated the `getNodeError` function to handle `ExecutionRevertedError` separately.
- Added imports for `UnknownNodeError` in multiple files.
- Updated error messages in multiple test files.
- Minor code formatting changes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->