### PR TITLE
chore: amend base `nativeCurrency.name`

### DIFF
--- a/.changeset/thirty-cycles-grab.md
+++ b/.changeset/thirty-cycles-grab.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Amended Base chain `nativeCurreny.name` to "Ether".

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -6,7 +6,7 @@ export const base = /*#__PURE__*/ defineChain(
     id: 8453,
     network: 'base',
     name: 'Base',
-    nativeCurrency: { name: 'Base', symbol: 'ETH', decimals: 18 },
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
       default: {
         http: ['https://mainnet.base.org'],

--- a/src/chains/definitions/baseGoerli.ts
+++ b/src/chains/definitions/baseGoerli.ts
@@ -6,7 +6,7 @@ export const baseGoerli = /*#__PURE__*/ defineChain(
     id: 84531,
     network: 'base-goerli',
     name: 'Base Goerli',
-    nativeCurrency: { name: 'Base Goerli', symbol: 'ETH', decimals: 18 },
+    nativeCurrency: { name: 'Goerli Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
       default: {
         http: ['https://goerli.base.org'],


### PR DESCRIPTION
Fixes #1118

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on amending the names of the native currencies in the Base and Base Goerli chains. 

### Detailed summary
- Amended the name of the native currency in the Base chain to "Ether".
- Amended the name of the native currency in the Base Goerli chain to "Goerli Ether".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->