### PR TITLE
feat: support function/event selectors as `name` in `getAbiItem`

### DIFF
--- a/.changeset/khaki-emus-run.md
+++ b/.changeset/khaki-emus-run.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support function/event selectors as `name` in `getAbiItem`.

--- a/site/docs/abi/getAbiItem.md
+++ b/site/docs/abi/getAbiItem.md
@@ -98,6 +98,15 @@ const encodedData = getAbiItem({
 })
 ```
 
+You can also provide the ABI item's 4byte selector:
+
+```ts
+const encodedData = getAbiItem({
+  abi: [...],
+  name: '0x70a08231', // [!code focus]
+})
+```
+
 ### args (optional)
 
 - **Type:** Inferred.

--- a/src/utils/abi/getAbiItem.test.ts
+++ b/src/utils/abi/getAbiItem.test.ts
@@ -35,6 +35,67 @@ test('default', () => {
   `)
 })
 
+describe('selector', () => {
+  test('function', () => {
+    expect(
+      getAbiItem({
+        abi: wagmiContractConfig.abi,
+        name: '0x70a08231',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "inputs": [
+          {
+            "name": "owner",
+            "type": "address",
+          },
+        ],
+        "name": "balanceOf",
+        "outputs": [
+          {
+            "name": "",
+            "type": "uint256",
+          },
+        ],
+        "stateMutability": "view",
+        "type": "function",
+      }
+    `)
+  })
+
+  test('event', () => {
+    expect(
+      getAbiItem({
+        abi: wagmiContractConfig.abi,
+        name: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+      }),
+    ).toMatchInlineSnapshot(`
+      {
+        "anonymous": false,
+        "inputs": [
+          {
+            "indexed": true,
+            "name": "from",
+            "type": "address",
+          },
+          {
+            "indexed": true,
+            "name": "to",
+            "type": "address",
+          },
+          {
+            "indexed": true,
+            "name": "tokenId",
+            "type": "uint256",
+          },
+        ],
+        "name": "Transfer",
+        "type": "event",
+      }
+    `)
+  })
+})
+
 test('no matching name', () => {
   expect(
     getAbiItem({


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- Support function/event selectors as `name` in `getAbiItem` function.
- Added support for providing the ABI item's 4byte selector in `getAbiItem` documentation.
- Added tests for function and event selectors in `getAbiItem`.
- Updated `getAbiItem` to handle function/event selectors as `name` parameter.
- Added new imports and utility functions in `getAbiItem`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->