### PR TITLE
fix: encodePacked on empty arrays

### DIFF
--- a/.changeset/heavy-baboons-notice.md
+++ b/.changeset/heavy-baboons-notice.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `encodePacked` for empty arrays.

--- a/src/utils/abi/encodePacked.test.ts
+++ b/src/utils/abi/encodePacked.test.ts
@@ -6,6 +6,11 @@ import { encodePacked } from './encodePacked.js'
 
 test.each([
   {
+    types: [],
+    values: [],
+    expected: '0x',
+  },
+  {
     types: ['address'],
     values: [address.vitalik],
     expected: '0xd8da6bf26964af9d7eed9e03e53415d37aa96045',

--- a/src/utils/abi/encodePacked.ts
+++ b/src/utils/abi/encodePacked.ts
@@ -18,7 +18,7 @@ import {
 import { InvalidAddressError } from '../../errors/address.js'
 import type { Hex } from '../../types/misc.js'
 import { isAddress } from '../address/isAddress.js'
-import { concat } from '../data/concat.js'
+import { concatHex } from '../data/concat.js'
 import { pad } from '../data/pad.js'
 import { boolToHex, numberToHex, stringToHex } from '../encoding/toHex.js'
 import { arrayRegex, bytesRegex, integerRegex } from '../regex.js'
@@ -54,7 +54,7 @@ export function encodePacked<
     const value = values[i]
     data.push(encode(type, value))
   }
-  return concat(data)
+  return concatHex(data)
 }
 
 function encode<const TPackedAbiType extends PackedAbiType | unknown>(
@@ -103,7 +103,7 @@ function encode<const TPackedAbiType extends PackedAbiType | unknown>(
       data.push(encode(childType, value[i], true))
     }
     if (data.length === 0) return '0x'
-    return concat(data)
+    return concatHex(data)
   }
 
   throw new UnsupportedPackedAbiType(type)


### PR DESCRIPTION
I have a helper function that uses `encodePacked` for an arbitrary array. I noticed when a set of empty types/values is passed in, `encodePacked` returns a `Uint8Array(0)` instead of `"0x"`.

This is fixed by specifically using `concatHex` over `concat` (since `concat` looks for a string as the first element to decide if it needs to return hex).

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed `encodePacked` for empty arrays.
- Updated import of `concat` to `concatHex` in `encodePacked.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->