### PR TITLE
Fixes deprecated Chainstack RPC

### DIFF
--- a/.changeset/real-numbers-pretend.md
+++ b/.changeset/real-numbers-pretend.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated Polygon Mumbai RPC URL.

--- a/src/chains/definitions/polygonMumbai.ts
+++ b/src/chains/definitions/polygonMumbai.ts
@@ -15,10 +15,10 @@ export const polygonMumbai = /*#__PURE__*/ defineChain({
       webSocket: ['wss://polygon-mumbai.infura.io/ws/v3'],
     },
     default: {
-      http: ['https://matic-mumbai.chainstacklabs.com'],
+      http: ['https://rpc-mumbai.matic.today'],
     },
     public: {
-      http: ['https://matic-mumbai.chainstacklabs.com'],
+      http: ['https://rpc-mumbai.matic.today'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Chainstack have sunset their Mumbai RPC. Added latest public RPC from the [Polygon wiki](https://wiki.polygon.technology/docs/pos/reference/rpc-endpoints/).

Replaces deprecated Mumbai RPC and fixes default

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the Polygon Mumbai RPC URL. 

### Detailed summary:
- Updated the RPC URL in the `polygonMumbai.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->