### PR TITLE
docs: Add 'gas' parameter to docs for writeContract and simulateContract

### DIFF
--- a/.changeset/pink-trains-speak.md
+++ b/.changeset/pink-trains-speak.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added docs for optional 'gas' parameter to writeContract and simulateContract

--- a/.changeset/pink-trains-speak.md
+++ b/.changeset/pink-trains-speak.md
@@ -1,5 +1,0 @@
----
-"viem": patch
----
-
-Added docs for optional 'gas' parameter to writeContract and simulateContract

--- a/site/docs/contract/simulateContract.md
+++ b/site/docs/contract/simulateContract.md
@@ -116,7 +116,7 @@ import { mainnet } from 'viem/chains'
 
 // JSON-RPC Account
 export const [account] = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
-// Local Account 
+// Local Account
 export const account = privateKeyToAccount(...)
 
 export const publicClient = createPublicClient({
@@ -187,7 +187,7 @@ export const publicClient = createPublicClient({
 
 ### Handling Custom Errors
 
-In the example below, we are **catching** a [custom error](https://blog.soliditylang.org/2021/04/21/custom-errors/) thrown by the `simulateContract`. It is important to include the custom error item in the contract `abi`. 
+In the example below, we are **catching** a [custom error](https://blog.soliditylang.org/2021/04/21/custom-errors/) thrown by the `simulateContract`. It is important to include the custom error item in the contract `abi`.
 
 You can access the custom error through the `data` attribute of the error:
 
@@ -228,10 +228,10 @@ export const wagmiAbi = [
     type: "function",
   },
   // Custom solidity error
-  { 
-    type: 'error', 
-    inputs: [], 
-    name: 'MintIsDisabled' 
+  {
+    type: 'error',
+    inputs: [],
+    name: 'MintIsDisabled'
   },
   ...
 ] as const;
@@ -359,7 +359,7 @@ const { result } = await publicClient.simulateContract({
   accessList: [{ // [!code focus:4]
     address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     storageKeys: ['0x1'],
-  }], 
+  }],
   account: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 })
 ```
@@ -385,7 +385,7 @@ const { result } = await publicClient.simulateContract({
 
 - **Type:** `Hex`
 
-Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). 
+Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f).
 
 ```ts
 const { result } = await publicClient.simulateContract({
@@ -394,6 +394,22 @@ const { result } = await publicClient.simulateContract({
   functionName: 'mint',
   args: [69420],
   dataSuffix: '0xdeadbeef' // [!code focus]
+})
+```
+
+### gas (optional)
+
+- **Type:** `bigint`
+
+The gas limit for the transaction.
+
+```ts
+await walletClient.writeContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  args: [69420],
+  gas: 69420n, // [!code focus]
 })
 ```
 

--- a/site/docs/contract/writeContract.md
+++ b/site/docs/contract/writeContract.md
@@ -16,13 +16,13 @@ head:
 
 Executes a write function on a contract.
 
-A "write" function on a Solidity contract modifies the state of the blockchain. These types of functions require gas to be executed, and hence a [Transaction](/docs/glossary/terms) is needed to be broadcast in order to change the state. 
+A "write" function on a Solidity contract modifies the state of the blockchain. These types of functions require gas to be executed, and hence a [Transaction](/docs/glossary/terms) is needed to be broadcast in order to change the state.
 
 Internally, `writeContract` uses a [Wallet Client](/docs/clients/wallet) to call the [`sendTransaction` action](/docs/actions/wallet/sendTransaction) with [ABI-encoded `data`](/docs/contract/encodeFunctionData).
 
 ::: warning
 
-The `writeContract` internally sends a transaction – it **does not** validate if the contract write will succeed (the contract may throw an error). It is highly recommended to [simulate the contract write with `simulateContract`](#usage) before you execute it. 
+The `writeContract` internally sends a transaction – it **does not** validate if the contract write will succeed (the contract may throw an error). It is highly recommended to [simulate the contract write with `simulateContract`](#usage) before you execute it.
 
 :::
 
@@ -289,7 +289,7 @@ await walletClient.writeContract({
   accessList: [{ // [!code focus:4]
     address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     storageKeys: ['0x1'],
-  }], 
+  }],
 })
 ```
 
@@ -333,7 +333,7 @@ await walletClient.writeContract({
 
 - **Type:** `Hex`
 
-Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f). 
+Data to append to the end of the calldata. Useful for adding a ["domain" tag](https://opensea.notion.site/opensea/Seaport-Order-Attributions-ec2d69bf455041a5baa490941aad307f).
 
 ```ts
 await walletClient.writeContract({
@@ -342,6 +342,22 @@ await walletClient.writeContract({
   functionName: 'mint',
   args: [69420],
   dataSuffix: '0xdeadbeef' // [!code focus]
+})
+```
+
+### gas (optional)
+
+- **Type:** `bigint`
+
+The gas limit for the transaction. Note that passing a gas limit also skips the gas estimation step.
+
+```ts
+await walletClient.writeContract({
+  address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+  abi: wagmiAbi,
+  functionName: 'mint',
+  args: [69420],
+  gas: 69420n, // [!code focus]
 })
 ```
 


### PR DESCRIPTION
See https://github.com/wagmi-dev/viem/discussions/719

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the `simulateContract.md` and `writeContract.md` files in the `site/docs/contract` directory.
- Fixed a typo in the `simulateContract.md` file.
- Added information about the `gas` parameter in the `simulateContract.md` and `writeContract.md` files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->