### PR TITLE
fix(viem/chains): update the crossbell chain multicall3 address

### DIFF
--- a/.changeset/cuddly-tables-hope.md
+++ b/.changeset/cuddly-tables-hope.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updated multicall3 address on Crossbell.

--- a/src/chains/definitions/crossbell.ts
+++ b/src/chains/definitions/crossbell.ts
@@ -22,8 +22,8 @@ export const crossbell = /*#__PURE__*/ defineChain({
   },
   contracts: {
     multicall3: {
-      address: '0xBB9759009cDaC82774EfC84D94cD9F7440f75Fcf',
-      blockCreated: 23_499_787,
+      address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+      blockCreated: 38_246_031,
     },
   },
 })


### PR DESCRIPTION
A more common used address `0xcA11bde05977b3631167028862bE2a173976CA11` for multicall3 has been deployed to crossbel chain.

https://scan.crossbell.io/tx/0x0d7367f09c151993f1a7ac32780948fc07d232806e81d0d0c3e7058e4538d7f5

Thanks.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `multicall3` address on Crossbell.

### Detailed summary
- Updated `multicall3` address on Crossbell from `0xBB9759009cDaC82774EfC84D94cD9F7440f75Fcf` to `0xcA11bde05977b3631167028862bE2a173976CA11`.
- Updated `blockCreated` value from `23_499_787` to `38_246_031`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->