### PR TITLE
feat: add base rpcUrls for Alchemy

### DIFF
--- a/.changeset/unlucky-dancers-float.md
+++ b/.changeset/unlucky-dancers-float.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added Alchemy RPC URLs for Base chain.

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -8,6 +8,10 @@ export const base = /*#__PURE__*/ defineChain(
     name: 'Base',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
+      alchemy: {
+        http: ['https://base-mainnet.g.alchemy.com/v2'],
+        webSocket: ['wss://base-mainnet.g.alchemy.com/v2'],
+      },
       default: {
         http: ['https://mainnet.base.org'],
       },

--- a/src/chains/definitions/baseGoerli.ts
+++ b/src/chains/definitions/baseGoerli.ts
@@ -8,6 +8,10 @@ export const baseGoerli = /*#__PURE__*/ defineChain(
     name: 'Base Goerli',
     nativeCurrency: { name: 'Goerli Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {
+      alchemy: {
+        http: ['https://base-goerli.g.alchemy.com/v2'],
+        webSocket: ['wss://base-goerli.g.alchemy.com/v2'],
+      },
       default: {
         http: ['https://goerli.base.org'],
       },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding Alchemy RPC URLs for the Base chain. 

### Detailed summary
- Added Alchemy RPC URLs for the Base chain in `src/chains/definitions/base.ts`.
- Added Alchemy RPC URLs for the Base Goerli chain in `src/chains/definitions/baseGoerli.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->