### PR TITLE
fix: fix typo in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 The `examples/` directory is a growing & living folder, and open for contributions.
 
-Each example has it's own isolated [StackBlitz](https://new.viem.sh) project, so folks can easily play around with the example.
+Each example has its own isolated [StackBlitz](https://new.viem.sh) project, so folks can easily play around with the example.
 
 The below list is not exhaustive, and is a work in progress. If you have an idea for an example that is not listed below, please open a [discussion thread](https://github.com/wagmi-dev/viem/discussions/new?category=feature-request&title=Example%20Request:) proposing your idea. If you wish to take on an example that is not completed, go ahead!
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR fixes a typo in the README.md file in the examples directory. 

### Detailed summary
- Corrected a typo in the sentence "Each example has it's own isolated StackBlitz project" to "Each example has its own isolated StackBlitz project".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->