### PR TITLE
fix: patch ws

### DIFF
--- a/.changeset/young-deers-relax.md
+++ b/.changeset/young-deers-relax.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where some environments would throw `WebSocket.default is not a constructor`.

--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -156,7 +156,9 @@ export async function getSocket(url: string) {
   const { schedule } = createBatchScheduler<undefined, [Socket]>({
     id: url,
     fn: async () => {
-      const webSocket = new WebSocket(url)
+      let WebSocket_ = WebSocket
+      if (!WebSocket.constructor) WebSocket_ = WebSocket.WebSocket
+      const webSocket = new WebSocket_(url)
 
       // Set up a cache for incoming "synchronous" requests.
       const requests = new Map<Id, CallbackFn>()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Fixing an issue where some environments would throw `WebSocket.default is not a constructor`.

### Detailed summary:
- Patched the `viem` library.
- Fixed the issue by modifying the `src/utils/rpc.ts` file.
- Replaced the usage of `new WebSocket(url)` with a conditional check and assignment to handle different environments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->