### PR TITLE
Name changed for Polygon to PolygonPOS

### DIFF
--- a/.changeset/young-steaks-dress.md
+++ b/.changeset/young-steaks-dress.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Since Polygon now has the zkEVM chain as well, the 'Polygon' name is misleading to developers. For sake of simplicity, this PR changes 'Polygon' to 'Polygon POS' and 'Polygon Mumbai' to 'Mumbai Testnet'.

--- a/site/docs/clients/chains.md
+++ b/site/docs/clients/chains.md
@@ -14,7 +14,7 @@ head:
 
 # Chains
 
-The `viem/chains` entrypoint contains references to popular EVM-compatible chains such as: Polygon, Optimism, Avalanche, Base, Zora, and more.
+The `viem/chains` entrypoint contains references to popular EVM-compatible chains such as: Polygon PoS, Optimism, Avalanche, Base, Zora, and more.
 
 ## Usage
 

--- a/site/docs/glossary/terms.md
+++ b/site/docs/glossary/terms.md
@@ -22,7 +22,7 @@ A block is a bundled unit of information that include an ordered list of transac
 
 A Chain refers to a specific blockchain network or protocol that maintains a decentralized, distributed ledger of transactions and other data. Each Chain has its own rules, consensus mechanism, and native cryptocurrency (if any).
 
-Examples of Chains include: Ethereum Mainnet, Polygon, Optimism, Avalanche, Binance Smart Chain, etc.
+Examples of Chains include: Ethereum Mainnet, Polygon PoS, Optimism, Avalanche, Binance Smart Chain, etc.
 
 ## EIP-1559 Transaction
 

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain.js'
 
 export const polygon = /*#__PURE__*/ defineChain({
   id: 137,
-  name: 'Polygon',
+  name: 'Polygon PoS',
   network: 'matic',
   nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
   rpcUrls: {

--- a/src/chains/definitions/polygonMumbai.ts
+++ b/src/chains/definitions/polygonMumbai.ts
@@ -2,7 +2,7 @@ import { defineChain } from '../../utils/chain.js'
 
 export const polygonMumbai = /*#__PURE__*/ defineChain({
   id: 80_001,
-  name: 'Polygon Mumbai',
+  name: 'Mumbai Testnet',
   network: 'maticmum',
   nativeCurrency: { name: 'MATIC', symbol: 'MATIC', decimals: 18 },
   rpcUrls: {

--- a/src/errors/transaction.test.ts
+++ b/src/errors/transaction.test.ts
@@ -200,7 +200,7 @@ describe('TransactionExecutionError', () => {
       [TransactionExecutionError: error
 
       Request Arguments:
-        chain:  Polygon (id: 137)
+        chain:  Polygon PoS (id: 137)
         from:   0xd8da6bf26964af9d7eed9e03e53415d37aa96045
         to:     0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078
         value:  0.00000000000000042 MATIC
@@ -232,7 +232,7 @@ describe('TransactionExecutionError', () => {
       omggg!
        
       Request Arguments:
-        chain:  Polygon (id: 137)
+        chain:  Polygon PoS (id: 137)
         from:   0xd8da6bf26964af9d7eed9e03e53415d37aa96045
         to:     0x5414d89a8bf7e99d732bc52f3e6a3ef461c0c078
         value:  0.00000000000000042 MATIC


### PR DESCRIPTION
# Description

Since Polygon now has the zkEVM chain as well, the 'Polygon' name is misleading to developers.

For sake of simplicity, this PR changes 'Polygon' to 'Polygon PoS' and 'Polygon Mumbai' to 'Mumbai Testnet'.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the names of chains in the codebase and documentation to provide more accurate and descriptive names.

### Detailed summary:
- Updated the name of the 'Polygon' chain to 'Polygon PoS' in the codebase and documentation.
- Updated the name of the 'Polygon Mumbai' chain to 'Mumbai Testnet' in the codebase and documentation.
- Updated references to the chains in the codebase and documentation to reflect the new names.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->