### PR TITLE
fix: support integer for `baseFeeMultiplier`

### DIFF
--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -106,10 +106,17 @@ export async function internal_estimateFeesPerGas<
   })()
   if (baseFeeMultiplier < 1) throw new BaseFeeScalarError()
 
-  const decimals = baseFeeMultiplier.toString().split('.')[1].length
-  const denominator = 10 ** decimals
-  const multiply = (base: bigint) =>
-    (base * BigInt(baseFeeMultiplier * denominator)) / BigInt(denominator)
+  const multiply = (base: bigint) => {
+    if (Number.isInteger(baseFeeMultiplier)) {
+      return base * BigInt(baseFeeMultiplier)
+    }
+    const decimals = baseFeeMultiplier.toString().split('.')[1].length
+    const denominator = 10 ** decimals
+
+    return (
+      (base * BigInt(baseFeeMultiplier * denominator)) / BigInt(denominator)
+    )
+  }
 
   const block = block_ ? block_ : await getBlock(client)
 


### PR DESCRIPTION
I set `baseFeeMultiplier` to `2` for the chain.
However, got the error
```
TypeError: Cannot read properties of undefined (reading 'length')
    at internal_estimateFeesPerGas (bundle.js:112518:62)
```


<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to handle the case when `baseFeeMultiplier` is an integer without decimals.
- Notable changes:
  - Added a check to see if `baseFeeMultiplier` is an integer.
  - If `baseFeeMultiplier` is an integer, the `multiply` function will return the result of `base` multiplied by `baseFeeMultiplier`.
  - If `baseFeeMultiplier` has decimals, the `multiply` function will calculate the result using the previous logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->