### PR TITLE
fix: base fee multiplier calculation

### DIFF
--- a/.changeset/silver-avocados-peel.md
+++ b/.changeset/silver-avocados-peel.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `baseFeeMultiplier` calculation.

--- a/src/actions/public/estimateFeesPerGas.test.ts
+++ b/src/actions/public/estimateFeesPerGas.test.ts
@@ -59,21 +59,44 @@ test('args: chain `baseFeeMultiplier` override (value)', async () => {
   const client = createPublicClient({
     transport: http(localHttpUrl),
   })
-  const { maxFeePerGas, maxPriorityFeePerGas } = await estimateFeesPerGas(
-    client,
-    {
-      chain: {
-        ...anvilChain,
-        fees: {
-          baseFeeMultiplier: 1.5,
-        },
+  const feesPerGas_1 = await estimateFeesPerGas(client, {
+    chain: {
+      ...anvilChain,
+      fees: {
+        baseFeeMultiplier: 1.5,
       },
     },
+  })
+  expect(feesPerGas_1.maxFeePerGas).toBe(
+    (block.baseFeePerGas! * 150n) / 100n + feesPerGas_1.maxPriorityFeePerGas,
   )
-  expect(maxFeePerGas).toBe(
-    (block.baseFeePerGas! * 150n) / 100n + maxPriorityFeePerGas,
+  expect(feesPerGas_1.maxPriorityFeePerGas).toBeDefined()
+
+  const feesPerGas_2 = await estimateFeesPerGas(client, {
+    chain: {
+      ...anvilChain,
+      fees: {
+        baseFeeMultiplier: 2,
+      },
+    },
+  })
+  expect(feesPerGas_2.maxFeePerGas).toBe(
+    block.baseFeePerGas! * 2n + feesPerGas_2.maxPriorityFeePerGas,
   )
-  expect(maxPriorityFeePerGas).toBeDefined()
+  expect(feesPerGas_2.maxPriorityFeePerGas).toBeDefined()
+
+  const feesPerGas_3 = await estimateFeesPerGas(client, {
+    chain: {
+      ...anvilChain,
+      fees: {
+        baseFeeMultiplier: 2.01,
+      },
+    },
+  })
+  expect(feesPerGas_3.maxFeePerGas).toBe(
+    (block.baseFeePerGas! * 201n) / 100n + feesPerGas_3.maxPriorityFeePerGas,
+  )
+  expect(feesPerGas_3.maxPriorityFeePerGas).toBeDefined()
 })
 
 test('args: chain `baseFeeMultiplier` override (sync fn)', async () => {

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -106,10 +106,11 @@ export async function internal_estimateFeesPerGas<
   })()
   if (baseFeeMultiplier < 1) throw new BaseFeeScalarError()
 
-  const decimals = baseFeeMultiplier.toString().split('.')[1].length
+  const decimals = baseFeeMultiplier.toString().split('.')[1]?.length ?? 0
   const denominator = 10 ** decimals
   const multiply = (base: bigint) =>
-    (base * BigInt(baseFeeMultiplier * denominator)) / BigInt(denominator)
+    (base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) /
+    BigInt(denominator)
 
   const block = block_ ? block_ : await getBlock(client)
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
Fixing the calculation of `baseFeeMultiplier` in the code.

### Detailed summary:
- Fixed the calculation of `baseFeeMultiplier`.
- Replaced `baseFeeMultiplier.toString().split('.')[1].length` with `baseFeeMultiplier.toString().split('.')[1]?.length ?? 0`.
- Changed `base * BigInt(baseFeeMultiplier * denominator)) / BigInt(denominator)` to `base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) / BigInt(denominator)`.
- Updated test cases for `estimateFeesPerGas` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->