### PR TITLE
feat: support error selector

### DIFF
--- a/src/utils/abi/getAbiItem.ts
+++ b/src/utils/abi/getAbiItem.ts
@@ -3,6 +3,7 @@ import type { Abi, AbiParameter, Address } from 'abitype'
 import type { GetFunctionArgs, InferItemName } from '../../types/contract.js'
 import type { Hex } from '../../types/misc.js'
 import { isHex } from '../../utils/data/isHex.js'
+import { getErrorSelector } from '../../utils/hash/getErrorSelector.js'
 import { getEventSelector } from '../../utils/hash/getEventSelector.js'
 import { getFunctionSelector } from '../../utils/hash/getFunctionSelector.js'
 import { isAddress } from '../address/isAddress.js'
@@ -43,6 +44,7 @@ export function getAbiItem<
       if (abiItem.type === 'function')
         return getFunctionSelector(abiItem) === name
       if (abiItem.type === 'event') return getEventSelector(abiItem) === name
+      if (abiItem.type === 'error') return getErrorSelector(abiItem) === name
       return false
     }
     return 'name' in abiItem && abiItem.name === name

--- a/src/utils/hash/getErrorSelector.ts
+++ b/src/utils/hash/getErrorSelector.ts
@@ -1,0 +1,7 @@
+import type { AbiError } from 'abitype'
+import { hashAbiItem, hashFunction } from './hashFunction.js'
+
+export const getErrorSelector = (error: string | AbiError) => {
+  if (typeof error === 'string') return hashFunction(error)
+  return hashAbiItem(error)
+}

--- a/src/utils/hash/hashFunction.ts
+++ b/src/utils/hash/hashFunction.ts
@@ -1,4 +1,4 @@
-import type { AbiEvent, AbiFunction } from 'abitype'
+import type { AbiError, AbiEvent, AbiFunction } from 'abitype'
 import { formatAbiItem } from '../abi/formatAbiItem.js'
 import {
   extractFunctionName,
@@ -16,6 +16,6 @@ export function hashFunction(def: string) {
   return hash(`${name}(${params.map(({ type }) => type).join(',')})`)
 }
 
-export function hashAbiItem(abiItem: AbiFunction | AbiEvent) {
+export function hashAbiItem(abiItem: AbiFunction | AbiEvent | AbiError) {
   return hash(formatAbiItem(abiItem))
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding support for hashing errors in the ABI. 

### Detailed summary
- Added `getErrorSelector` function to hash error names.
- Modified `hashAbiItem` function to support hashing errors.
- Updated `getAbiItem` function to check error names using `getErrorSelector`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->