### PR TITLE
chore: replace wagmi with viem in `chains.md`

### DIFF
--- a/site/docs/clients/chains.md
+++ b/site/docs/clients/chains.md
@@ -36,7 +36,7 @@ const client = createPublicClient({
 
 ## Custom Chains
 
-You can also extend wagmi to support other EVM-compatible chains by building your own chain object that inherits the `Chain` type.
+You can also extend viem to support other EVM-compatible chains by building your own chain object that inherits the `Chain` type.
 
 ```ts
 import { defineChain } from 'viem'


### PR DESCRIPTION
When going through the docs this line stood out to me as odd because using `defineChain` is independent of `wagmi`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the name of the library from "wagmi" to "viem" in the documentation. 

### Detailed summary
- Updated the library name from "wagmi" to "viem" in the documentation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->