### PR TITLE
docs: remove duplicate sidebar item

### DIFF
--- a/site/.vitepress/sidebar.ts
+++ b/site/.vitepress/sidebar.ts
@@ -188,10 +188,6 @@ export const sidebar: DefaultTheme.Sidebar = {
               link: '/docs/actions/public/getTransactionReceipt',
             },
             {
-              text: 'sendRawTransaction',
-              link: '/docs/actions/public/sendRawTransaction',
-            },
-            {
               text: 'waitForTransactionReceipt',
               link: '/docs/actions/public/waitForTransactionReceipt',
             },


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

This PR removes the `sendRawTransaction` entry from the sidebar in `site/.vitepress/sidebar.ts`.

- Removed `sendRawTransaction` entry from the sidebar in `site/.vitepress/sidebar.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->