### PR TITLE
fix(rpc): wrap JSON.parse in try/catch

### DIFF
--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -168,13 +168,18 @@ export async function getSocket(url: string) {
       const subscriptions = new Map<Id, CallbackFn>()
 
       const onMessage: (event: MessageEvent) => void = ({ data }) => {
-        const message: RpcResponse = JSON.parse(data as string)
-        const isSubscription = message.method === 'eth_subscription'
-        const id = isSubscription ? message.params.subscription : message.id
-        const cache = isSubscription ? subscriptions : requests
-        const callback = cache.get(id)
-        if (callback) callback({ data })
-        if (!isSubscription) cache.delete(id)
+        try {
+          const message: RpcResponse = JSON.parse(data as string)
+          const isSubscription = message.method === 'eth_subscription'
+          const id = isSubscription ? message.params.subscription : message.id
+          const cache = isSubscription ? subscriptions : requests
+          const callback = cache.get(id)
+          if (callback) callback({ data })
+          if (!isSubscription) cache.delete(id)
+        } catch {
+          // sometimes message received is not json format
+          // what do you me to do here?
+        }
       }
       const onClose = () => {
         socketsCache.delete(url)


### PR DESCRIPTION
With QuickNode I'm getting a few errors like this:

![image](https://github.com/wagmi-dev/viem/assets/893837/dd856db4-42ef-46c2-8a91-f0a808f9af80)

I've just put a comment, willing to change according to your guidelines.
Cheers.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on handling non-JSON message formats in the `onMessage` function in `rpc.ts` file.

### Detailed summary:
- Added a try-catch block to handle non-JSON message formats in the `onMessage` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->