### PR TITLE
Add optional 'bytecodeHash' parameter to getContractAddress

### DIFF
--- a/.changeset/early-penguins-drum.md
+++ b/.changeset/early-penguins-drum.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Added optional 'bytecodeHash' parameter to getContractAddress
+Added optional `bytecodeHash` parameter to `getContractAddress`.

--- a/.changeset/early-penguins-drum.md
+++ b/.changeset/early-penguins-drum.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added optional 'bytecodeHash' parameter to getContractAddress

--- a/site/docs/utilities/getContractAddress.md
+++ b/site/docs/utilities/getContractAddress.md
@@ -49,7 +49,7 @@ The contract address.
 The address the contract was deployed from.
 
 ```ts
-getContractAddress({ 
+getContractAddress({
   from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b', // [!code focus:1]
   nonce: 69420n
 })
@@ -62,7 +62,7 @@ getContractAddress({
 The nonce of the transaction which deployed the contract.
 
 ```ts
-getContractAddress({ 
+getContractAddress({
   from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
   nonce: 69420n // [!code focus:1]
 })
@@ -78,7 +78,7 @@ The opcode to invoke the contract deployment. Defaults to `"CREATE"`.
 [Learn more about `CREATE2`](https://eips.ethereum.org/EIPS/eip-1014).
 
 ```ts
-getContractAddress({ 
+getContractAddress({
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...',
   from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
   opcode: 'CREATE2', // [!code focus:1]
@@ -94,8 +94,24 @@ getContractAddress({
 The to-be-deployed contract’s bytecode
 
 ```ts
-getContractAddress({ 
+getContractAddress({
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...', // [!code focus:1]
+  from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
+  opcode: 'CREATE2',
+  salt: toBytes('wagmi'),
+})
+```
+
+### bytecodeHash (optional)
+
+- **Type:** `ByteArray` | [`Hex`](/docs/glossary/types#hex)
+- **Only applicable for `opcode: 'CREATE2'` deployments**
+
+A hash of the to-be-deployed contract’s bytecode
+
+```ts
+getContractAddress({
+  bytecodeHash: '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54', // [!code focus:1]
   from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
   opcode: 'CREATE2',
   salt: toBytes('wagmi'),
@@ -110,7 +126,7 @@ getContractAddress({
 An arbitrary value provided by the sender.
 
 ```ts
-getContractAddress({ 
+getContractAddress({
   bytecode: '0x608060405260405161083e38038061083e833981016040819052610...',
   from: '0xc961145a54C96E3aE9bAA048c4F4D6b04C13916b',
   opcode: 'CREATE2',

--- a/src/utils/address/getContractAddress.test.ts
+++ b/src/utils/address/getContractAddress.test.ts
@@ -84,6 +84,20 @@ test('gets contract address (CREATE2)', () => {
     }),
   ).toMatchInlineSnapshot('"0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"')
   expect(
+    getCreate2Address({
+      from: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+      bytecodeHash:
+        '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',
+      salt: keccak256(
+        encodeAbiParameters(parseAbiParameters('address, address, uint24'), [
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          500,
+        ]),
+      ),
+    }),
+  ).toMatchInlineSnapshot('"0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"')
+  expect(
     getContractAddress({
       from: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
       bytecodeHash: toBytes(

--- a/src/utils/address/getContractAddress.test.ts
+++ b/src/utils/address/getContractAddress.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from 'vitest'
 import { toBytes } from '../encoding/toBytes.js'
 import { toHex } from '../encoding/toHex.js'
 
+import { encodeAbiParameters, keccak256, parseAbiParameters } from '../index.js'
 import {
   getContractAddress,
   getCreate2Address,
@@ -67,6 +68,37 @@ test('gets contract address (CREATE2)', () => {
       salt: toHex('hello world'),
     }),
   ).toMatchInlineSnapshot('"0x59fbB593ABe27Cb193b6ee5C5DC7bbde312290aB"')
+  expect(
+    getCreate2Address({
+      from: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+      bytecodeHash: toBytes(
+        '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',
+      ),
+      salt: keccak256(
+        encodeAbiParameters(parseAbiParameters('address, address, uint24'), [
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          500,
+        ]),
+      ),
+    }),
+  ).toMatchInlineSnapshot('"0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"')
+  expect(
+    getContractAddress({
+      from: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+      bytecodeHash: toBytes(
+        '0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54',
+      ),
+      salt: keccak256(
+        encodeAbiParameters(parseAbiParameters('address, address, uint24'), [
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+          500,
+        ]),
+      ),
+      opcode: 'CREATE2',
+    }),
+  ).toMatchInlineSnapshot('"0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"')
   expect(
     getContractAddress({
       from: '0x1a1e021a302c237453d3d45c7b82b19ceeb7e2e6',

--- a/src/utils/address/getContractAddress.ts
+++ b/src/utils/address/getContractAddress.ts
@@ -16,11 +16,17 @@ export type GetCreateAddressOptions = {
   nonce: bigint
 }
 
-export type GetCreate2AddressOptions = {
-  bytecode: ByteArray | Hex
-  from: Address
-  salt: ByteArray | Hex
-}
+export type GetCreate2AddressOptions =
+  | {
+      bytecode: ByteArray | Hex
+      from: Address
+      salt: ByteArray | Hex
+    }
+  | {
+      bytecodeHash: ByteArray | Hex
+      from: Address
+      salt: ByteArray | Hex
+    }
 
 export type GetContractAddressOptions =
   | ({
@@ -46,16 +52,19 @@ export function getCreateAddress(opts: GetCreateAddressOptions) {
 
 export function getCreate2Address(opts: GetCreate2AddressOptions) {
   const from = toBytes(getAddress(opts.from))
-  const salt = pad(isBytes(opts.salt) ? opts.salt : toBytes(opts.salt as Hex), {
+  const salt = pad(isBytes(opts.salt) ? opts.salt : toBytes(opts.salt), {
     size: 32,
-  }) as ByteArray
-  const bytecodeHash = toBytes(
-    keccak256(
-      (isBytes(opts.bytecode)
-        ? opts.bytecode
-        : toBytes(opts.bytecode as Hex)) as ByteArray,
-    ),
-  )
+  })
+  const bytecodeHash =
+    'bytecodeHash' in opts
+      ? isBytes(opts.bytecodeHash)
+        ? opts.bytecodeHash
+        : toBytes(opts.bytecodeHash)
+      : toBytes(
+          keccak256(
+            isBytes(opts.bytecode) ? opts.bytecode : toBytes(opts.bytecode),
+          ),
+        )
   return getAddress(
     slice(keccak256(concat([toBytes('0xff'), from, salt, bytecodeHash])), 12),
   )

--- a/src/utils/address/getContractAddress.ts
+++ b/src/utils/address/getContractAddress.ts
@@ -55,16 +55,15 @@ export function getCreate2Address(opts: GetCreate2AddressOptions) {
   const salt = pad(isBytes(opts.salt) ? opts.salt : toBytes(opts.salt), {
     size: 32,
   })
-  const bytecodeHash =
-    'bytecodeHash' in opts
-      ? isBytes(opts.bytecodeHash)
-        ? opts.bytecodeHash
-        : toBytes(opts.bytecodeHash)
-      : toBytes(
-          keccak256(
-            isBytes(opts.bytecode) ? opts.bytecode : toBytes(opts.bytecode),
-          ),
-        )
+
+  const bytecodeHash = (() => {
+    if ('bytecodeHash' in opts) {
+      if (isBytes(opts.bytecodeHash)) return opts.bytecodeHash
+      return toBytes(opts.bytecodeHash)
+    }
+    return keccak256(opts.bytecode, 'bytes')
+  })()
+
   return getAddress(
     slice(keccak256(concat([toBytes('0xff'), from, salt, bytecodeHash])), 12),
   )


### PR DESCRIPTION
In certain cases, such as [UniSwap Pair contracts](https://docs.uniswap.org/sdk/v3/guides/quoting#computing-the-pools-deployment-address), the hash of the bytecode is easily publicly available. In these cases it can be useful to allow passing a `bytecodeHash` into `getContractAddress`, instead of having to retrieve (and include in your code) the full contract bytecode.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added an optional `bytecodeHash` parameter to the `getContractAddress` function in the `src/utils/address/getContractAddress.ts` file.
- Modified the `GetCreate2AddressOptions` type to include the new `bytecodeHash` parameter.
- Updated the tests in the `src/utils/address/getContractAddress.test.ts` file to include cases with the `bytecodeHash` parameter.
- Added documentation in the `site/docs/utilities/getContractAddress.md` file for the new `bytecodeHash` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->