### PR TITLE
Fuse updates: RPC URL & Configure the multicall3 contract address

### DIFF
--- a/.changeset/giant-gifts-mix.md
+++ b/.changeset/giant-gifts-mix.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Updates Fuse chain config: RPC URL & Configure the multicall3 contract address

--- a/src/chains/definitions/fuse.ts
+++ b/src/chains/definitions/fuse.ts
@@ -7,9 +7,15 @@ export const fuse = /*#__PURE__*/ defineChain({
   nativeCurrency: { name: 'Fuse', symbol: 'FUSE', decimals: 18 },
   rpcUrls: {
     default: { http: ['https://rpc.fuse.io'] },
-    public: { http: ['https://fuse-mainnet.chainstacklabs.com'] },
+    public: { http: ['https://rpc.fuse.io'] },
   },
   blockExplorers: {
     default: { name: 'Fuse Explorer', url: 'https://explorer.fuse.io' },
+  },
+  contracts: {
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 16146628,
+    },
   },
 })


### PR DESCRIPTION
We have updated the RPC URL for Fuse from https://fuse-mainnet.chainstacklabs.com to https://rpc.fuse.io due to Chainstack ending support for Fuse. Additionally, we have configured the multicall3 contract address.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Fuse chain configuration by changing the RPC URL and configuring the multicall3 contract address.

### Detailed summary
- Updated the Fuse chain config by changing the RPC URL to 'https://rpc.fuse.io'
- Configured the multicall3 contract address as '0xca11bde05977b3631167028862be2a173976ca11' with a blockCreated value of 16146628.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->