### PR TITLE
fix: zero base fee

### DIFF
--- a/src/actions/public/estimateMaxPriorityFeePerGas.test.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.test.ts
@@ -154,7 +154,7 @@ test('client: chain `defaultPriorityFee` override', async () => {
     transport: http(),
   })
   expect(await estimateMaxPriorityFeePerGas(client_4)).toBe(0n)
-  
+
   // async zero base fee
   const client_5 = createPublicClient({
     chain: {

--- a/src/actions/public/estimateMaxPriorityFeePerGas.test.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.test.ts
@@ -74,6 +74,36 @@ test('args: chain `defaultPriorityFee` override', async () => {
       },
     }),
   ).toBe(69420n)
+
+  // zero base fee
+  const client_4 = createPublicClient({
+    transport: http(localHttpUrl),
+  })
+  expect(
+    await estimateMaxPriorityFeePerGas(client_4, {
+      chain: {
+        ...anvilChain,
+        fees: {
+          defaultPriorityFee: 0n,
+        },
+      },
+    }),
+  ).toBe(0n)
+
+  // async zero base fee
+  const client_5 = createPublicClient({
+    transport: http(localHttpUrl),
+  })
+  expect(
+    await estimateMaxPriorityFeePerGas(client_5, {
+      chain: {
+        ...anvilChain,
+        fees: {
+          defaultPriorityFee: async () => 0n,
+        },
+      },
+    }),
+  ).toBe(0n)
 })
 
 test('client: chain `defaultPriorityFee` override', async () => {
@@ -112,6 +142,30 @@ test('client: chain `defaultPriorityFee` override', async () => {
     transport: http(),
   })
   expect(await estimateMaxPriorityFeePerGas(client_3)).toBe(69420n)
+
+  // zero base fee
+  const client_4 = createPublicClient({
+    chain: {
+      ...anvilChain,
+      fees: {
+        defaultPriorityFee: 0n,
+      },
+    },
+    transport: http(),
+  })
+  expect(await estimateMaxPriorityFeePerGas(client_4)).toBe(0n)
+  
+  // async zero base fee
+  const client_5 = createPublicClient({
+    chain: {
+      ...anvilChain,
+      fees: {
+        defaultPriorityFee: async () => 0n,
+      },
+    },
+    transport: http(),
+  })
+  expect(await estimateMaxPriorityFeePerGas(client_5)).toBe(0n)
 })
 
 test('chain does not support eip1559', async () => {

--- a/src/actions/public/estimateMaxPriorityFeePerGas.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.ts
@@ -88,7 +88,7 @@ export async function internal_estimateMaxPriorityFeePerGas<
       client,
       request,
     } as ChainFeesFnParameters)
-  } else if (chain?.fees?.defaultPriorityFee)
+  } else if (typeof chain?.fees?.defaultPriorityFee !== 'undefined')
     return chain?.fees?.defaultPriorityFee
 
   try {

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -586,7 +586,7 @@ describe('prepareTransactionRequest', () => {
       (block.baseFeePerGas! * 120n) / 100n + parseGwei('69'),
     )
 
-    // chain override (zero base fee)
+    // chain override (bigint zero base fee)
     const request_7 = await prepareTransactionRequest(walletClient, {
       account: privateKeyToAccount(sourceAccount.privateKey),
       chain: {
@@ -600,6 +600,21 @@ describe('prepareTransactionRequest', () => {
     })
     expect(request_7.maxFeePerGas).toEqual(0n)
     expect(request_7.maxPriorityFeePerGas).toEqual(0n)
+
+    // chain override (async zero base fee)
+    const request_8 = await prepareTransactionRequest(walletClient, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      chain: {
+        ...anvilChain,
+        fees: {
+          defaultPriorityFee: async () => 0n,
+        },
+      },
+      to: targetAccount.address,
+      value: parseEther('1'),
+    })
+    expect(request_8.maxFeePerGas).toEqual(0n)
+    expect(request_8.maxPriorityFeePerGas).toEqual(0n)
   })
 
   test('no account', async () => {

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -585,6 +585,21 @@ describe('prepareTransactionRequest', () => {
     expect(request_6.maxFeePerGas).toEqual(
       (block.baseFeePerGas! * 120n) / 100n + parseGwei('69'),
     )
+
+    // chain override (zero base fee)
+    const request_7 = await prepareTransactionRequest(walletClient, {
+      account: privateKeyToAccount(sourceAccount.privateKey),
+      chain: {
+        ...anvilChain,
+        fees: {
+          defaultPriorityFee: 0n,
+        },
+      },
+      to: targetAccount.address,
+      value: parseEther('1'),
+    })
+    expect(request_7.maxFeePerGas).toEqual(0n)
+    expect(request_7.maxPriorityFeePerGas).toEqual(0n)
   })
 
   test('no account', async () => {

--- a/src/actions/wallet/prepareTransactionRequest.test.ts
+++ b/src/actions/wallet/prepareTransactionRequest.test.ts
@@ -598,7 +598,6 @@ describe('prepareTransactionRequest', () => {
       to: targetAccount.address,
       value: parseEther('1'),
     })
-    expect(request_7.maxFeePerGas).toEqual(0n)
     expect(request_7.maxPriorityFeePerGas).toEqual(0n)
 
     // chain override (async zero base fee)
@@ -613,7 +612,6 @@ describe('prepareTransactionRequest', () => {
       to: targetAccount.address,
       value: parseEther('1'),
     })
-    expect(request_8.maxFeePerGas).toEqual(0n)
     expect(request_8.maxPriorityFeePerGas).toEqual(0n)
   })
 

--- a/src/package.json
+++ b/src/package.json
@@ -86,42 +86,18 @@
   },
   "typesVersions": {
     "*": {
-      "abi": [
-        "./_types/abi/index.d.ts"
-      ],
-      "accounts": [
-        "./_types/accounts/index.d.ts"
-      ],
-      "actions": [
-        "./_types/actions/index.d.ts"
-      ],
-      "chains": [
-        "./_types/chains/index.d.ts"
-      ],
-      "chains/utils": [
-        "./_types/chains/utils/index.d.ts"
-      ],
-      "contract": [
-        "./_types/contract/index.d.ts"
-      ],
-      "ens": [
-        "./_types/ens/index.d.ts"
-      ],
-      "public": [
-        "./_types/public/index.d.ts"
-      ],
-      "test": [
-        "./_types/test/index.d.ts"
-      ],
-      "utils": [
-        "./_types/utils/index.d.ts"
-      ],
-      "wallet": [
-        "./_types/wallet/index.d.ts"
-      ],
-      "window": [
-        "./_types/window/index.d.ts"
-      ]
+      "abi": ["./_types/abi/index.d.ts"],
+      "accounts": ["./_types/accounts/index.d.ts"],
+      "actions": ["./_types/actions/index.d.ts"],
+      "chains": ["./_types/chains/index.d.ts"],
+      "chains/utils": ["./_types/chains/utils/index.d.ts"],
+      "contract": ["./_types/contract/index.d.ts"],
+      "ens": ["./_types/ens/index.d.ts"],
+      "public": ["./_types/public/index.d.ts"],
+      "test": ["./_types/test/index.d.ts"],
+      "utils": ["./_types/utils/index.d.ts"],
+      "wallet": ["./_types/wallet/index.d.ts"],
+      "window": ["./_types/window/index.d.ts"]
     }
   },
   "peerDependencies": {
@@ -145,21 +121,12 @@
   },
   "license": "MIT",
   "repository": "wagmi-dev/viem",
-  "authors": [
-    "awkweb.eth",
-    "jxom.eth"
-  ],
+  "authors": ["awkweb.eth", "jxom.eth"],
   "funding": [
     {
       "type": "github",
       "url": "https://github.com/sponsors/wagmi-dev"
     }
   ],
-  "keywords": [
-    "eth",
-    "ethereum",
-    "dapps",
-    "wallet",
-    "web3"
-  ]
+  "keywords": ["eth", "ethereum", "dapps", "wallet", "web3"]
 }


### PR DESCRIPTION
I just bumped viem from 1.6.0 to 1.14.0 and I am seeing "intrinsic gas too high" when using `writeContract` on an anvil chain running with `--base-fee 0` and [viem chain set to `fees: { defaultPriorityFee: 0n }`](https://github.com/latticexyz/mud/blob/f99e889872e6881bf32bcb9a605b8b5c1b05fac4/packages/common/src/chains/mudFoundry.ts#L7).

Looking at request logs, I can see a new call to `eth_maxPriorityFeePerGas` before `eth_estimateGas` that returns `0x3b9aca00`, which is used as the value for `maxFeePerGas` and `maxPriorityFeePerGas` in the `eth_estimateGas` call.

Before the version bump, there was no `eth_maxPriorityFeePerGas` call and the `0n` from the chain config's `defaultPriorityFee` was used as the value of `maxFeePerGas` and `maxPriorityFeePerGas`.

I am not sure if I am misunderstanding the new fee calculation but this seems like a regression from the previous behavior that respected the chain config's `defaultPriorityFee`? I think this behavior changed in https://github.com/wagmi-dev/viem/pull/1058 but haven't read it thoroughly.

I've added a test for this here, but can't seem to get tests running locally to verify that it fails + add a fix.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
This PR focuses on improving the handling of defaultPriorityFee in the code.

### Detailed summary:
- Added a check for typeof chain?.fees?.defaultPriorityFee to handle undefined values.
- Added tests for chain override with zero base fee and async zero base fee.
- Updated package.json to include typesVersions for better type definitions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->