### PR TITLE
fix: TransactionRequest `to` type

### DIFF
--- a/.changeset/violet-actors-fry.md
+++ b/.changeset/violet-actors-fry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added `null` as a valid value on `TransactionRequestBase['to']` type.

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -133,7 +133,7 @@ export type TransactionRequestBase<TQuantity = bigint, TIndex = number> = {
   /** Unique number identifying this transaction */
   nonce?: TIndex
   /** Transaction recipient */
-  to?: Address
+  to?: Address | null
   /** Value in wei sent with this transaction */
   value?: TQuantity
 }


### PR DESCRIPTION
Fixes #1296 – as `null` is a valid serializable value (serializes to `"0x"`), we should accept it as a value to `TransactionRequest`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding `null` as a valid value on the `to` property of the `TransactionRequestBase` type.

### Detailed summary
- Added `null` as a valid value on the `to` property of the `TransactionRequestBase` type in `transaction.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->