### PR TITLE
fix: add back HttpTransportConfig to exported types

### DIFF
--- a/.changeset/short-peas-taste.md
+++ b/.changeset/short-peas-taste.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Exported `HttpTransportConfig`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -435,6 +435,7 @@ export {
 } from './clients/transports/fallback.js'
 export {
   type HttpTransport,
+  type HttpTransportConfig,
   type HttpTransportErrorType,
   http,
 } from './clients/transports/http.js'


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on exporting the `HttpTransportConfig` in the `index.ts` file.

### Detailed summary
- Exported `HttpTransportConfig` in `index.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->