### PR TITLE
feat: export fetchOptions from http transport init

### DIFF
--- a/src/clients/transports/http.test.ts
+++ b/src/clients/transports/http.test.ts
@@ -27,6 +27,7 @@ test('default', () => {
       },
       "request": [Function],
       "value": {
+        "fetchOptions": undefined,
         "url": "https://mockapi.com/rpc",
       },
     }
@@ -52,6 +53,7 @@ describe('config', () => {
         },
         "request": [Function],
         "value": {
+          "fetchOptions": undefined,
           "url": "https://mockapi.com/rpc",
         },
       }
@@ -76,6 +78,7 @@ describe('config', () => {
         },
         "request": [Function],
         "value": {
+          "fetchOptions": undefined,
           "url": "https://mockapi.com/rpc",
         },
       }
@@ -98,6 +101,40 @@ describe('config', () => {
         },
         "request": [Function],
         "value": {
+          "fetchOptions": undefined,
+          "url": "https://mockapi.com/rpc",
+        },
+      }
+    `)
+  })
+
+  test('fetchOptions', () => {
+    const transport = http('https://mockapi.com/rpc', {
+      fetchOptions: {
+        headers: {
+          A: 'b',
+        },
+      },
+    })({})
+
+    expect(transport).toMatchInlineSnapshot(`
+      {
+        "config": {
+          "key": "http",
+          "name": "HTTP JSON-RPC",
+          "request": [Function],
+          "retryCount": 3,
+          "retryDelay": 150,
+          "timeout": 10000,
+          "type": "http",
+        },
+        "request": [Function],
+        "value": {
+          "fetchOptions": {
+            "headers": {
+              "A": "b",
+            },
+          },
           "url": "https://mockapi.com/rpc",
         },
       }

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -47,7 +47,8 @@ export type HttpTransportConfig = {
 export type HttpTransport = Transport<
   'http',
   {
-    url?: string
+    url: string
+    fetchOptions?: HttpOptions['fetchOptions']
   }
 >
 
@@ -119,7 +120,8 @@ export function http(
         type: 'http',
       },
       {
-        url,
+        url: url_,
+        fetchOptions,
       },
     )
   }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Focus of this PR:
This PR focuses on updating the `http` function in the `http.ts` file to include a required `url` parameter and an optional `fetchOptions` parameter. It also updates the corresponding test file `http.test.ts` to reflect these changes.

### Detailed summary:
- In `http.ts`:
  - The `url` parameter is changed from optional to required.
  - The `fetchOptions` parameter is added as an optional parameter.
- In `http.test.ts`:
  - The `fetchOptions` property is added to the test value object.
  - The `fetchOptions` property is added to the test value object in multiple test cases.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->