### PR TITLE
fix: `decodeEventLogs` strict mode

### DIFF
--- a/.changeset/plenty-meals-visit.md
+++ b/.changeset/plenty-meals-visit.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed topics mismatch in `decodeEventLogs` strict mode.

--- a/src/actions/public/getFilterChanges.test.ts
+++ b/src/actions/public/getFilterChanges.test.ts
@@ -356,7 +356,7 @@ describe('contract events', () => {
         'Transfer'
       >[]
     >(logs)
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
   })
 
   test('args: singular `from`', async () => {
@@ -858,7 +858,7 @@ describe('events', () => {
 
     assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
 
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<{
       from: Address
@@ -920,7 +920,7 @@ describe('events', () => {
     let logs = await getFilterChanges(publicClient, { filter })
     assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
 
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<
       readonly [`0x${string}`, `0x${string}`, bigint]

--- a/src/actions/public/getFilterLogs.test.ts
+++ b/src/actions/public/getFilterLogs.test.ts
@@ -315,7 +315,7 @@ describe('contract events', () => {
         'Transfer'
       >[]
     >(logs)
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
   })
 
   test('args: singular `from`', async () => {
@@ -740,7 +740,7 @@ describe('raw events', () => {
 
     assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
 
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<{
       from: Address
@@ -797,7 +797,7 @@ describe('raw events', () => {
 
     assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
 
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<
       readonly [`0x${string}`, `0x${string}`, bigint]

--- a/src/actions/public/getLogs.test.ts
+++ b/src/actions/public/getLogs.test.ts
@@ -281,7 +281,7 @@ describe('events', () => {
     })
 
     assertType<Log<bigint, number, boolean, typeof event.default, true>[]>(logs)
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<{
       from: `0x${string}`
@@ -334,7 +334,7 @@ describe('events', () => {
     })
 
     assertType<Log<bigint, number, boolean, typeof event.unnamed, true>[]>(logs)
-    expect(logs.length).toBe(784)
+    expect(logs.length).toBe(783)
 
     expectTypeOf(logs[0].args).toEqualTypeOf<
       readonly [`0x${string}`, `0x${string}`, bigint]

--- a/src/utils/abi/decodeEventLog.test.ts
+++ b/src/utils/abi/decodeEventLog.test.ts
@@ -773,6 +773,52 @@ describe('GitHub repros', () => {
       `)
     })
   })
+
+  describe('https://github.com/wagmi-dev/viem/issues/1336', () => {
+    test('topics + event params mismatch', () => {
+      expect(() =>
+        decodeEventLog({
+          abi: [
+            {
+              anonymous: false,
+              inputs: [
+                {
+                  indexed: true,
+                  internalType: 'uint256',
+                  name: 'nounId',
+                  type: 'uint256',
+                },
+                {
+                  indexed: false,
+                  internalType: 'uint256',
+                  name: 'startTime',
+                  type: 'uint256',
+                },
+                {
+                  indexed: false,
+                  internalType: 'uint256',
+                  name: 'endTime',
+                  type: 'uint256',
+                },
+              ],
+              name: 'AuctionCreated',
+              type: 'event',
+            },
+          ],
+          data: '0x00000000000000000000000000000000000000000000000000000000000000680000000000000000000000000000000000000000000000004563918244f400000000000000000000000000000000000000000000000000000000000062845fba',
+          topics: [
+            '0xd6eddd1118d71820909c1197aa966dbc15ed6f508554252169cc3d5ccac756ca',
+          ],
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `
+        "Expected a topic for indexed event parameter \\"nounId\\" on event \\"AuctionCreated(uint256 nounId, uint256 startTime, uint256 endTime)\\".
+
+        Version: viem@1.0.2"
+      `,
+      )
+    })
+  })
 })
 
 test("errors: event doesn't exist", () => {

--- a/src/utils/abi/decodeEventLog.ts
+++ b/src/utils/abi/decodeEventLog.ts
@@ -124,17 +124,15 @@ export function decodeEventLog<
 
   // Decode topics (indexed args).
   const indexedInputs = inputs.filter((x) => 'indexed' in x && x.indexed)
-  if (argTopics.length > 0) {
-    for (let i = 0; i < indexedInputs.length; i++) {
-      const param = indexedInputs[i]
-      const topic = argTopics[i]
-      if (!topic)
-        throw new DecodeLogTopicsMismatch({
-          abiItem,
-          param: param as AbiParameter & { indexed: boolean },
-        })
-      args[param.name || i] = decodeTopic({ param, value: topic })
-    }
+  for (let i = 0; i < indexedInputs.length; i++) {
+    const param = indexedInputs[i]
+    const topic = argTopics[i]
+    if (!topic)
+      throw new DecodeLogTopicsMismatch({
+        abiItem,
+        param: param as AbiParameter & { indexed: boolean },
+      })
+    args[param.name || i] = decodeTopic({ param, value: topic })
   }
 
   // Decode data (non-indexed args).


### PR DESCRIPTION
Fixes #1336.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed topics mismatch in `decodeEventLogs` strict mode.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->