### PR TITLE
docs: multicall add blockNumber option

### DIFF
--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -271,6 +271,26 @@ const results = await publicClient.multicall({
 })
 ```
 
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the read against.
+
+```ts
+const results = await publicClient.multicall({
+  contracts: [
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: wagmiAbi,
+      functionName: 'totalSupply',
+    },
+    ...
+  ],
+  blockNumber: 15121123n, // [!code focus]
+})
+```
+
 ## Live Example
 
 Check out the usage of `multicall` in the live [Multicall Example](https://stackblitz.com/github/wagmi-dev/viem/tree/main/examples/contracts_multicall) below.

--- a/site/docs/contract/multicall.md
+++ b/site/docs/contract/multicall.md
@@ -250,6 +250,26 @@ const results = await publicClient.multicall({
 })
 ```
 
+### blockNumber (optional)
+
+- **Type:** `number`
+
+The block number to perform the read against.
+
+```ts
+const results = await publicClient.multicall({
+  contracts: [
+    {
+      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
+      abi: wagmiAbi,
+      functionName: 'totalSupply',
+    },
+    ...
+  ],
+  blockNumber: 15121123n, // [!code focus]
+})
+```
+
 ### multicallAddress (optional)
 
 - **Type:** [`Address`](/docs/glossary/types#address)
@@ -268,26 +288,6 @@ const results = await publicClient.multicall({
     ...
   ],
   multicallAddress: '0xca11bde05977b3631167028862be2a173976ca11' // [!code focus]
-})
-```
-
-### blockNumber (optional)
-
-- **Type:** `number`
-
-The block number to perform the read against.
-
-```ts
-const results = await publicClient.multicall({
-  contracts: [
-    {
-      address: '0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2',
-      abi: wagmiAbi,
-      functionName: 'totalSupply',
-    },
-    ...
-  ],
-  blockNumber: 15121123n, // [!code focus]
 })
 ```
 


### PR DESCRIPTION
Adds missing blockNumber option to multicall.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added a new optional parameter `blockNumber` to the `multicall` function in `multicall.md` file.
- The `blockNumber` parameter is of type `number` and specifies the block number to perform the read against.
- Updated the code example to include the usage of the `blockNumber` parameter.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->