### PR TITLE
Docs: fixes minuscule typos in docs

### DIFF
--- a/site/docs/accounts/signTransaction.md
+++ b/site/docs/accounts/signTransaction.md
@@ -51,7 +51,7 @@ const signature = await account.signTransaction({
   nonce: 69,
   to: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266'
 }, {
-  serialize(transaction) { // [!code focus:16]
+  serializer(transaction) { // [!code focus:16]
     const {
       chainId,
       nonce,

--- a/site/docs/actions/wallet/sendRawTransaction.md
+++ b/site/docs/actions/wallet/sendRawTransaction.md
@@ -29,7 +29,7 @@ const request = await walletClient.prepareTransactionRequest({
   value: 1000000000000000000n
 })
 
-const signature = await walletClient.signTranasction(request)
+const signature = await walletClient.signTransaction(request)
 
 const hash = await walletClient.sendRawTransaction(signature) // [!code focus]
 ```


### PR DESCRIPTION
Mini PR to fix two typos I ran into while using the code examples.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary

- Changed the `serialize` function to `serializer` in the `signTransaction` method of the `walletClient` object.
- Corrected the misspelling of `signTransaction` in the `sendRawTransaction` method of the `walletClient` object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->