### PR TITLE
feat(chain): add light account factory addresses to chain config

### DIFF
--- a/src/chains/definitions/arbitrum.ts
+++ b/src/chains/definitions/arbitrum.ts
@@ -30,5 +30,9 @@ export const arbitrum = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 7654707,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 137267889,
+    },
   },
 })

--- a/src/chains/definitions/arbitrumGoerli.ts
+++ b/src/chains/definitions/arbitrumGoerli.ts
@@ -34,6 +34,10 @@ export const arbitrumGoerli = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 88114,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 45323084,
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/base.ts
+++ b/src/chains/definitions/base.ts
@@ -42,6 +42,10 @@ export const base = /*#__PURE__*/ defineChain(
         address: '0xca11bde05977b3631167028862be2a173976ca11',
         blockCreated: 5022,
       },
+      lightAccountFactory: {
+        address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+        blockCreated: 4795540,
+      },
     },
   },
   {

--- a/src/chains/definitions/baseGoerli.ts
+++ b/src/chains/definitions/baseGoerli.ts
@@ -34,6 +34,10 @@ export const baseGoerli = /*#__PURE__*/ defineChain(
         address: '0xca11bde05977b3631167028862be2a173976ca11',
         blockCreated: 1376988,
       },
+      lightAccountFactory: {
+        address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+        blockCreated: 10593327,
+      },
     },
     testnet: true,
     sourceId: 5, // goerli

--- a/src/chains/definitions/goerli.ts
+++ b/src/chains/definitions/goerli.ts
@@ -43,6 +43,10 @@ export const goerli = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 6507670,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 9804800,
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/mainnet.ts
+++ b/src/chains/definitions/mainnet.ts
@@ -43,5 +43,9 @@ export const mainnet = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 14353601,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 18273508,
+    },
   },
 })

--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -38,6 +38,10 @@ export const optimism = /*#__PURE__*/ defineChain(
         address: '0xca11bde05977b3631167028862be2a173976ca11',
         blockCreated: 4286263,
       },
+      lightAccountFactory: {
+        address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+        blockCreated: 110390539,
+      },
     },
   },
   {

--- a/src/chains/definitions/optimismGoerli.ts
+++ b/src/chains/definitions/optimismGoerli.ts
@@ -38,6 +38,10 @@ export const optimismGoerli = /*#__PURE__*/ defineChain(
         address: '0xca11bde05977b3631167028862be2a173976ca11',
         blockCreated: 49461,
       },
+      lightAccountFactory: {
+        address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+        blockCreated: 15475831,
+      },
     },
     testnet: true,
   },

--- a/src/chains/definitions/polygon.ts
+++ b/src/chains/definitions/polygon.ts
@@ -36,5 +36,9 @@ export const polygon = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 25770160,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 48296607,
+    },
   },
 })

--- a/src/chains/definitions/polygonMumbai.ts
+++ b/src/chains/definitions/polygonMumbai.ts
@@ -36,6 +36,10 @@ export const polygonMumbai = /*#__PURE__*/ defineChain({
       address: '0xca11bde05977b3631167028862be2a173976ca11',
       blockCreated: 25770160,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 40811264,
+    },
   },
   testnet: true,
 })

--- a/src/chains/definitions/sepolia.ts
+++ b/src/chains/definitions/sepolia.ts
@@ -41,6 +41,10 @@ export const sepolia = /*#__PURE__*/ defineChain({
       address: '0x21B000Fd62a880b2125A61e36a284BB757b76025',
       blockCreated: 3914906,
     },
+    lightAccountFactory: {
+      address: '0x000000893A26168158fbeaDD9335Be5bC96592E2',
+      blockCreated: 4419384,
+    },
   },
   testnet: true,
 })

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -39,6 +39,7 @@ export type ChainConstants = {
     ensRegistry?: ChainContract
     ensUniversalResolver?: ChainContract
     multicall3?: ChainContract
+    lightAccountFactory?: ChainContract
   }
   /** ID in number form */
   id: number


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding a `lightAccountFactory` property to different chain definitions. 

### Detailed summary
- Added `lightAccountFactory` property to the `ChainDefinition` interface in `src/types/chain.ts`
- Added `lightAccountFactory` property to the `base.ts`, `mainnet.ts`, `polygon.ts`, `arbitrum.ts`, `optimism.ts`, `goerli.ts`, `sepolia.ts`, `arbitrumGoerli.ts`, `optimismGoerli.ts`, `polygonMumbai.ts`, and `baseGoerli.ts` files in the `src/chains/definitions` directory

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->