### PR TITLE
Fix trailing slash in arbiscan goerli block explorer url

### DIFF
--- a/.changeset/nasty-goats-lick.md
+++ b/.changeset/nasty-goats-lick.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Remove trailing slash from arbiscan goerli blockexplorer url

--- a/.changeset/nasty-goats-lick.md
+++ b/.changeset/nasty-goats-lick.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Remove trailing slash from arbiscan goerli blockexplorer url
+Removed trailing slash from arbiscan goerli blockexplorer url

--- a/src/chains/definitions/arbitrumGoerli.ts
+++ b/src/chains/definitions/arbitrumGoerli.ts
@@ -26,8 +26,8 @@ export const arbitrumGoerli = /*#__PURE__*/ defineChain({
     },
   },
   blockExplorers: {
-    etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },
-    default: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io/' },
+    etherscan: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io' },
+    default: { name: 'Arbiscan', url: 'https://goerli.arbiscan.io' },
   },
   contracts: {
     multicall3: {


### PR DESCRIPTION
Fix for https://github.com/wagmi-dev/viem/issues/1355

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the trailing slash from the Arbiscan Goerli block explorer URL.

### Detailed summary
- Removed trailing slash from the Arbiscan Goerli block explorer URL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->