### PR TITLE
Change displayed name for Optimism network

### DIFF
--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -4,7 +4,7 @@ import { formattersOptimism } from '../optimism/formatters.js'
 export const optimism = /*#__PURE__*/ defineChain(
   {
     id: 10,
-    name: 'OP Mainnet',
+    name: 'Optimism',
     network: 'optimism',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {


### PR DESCRIPTION
Several protocols utilize metadata views to display network names to end users. The current displayed name, "OP Mainnet," can cause confusion among some users. Most users refer to this network simply as "Optimism." 

Changing the displayed name to "Optimism" would align with the standard name users expect for the network. Overall, the change helps streamline understanding of the network's identity across interfaces.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the `OP Mainnet` to `Optimism` in the `optimism.ts` file.

### Detailed summary
- Renamed `OP Mainnet` to `Optimism` in the `name` field.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->