### PR TITLE
fix: optimism mainnet name to be cohesive with the rest

### DIFF
--- a/src/chains/definitions/optimism.ts
+++ b/src/chains/definitions/optimism.ts
@@ -4,7 +4,7 @@ import { formattersOptimism } from '../optimism/formatters.js'
 export const optimism = /*#__PURE__*/ defineChain(
   {
     id: 10,
-    name: 'OP Mainnet',
+    name: 'Optimism',
     network: 'optimism',
     nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
     rpcUrls: {


### PR DESCRIPTION
This changes OP Mainnet to Optimism. This modification makes Optimism (mainnet) cohesive with Optmism Goerli and Optimism Sepolia. Also, it's better for end users using websites that use `viem`.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming the "OP Mainnet" to "Optimism" in the `optimism.ts` file.

### Detailed summary
- Renamed the `name` property from `'OP Mainnet'` to `'Optimism'` in the `optimism.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->