### PR TITLE
auto-publish provenance statements on release

### DIFF
--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -33,8 +33,8 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bun run changeset:version
-          commit: "chore: version package"
-          title: "chore: version package"
+          commit: 'chore: version package'
+          title: 'chore: version package'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -33,8 +33,8 @@ jobs:
         uses: changesets/action@v1
         with:
           version: bun run changeset:version
-          commit: 'chore: version package'
-          title: 'chore: version package'
+          commit: "chore: version package"
+          title: "chore: version package"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -58,3 +58,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # https://docs.npmjs.com/generating-provenance-statements
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
[provenance statements](https://docs.npmjs.com/generating-provenance-statements) "allow you to publicly establish where a package was built and who published a package, which can increase supply-chain security for your packages."

Example of a package that publishes provenance statements:

https://www.npmjs.com/package/rehype-pretty-code#provenance

Public ledger logs example: https://search.sigstore.dev/?logIndex=33881708

![CleanShot 2023-10-21 at 10 04 24@2x](https://github.com/wagmi-dev/viem/assets/23618431/d2be0f45-c504-4f19-a850-049d1cf7b94a)
links:
- https://docs.npmjs.com/generating-provenance-statements
- https://github.blog/2023-04-19-introducing-npm-package-provenance/

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enabling provenance statements for npm packages. 

### Detailed summary:
- Added `NPM_CONFIG_PROVENANCE: true` to enable provenance statements for npm packages.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->