### PR TITLE
*added multicall3 contract to mode-testnet

### DIFF
--- a/.changeset/curly-years-teach.md
+++ b/.changeset/curly-years-teach.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-added multicall3 to mode-testnet
+Added `multicall3` contract to `modeTestnet` chain.

--- a/.changeset/curly-years-teach.md
+++ b/.changeset/curly-years-teach.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+added multicall3 to mode-testnet

--- a/src/chains/definitions/modeTestnet.ts
+++ b/src/chains/definitions/modeTestnet.ts
@@ -19,5 +19,11 @@ export const modeTestnet = /*#__PURE__*/ defineChain({
       url: 'https://sepolia.explorer.mode.network',
     },
   },
+  contracts: {
+    multicall3: {
+      address: '0xBAba8373113Fb7a68f195deF18732e01aF8eDfCF',
+      blockCreated: 3019007,
+    },
+  },
   testnet: true,
 })


### PR DESCRIPTION
Adding support for `multicall3` contract for `mode-testnet` network.

Link to the smart contract in block explorer is [here](https://sepolia.explorer.mode.network/address/0xBAba8373113Fb7a68f195deF18732e01aF8eDfCF?tab=contract). The contract is verified.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Added `multicall3` contract to `modeTestnet` chain with its address and block created information.
- Set `testnet` flag to `true` in the `modeTestnet` chain definition.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->