### PR TITLE
feat: infer actions from extended client

### DIFF
--- a/.changeset/cyan-oranges-stare.md
+++ b/.changeset/cyan-oranges-stare.md
@@ -1,0 +1,7 @@
+---
+"viem": minor
+---
+
+Added ability for Actions (i.e. `readContract`) to infer their internal/dependant Actions (i.e. `call`) from the optionally extended Client.
+
+For instance, if an extended Client has overridden the `call` Action, then the `readContract` Action will use that instead of Viem's internal `call` Action.

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -29,6 +29,7 @@ import {
   type PacketToBytesErrorType,
   packetToBytes,
 } from '../../utils/ens/packetToBytes.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type ReadContractParameters,
   readContract,
@@ -118,7 +119,10 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
         : { args: [namehash(name)] }),
     })
 
-    const res = await readContract(client, {
+    const res = await getAction(
+      client,
+      readContract,
+    )({
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,
       functionName: 'resolve',

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -8,6 +8,7 @@ import {
   type ParseAvatarRecordErrorType,
   parseAvatarRecord,
 } from '../../utils/ens/avatar/parseAvatarRecord.js'
+import { getAction } from '../../utils/getAction.js'
 
 import {
   type GetEnsTextErrorType,
@@ -67,7 +68,10 @@ export async function getEnsAvatar<TChain extends Chain | undefined>(
     universalResolverAddress,
   }: GetEnsAvatarParameters,
 ): Promise<GetEnsAvatarReturnType> {
-  const record = await getEnsText(client, {
+  const record = await getAction(
+    client,
+    getEnsText,
+  )({
     blockNumber,
     blockTag,
     key: 'avatar',

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -16,6 +16,7 @@ import {
   type PacketToBytesErrorType,
   packetToBytes,
 } from '../../utils/ens/packetToBytes.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type ReadContractErrorType,
   type ReadContractParameters,
@@ -91,7 +92,10 @@ export async function getEnsName<TChain extends Chain | undefined>(
 
   const reverseNode = `${address.toLowerCase().substring(2)}.addr.reverse`
   try {
-    const res = await readContract(client, {
+    const res = await getAction(
+      client,
+      readContract,
+    )({
       address: universalResolverAddress,
       abi: universalResolverReverseAbi,
       functionName: 'reverse',

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -14,6 +14,7 @@ import {
   type PacketToBytesErrorType,
   packetToBytes,
 } from '../../utils/ens/packetToBytes.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type ReadContractParameters,
   readContract,
@@ -87,7 +88,10 @@ export async function getEnsResolver<TChain extends Chain | undefined>(
     })
   }
 
-  const [resolverAddress] = await readContract(client, {
+  const [resolverAddress] = await getAction(
+    client,
+    readContract,
+  )({
     address: universalResolverAddress,
     abi: [
       {

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -27,6 +27,7 @@ import {
   type PacketToBytesErrorType,
   packetToBytes,
 } from '../../utils/ens/packetToBytes.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type ReadContractErrorType,
   type ReadContractParameters,
@@ -109,7 +110,10 @@ export async function getEnsText<TChain extends Chain | undefined>(
   }
 
   try {
-    const res = await readContract(client, {
+    const res = await getAction(
+      client,
+      readContract,
+    )({
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,
       functionName: 'resolve',

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -28,6 +28,7 @@ import type {
 } from '../types/utils.js'
 
 import type { ErrorType } from '../errors/utils.js'
+import { getAction } from '../utils/getAction.js'
 import {
   type CreateContractEventFilterParameters,
   type CreateContractEventFilterReturnType,
@@ -485,7 +486,10 @@ export function getContract<
               ]
             ) => {
               const { args, options } = getFunctionParameters(parameters)
-              return readContract(publicClient, {
+              return getAction(
+                publicClient,
+                readContract,
+              )({
                 abi,
                 address,
                 functionName,
@@ -512,7 +516,10 @@ export function getContract<
               ]
             ) => {
               const { args, options } = getFunctionParameters(parameters)
-              return simulateContract(publicClient, {
+              return getAction(
+                publicClient,
+                simulateContract,
+              )({
                 abi,
                 address,
                 functionName,
@@ -545,7 +552,10 @@ export function getContract<
                 parameters,
                 abiEvent!,
               )
-              return createContractEventFilter(publicClient, {
+              return getAction(
+                publicClient,
+                createContractEventFilter,
+              )({
                 abi,
                 address,
                 eventName,
@@ -576,7 +586,10 @@ export function getContract<
                 parameters,
                 abiEvent!,
               )
-              return getContractEvents(publicClient, {
+              return getAction(
+                publicClient,
+                getContractEvents,
+              )({
                 abi,
                 address,
                 eventName,
@@ -607,7 +620,10 @@ export function getContract<
                 parameters,
                 abiEvent!,
               )
-              return watchContractEvent(publicClient, {
+              return getAction(
+                publicClient,
+                watchContractEvent,
+              )({
                 abi,
                 address,
                 eventName,
@@ -637,7 +653,10 @@ export function getContract<
               ]
             ) => {
               const { args, options } = getFunctionParameters(parameters)
-              return writeContract(walletClient, {
+              return getAction(
+                walletClient,
+                writeContract,
+              )({
                 abi,
                 address,
                 functionName,
@@ -672,7 +691,10 @@ export function getContract<
             ) => {
               const { args, options } = getFunctionParameters(parameters)
               const client = (publicClient ?? walletClient)!
-              return estimateContractGas(client, {
+              return getAction(
+                client,
+                estimateContractGas,
+              )({
                 abi,
                 address,
                 functionName,

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -20,6 +20,7 @@ import {
   type GetContractErrorReturnType,
   getContractError,
 } from '../../utils/errors/getContractError.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type EstimateGasErrorType,
   type EstimateGasParameters,
@@ -95,7 +96,10 @@ export async function estimateContractGas<
     functionName,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
   try {
-    const gas = await estimateGas(client, {
+    const gas = await getAction(
+      client,
+      estimateGas,
+    )({
       data,
       to: address,
       ...request,

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -19,6 +19,7 @@ import type {
   FeeValuesLegacy,
   FeeValuesType,
 } from '../../types/fee.js'
+import { getAction } from '../../utils/getAction.js'
 import type { PrepareTransactionRequestParameters } from '../wallet/prepareTransactionRequest.js'
 import {
   type EstimateMaxPriorityFeePerGasErrorType,
@@ -125,7 +126,7 @@ export async function internal_estimateFeesPerGas<
     (base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) /
     BigInt(denominator)
 
-  const block = block_ ? block_ : await getBlock(client)
+  const block = block_ ? block_ : await getAction(client, getBlock)({})
 
   if (typeof chain?.fees?.estimateFeesPerGas === 'function')
     return chain.fees.estimateFeesPerGas({
@@ -161,7 +162,8 @@ export async function internal_estimateFeesPerGas<
     } as EstimateFeesPerGasReturnType<type>
   }
 
-  const gasPrice = request?.gasPrice ?? multiply(await getGasPrice(client))
+  const gasPrice =
+    request?.gasPrice ?? multiply(await getAction(client, getGasPrice)({}))
   return {
     gasPrice,
   } as EstimateFeesPerGasReturnType<type>

--- a/src/actions/public/estimateMaxPriorityFeePerGas.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.ts
@@ -14,6 +14,7 @@ import {
   type HexToBigIntErrorType,
   hexToBigInt,
 } from '../../utils/encoding/fromHex.js'
+import { getAction } from '../../utils/getAction.js'
 import type { PrepareTransactionRequestParameters } from '../wallet/prepareTransactionRequest.js'
 import { type GetBlockErrorType, getBlock } from './getBlock.js'
 import { type GetGasPriceErrorType, getGasPrice } from './getGasPrice.js'
@@ -82,7 +83,7 @@ export async function internal_estimateMaxPriorityFeePerGas<
 ): Promise<EstimateMaxPriorityFeePerGasReturnType> {
   const { block: block_, chain = client.chain, request } = args || {}
   if (typeof chain?.fees?.defaultPriorityFee === 'function') {
-    const block = block_ || (await getBlock(client))
+    const block = block_ || (await getAction(client, getBlock)({}))
     return chain.fees.defaultPriorityFee({
       block,
       client,
@@ -101,8 +102,8 @@ export async function internal_estimateMaxPriorityFeePerGas<
     // fall back to calculating it manually via `gasPrice - baseFeePerGas`.
     // See: https://github.com/ethereum/pm/issues/328#:~:text=eth_maxPriorityFeePerGas%20after%20London%20will%20effectively%20return%20eth_gasPrice%20%2D%20baseFee
     const [block, gasPrice] = await Promise.all([
-      block_ ? Promise.resolve(block_) : getBlock(client),
-      getGasPrice(client),
+      block_ ? Promise.resolve(block_) : getAction(client, getBlock)({}),
+      getAction(client, getGasPrice)({}),
     ])
 
     if (typeof block.baseFeePerGas !== 'bigint')

--- a/src/actions/public/getContractEvents.ts
+++ b/src/actions/public/getContractEvents.ts
@@ -13,6 +13,7 @@ import {
   type GetAbiItemParameters,
   getAbiItem,
 } from '../../utils/abi/getAbiItem.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type GetLogsErrorType,
   type GetLogsParameters,
@@ -130,7 +131,10 @@ export async function getContractEvents<
   const events = !event
     ? (abi as Abi).filter((x) => x.type === 'event')
     : undefined
-  return getLogs(client, {
+  return getAction(
+    client,
+    getLogs,
+  )({
     address,
     args,
     blockHash,

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -4,6 +4,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { Hash } from '../../types/misc.js'
 import type { FormattedTransactionReceipt } from '../../utils/formatters/transactionReceipt.js'
+import { getAction } from '../../utils/getAction.js'
 
 import {
   type GetBlockNumberErrorType,
@@ -66,8 +67,8 @@ export async function getTransactionConfirmations<
   { hash, transactionReceipt }: GetTransactionConfirmationsParameters<TChain>,
 ): Promise<GetTransactionConfirmationsReturnType> {
   const [blockNumber, transaction] = await Promise.all([
-    getBlockNumber(client),
-    hash ? getTransaction(client, { hash }) : undefined,
+    getAction(client, getBlockNumber)({}),
+    hash ? getAction(client, getTransaction)({ hash }) : undefined,
   ])
   const transactionBlockNumber =
     transactionReceipt?.blockNumber || transaction?.blockNumber

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -32,6 +32,7 @@ import {
 } from '../../utils/errors/getContractError.js'
 
 import type { ErrorType } from '../../errors/utils.js'
+import { getAction } from '../../utils/getAction.js'
 import type { CallParameters } from './call.js'
 import { type ReadContractErrorType, readContract } from './readContract.js'
 
@@ -200,7 +201,10 @@ export async function multicall<
 
   const aggregate3Results = await Promise.allSettled(
     chunkedCalls.map((calls) =>
-      readContract(client, {
+      getAction(
+        client,
+        readContract,
+      )({
         abi: multicall3Abi,
         address: multicallAddress!,
         args: [calls],

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -22,6 +22,7 @@ import {
   type GetContractErrorReturnType,
   getContractError,
 } from '../../utils/errors/getContractError.js'
+import { getAction } from '../../utils/getAction.js'
 
 import { type CallErrorType, type CallParameters, call } from './call.js'
 
@@ -91,7 +92,10 @@ export async function readContract<
     functionName,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
   try {
-    const { data } = await call(client, {
+    const { data } = await getAction(
+      client,
+      call,
+    )({
       data: calldata,
       to: address,
       ...callRequest,

--- a/src/actions/public/simulateContract.test.ts
+++ b/src/actions/public/simulateContract.test.ts
@@ -25,7 +25,6 @@ import { parseEther } from '../../utils/unit/parseEther.js'
 import { parseGwei } from '../../utils/unit/parseGwei.js'
 import { mine } from '../test/mine.js'
 
-import * as call from './call.js'
 import { simulateContract } from './simulateContract.js'
 
 describe('wagmi', () => {
@@ -158,14 +157,14 @@ describe('wagmi', () => {
 })
 
 test('args: dataSuffix', async () => {
-  const spy = vi.spyOn(call, 'call')
+  const spy = vi.spyOn(publicClient, 'call')
   const { request } = await simulateContract(publicClient, {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
     dataSuffix: '0x12345678',
   })
-  expect(spy).toHaveBeenCalledWith(publicClient, {
+  expect(spy).toHaveBeenCalledWith({
     account: accounts[0].address,
     batch: false,
     data: '0x1249c58b12345678',

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -32,6 +32,7 @@ import {
 import type { WriteContractParameters } from '../wallet/writeContract.js'
 
 import type { ErrorType } from '../../errors/utils.js'
+import { getAction } from '../../utils/getAction.js'
 import { type CallErrorType, type CallParameters, call } from './call.js'
 
 export type SimulateContractParameters<
@@ -142,7 +143,10 @@ export async function simulateContract<
     functionName,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
   try {
-    const { data } = await call(client, {
+    const { data } = await getAction(
+      client,
+      call,
+    )({
       batch: false,
       data: `${calldata}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
       to: address,

--- a/src/actions/public/verifyHash.ts
+++ b/src/actions/public/verifyHash.ts
@@ -15,6 +15,7 @@ import {
 } from '../../utils/data/isBytesEqual.js'
 import type { IsHexErrorType } from '../../utils/data/isHex.js'
 import type { ToHexErrorType } from '../../utils/encoding/toHex.js'
+import { getAction } from '../../utils/getAction.js'
 import { encodeDeployData, isHex, toHex } from '../../utils/index.js'
 import { type CallErrorType, type CallParameters, call } from './call.js'
 
@@ -54,7 +55,10 @@ export async function verifyHash<TChain extends Chain | undefined,>(
   const signatureHex = isHex(signature) ? signature : toHex(signature)
 
   try {
-    const { data } = await call(client, {
+    const { data } = await getAction(
+      client,
+      call,
+    )({
       data: encodeDeployData({
         abi: universalSignatureValidatorAbi,
         args: [address, hash, signatureHex],

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -4,6 +4,7 @@ import type { ErrorType } from '../../errors/utils.js'
 import type { Chain } from '../../types/chain.js'
 import type { GetTransportConfig } from '../../types/transport.js'
 import { hexToBigInt } from '../../utils/encoding/fromHex.js'
+import { getAction } from '../../utils/getAction.js'
 import { observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
 import { stringify } from '../../utils/stringify.js'
@@ -108,7 +109,10 @@ export function watchBlockNumber<
       poll(
         async () => {
           try {
-            const blockNumber = await getBlockNumber(client, { cacheTime: 0 })
+            const blockNumber = await getAction(
+              client,
+              getBlockNumber,
+            )({ cacheTime: 0 })
 
             if (prevBlockNumber) {
               // If the current block number is the same as the previous,

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -5,6 +5,7 @@ import type { BlockTag } from '../../types/block.js'
 import type { Chain } from '../../types/chain.js'
 import type { GetTransportConfig } from '../../types/transport.js'
 import { formatBlock } from '../../utils/formatters/block.js'
+import { getAction } from '../../utils/getAction.js'
 import { observe } from '../../utils/observe.js'
 import { type PollErrorType, poll } from '../../utils/poll.js'
 import { type StringifyErrorType, stringify } from '../../utils/stringify.js'
@@ -140,7 +141,10 @@ export function watchBlocks<
       poll(
         async () => {
           try {
-            const block = await getBlock(client, {
+            const block = await getAction(
+              client,
+              getBlock,
+            )({
               blockTag,
               includeTransactions,
             })
@@ -153,10 +157,13 @@ export function watchBlocks<
               // `emitMissed` flag is truthy, let's emit those blocks.
               if (block.number - prevBlock.number > 1 && emitMissed) {
                 for (let i = prevBlock?.number + 1n; i < block.number; i++) {
-                  const block = await getBlock(client, {
+                  const block = (await getAction(
+                    client,
+                    getBlock,
+                  )({
                     blockNumber: i,
                     includeTransactions,
-                  })
+                  })) as GetBlockReturnType<TChain>
                   emit.onBlock(block as any, prevBlock as any)
                   prevBlock = block
                 }

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -25,6 +25,7 @@ import {
   encodeEventTopics,
 } from '../../utils/abi/encodeEventTopics.js'
 import { formatLog } from '../../utils/formatters/log.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type CreateContractEventFilterParameters,
   createContractEventFilter,
@@ -187,7 +188,10 @@ export function watchContractEvent<
         async () => {
           if (!initialized) {
             try {
-              filter = (await createContractEventFilter(client, {
+              filter = (await getAction(
+                client,
+                createContractEventFilter,
+              )({
                 abi,
                 address,
                 args,
@@ -206,19 +210,22 @@ export function watchContractEvent<
           try {
             let logs: Log[]
             if (filter) {
-              logs = await getFilterChanges(client, { filter })
+              logs = await getAction(client, getFilterChanges)({ filter })
             } else {
               // If the filter doesn't exist, we will fall back to use `getLogs`.
               // The fall back exists because some RPC Providers do not support filters.
 
               // Fetch the block number to use for `getLogs`.
-              const blockNumber = await getBlockNumber(client)
+              const blockNumber = await getAction(client, getBlockNumber)({})
 
               // If the block number has changed, we will need to fetch the logs.
               // If the block number doesn't exist, we are yet to reach the first poll interval,
               // so do not emit any logs.
               if (previousBlockNumber && previousBlockNumber !== blockNumber) {
-                logs = await getContractEvents(client, {
+                logs = await getAction(
+                  client,
+                  getContractEvents,
+                )({
                   abi,
                   address,
                   args,
@@ -250,7 +257,7 @@ export function watchContractEvent<
       )
 
       return async () => {
-        if (filter) await uninstallFilter(client, { filter })
+        if (filter) await getAction(client, uninstallFilter)({ filter })
         unwatch()
       }
     })

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -5,6 +5,7 @@ import type { Chain } from '../../types/chain.js'
 import type { Filter } from '../../types/filter.js'
 import type { Hash } from '../../types/misc.js'
 import type { GetTransportConfig } from '../../types/transport.js'
+import { getAction } from '../../utils/getAction.js'
 import { type ObserveErrorType, observe } from '../../utils/observe.js'
 import { poll } from '../../utils/poll.js'
 import { type StringifyErrorType, stringify } from '../../utils/stringify.js'
@@ -125,7 +126,10 @@ export function watchPendingTransactions<
           try {
             if (!filter) {
               try {
-                filter = await createPendingTransactionFilter(client)
+                filter = await getAction(
+                  client,
+                  createPendingTransactionFilter,
+                )({})
                 return
               } catch (err) {
                 unwatch()
@@ -133,7 +137,7 @@ export function watchPendingTransactions<
               }
             }
 
-            const hashes = await getFilterChanges(client, { filter })
+            const hashes = await getAction(client, getFilterChanges)({ filter })
             if (hashes.length === 0) return
             if (batch) emit.onTransactions(hashes)
             else hashes.forEach((hash) => emit.onTransactions([hash]))
@@ -148,7 +152,7 @@ export function watchPendingTransactions<
       )
 
       return async () => {
-        if (filter) await uninstallFilter(client, { filter })
+        if (filter) await getAction(client, uninstallFilter)({ filter })
         unwatch()
       }
     })

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -36,6 +36,7 @@ import type { GetChain } from '../../types/chain.js'
 import type { TransactionSerializable } from '../../types/transaction.js'
 import type { UnionOmit } from '../../types/utils.js'
 import type { FormattedTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import { getAction } from '../../utils/getAction.js'
 import type {
   AssertRequestErrorType,
   AssertRequestParameters,
@@ -129,12 +130,15 @@ export async function prepareTransactionRequest<
   if (!account_) throw new AccountNotFoundError()
   const account = parseAccount(account_)
 
-  const block = await getBlock(client, { blockTag: 'latest' })
+  const block = await getAction(client, getBlock)({ blockTag: 'latest' })
 
   const request = { ...args, from: account.address }
 
   if (typeof nonce === 'undefined')
-    request.nonce = await getTransactionCount(client, {
+    request.nonce = await getAction(
+      client,
+      getTransactionCount,
+    )({
       address: account.address,
       blockTag: 'pending',
     })
@@ -189,7 +193,10 @@ export async function prepareTransactionRequest<
   }
 
   if (typeof gas === 'undefined')
-    request.gas = await estimateGas(client, {
+    request.gas = await getAction(
+      client,
+      estimateGas,
+    )({
       ...request,
       account: { address: account.address, type: 'json-rpc' },
     } as EstimateGasParameters)

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -32,6 +32,7 @@ import {
   type FormattedTransactionRequest,
   formatTransactionRequest,
 } from '../../utils/formatters/transactionRequest.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type AssertRequestErrorType,
   type AssertRequestParameters,
@@ -154,7 +155,7 @@ export async function sendTransaction<
 
     let chainId
     if (chain !== null) {
-      chainId = await getChainId(client)
+      chainId = await getAction(client, getChainId)({})
       assertCurrentChain({
         currentChainId: chainId,
         chain,
@@ -163,7 +164,10 @@ export async function sendTransaction<
 
     if (account.type === 'local') {
       // Prepare the request for signing (assign appropriate fees, etc.)
-      const request = await prepareTransactionRequest(client, {
+      const request = await getAction(
+        client,
+        prepareTransactionRequest,
+      )({
         account,
         accessList,
         chain,
@@ -178,7 +182,7 @@ export async function sendTransaction<
         ...rest,
       } as any)
 
-      if (!chainId) chainId = await getChainId(client)
+      if (!chainId) chainId = await getAction(client, getChainId)({})
 
       const serializer = chain?.serializers?.transaction
       const serializedTransaction = (await account.signTransaction(
@@ -188,7 +192,10 @@ export async function sendTransaction<
         } as TransactionSerializable,
         { serializer },
       )) as Hash
-      return await sendRawTransaction(client, {
+      return await getAction(
+        client,
+        sendRawTransaction,
+      )({
         serializedTransaction,
       })
     }

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -27,6 +27,7 @@ import {
   type FormattedTransactionRequest,
   formatTransactionRequest,
 } from '../../utils/formatters/transactionRequest.js'
+import { getAction } from '../../utils/getAction.js'
 import { numberToHex } from '../../utils/index.js'
 import {
   type AssertRequestErrorType,
@@ -127,7 +128,7 @@ export async function signTransaction<
     ...args,
   })
 
-  const chainId = await getChainId(client)
+  const chainId = await getAction(client, getChainId)({})
   if (chain !== null)
     assertCurrentChain({
       currentChainId: chainId,

--- a/src/actions/wallet/writeContract.test.ts
+++ b/src/actions/wallet/writeContract.test.ts
@@ -18,7 +18,6 @@ import { getTransaction } from '../public/getTransaction.js'
 import { simulateContract } from '../public/simulateContract.js'
 import { mine } from '../test/mine.js'
 
-import * as sendTransaction from './sendTransaction.js'
 import { writeContract } from './writeContract.js'
 
 test('default', async () => {
@@ -132,14 +131,14 @@ describe('args: chain', () => {
 })
 
 test('args: dataSuffix', async () => {
-  const spy = vi.spyOn(sendTransaction, 'sendTransaction')
+  const spy = vi.spyOn(walletClient, 'sendTransaction')
   await writeContract(walletClient, {
     ...wagmiContractConfig,
     account: accounts[0].address,
     functionName: 'mint',
     dataSuffix: '0x12345678',
   })
-  expect(spy).toHaveBeenCalledWith(walletClient, {
+  expect(spy).toHaveBeenCalledWith({
     account: accounts[0].address,
     data: '0x1249c58b12345678',
     to: wagmiContractConfig.address,

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -16,6 +16,7 @@ import {
   encodeFunctionData,
 } from '../../utils/abi/encodeFunctionData.js'
 import type { FormattedTransactionRequest } from '../../utils/formatters/transactionRequest.js'
+import { getAction } from '../../utils/getAction.js'
 import {
   type SendTransactionErrorType,
   type SendTransactionParameters,
@@ -138,7 +139,10 @@ export async function writeContract<
     args,
     functionName,
   } as unknown as EncodeFunctionDataParameters<TAbi, TFunctionName>)
-  const hash = await sendTransaction(client, {
+  const hash = await getAction(
+    client,
+    sendTransaction,
+  )({
     data: `${data}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
     to: address,
     ...request,

--- a/src/clients/createClient.test-d.ts
+++ b/src/clients/createClient.test-d.ts
@@ -1,6 +1,7 @@
-import { expectTypeOf, test } from 'vitest'
+import type { Address } from 'abitype'
+import { describe, expectTypeOf, test } from 'vitest'
 
-import type { JsonRpcAccount } from '../accounts/types.js'
+import type { Account, JsonRpcAccount } from '../accounts/types.js'
 import { localhost } from '../chains/index.js'
 import { type Client, createClient } from './createClient.js'
 import { http } from './transports/http.js'
@@ -42,22 +43,61 @@ test('without account', () => {
   expectTypeOf(client.account).toEqualTypeOf(undefined)
 })
 
-test('extend', () => {
-  const client = createClient({
-    chain: localhost,
-    transport: http(),
+describe('extend', () => {
+  test('default', () => {
+    const client = createClient({
+      chain: localhost,
+      transport: http(),
+    })
+
+    const extended = client
+      .extend((config) => ({
+        getChainId: async () => config.chain.id,
+        foo: 'bar',
+      }))
+      .extend(() => ({}))
+      .extend((config) => ({ bar: `${config.foo}baz` }))
+
+    expectTypeOf(extended).toMatchTypeOf<Client>()
+    expectTypeOf(extended.bar).toEqualTypeOf<'barbaz'>()
+    expectTypeOf(extended.foo).toEqualTypeOf<'bar'>()
+    expectTypeOf(extended.getChainId).toEqualTypeOf<() => Promise<1337>>()
   })
 
-  const extended = client
-    .extend((config) => ({
-      getChainId: () => config.chain.id,
-      foo: 'bar',
-    }))
-    .extend(() => ({}))
-    .extend((config) => ({ bar: `${config.foo}baz` }))
+  test('protected action', () => {
+    const client = createClient({
+      chain: localhost,
+      transport: http(),
+    })
 
-  expectTypeOf(extended).toMatchTypeOf<Client>()
-  expectTypeOf(extended.bar).toEqualTypeOf<'barbaz'>()
-  expectTypeOf(extended.foo).toEqualTypeOf<'bar'>()
-  expectTypeOf(extended.getChainId).toEqualTypeOf<() => 1337>()
+    client.extend(() => ({
+      async sendTransaction(args) {
+        expectTypeOf(args.account).toEqualTypeOf<Address | Account>()
+        expectTypeOf(args.to).toEqualTypeOf<Address | null | undefined>()
+        expectTypeOf(args.value).toEqualTypeOf<bigint | undefined>()
+        return '0x'
+      },
+    }))
+
+    client.extend(() => ({
+      // @ts-expect-error: Type 'string' is not assignable to type 'Promise<`0x${string}`>'.
+      sendTransaction() {
+        return '0x'
+      },
+    }))
+
+    client.extend(() => ({
+      // @ts-expect-error: Type '"bogus"' is not assignable to type '`0x${string}`'.
+      async sendTransaction() {
+        return 'bogus'
+      },
+    }))
+
+    client.extend(() => ({
+      // @ts-expect-error: Type 'SendTransactionParameters<Chain | undefined, Account | undefined, TChainOverride>' is not assignable to type 'number'.
+      async sendTransaction(_args: number) {
+        return '0x'
+      },
+    }))
+  })
 })

--- a/src/clients/createClient.test.ts
+++ b/src/clients/createClient.test.ts
@@ -401,15 +401,15 @@ describe('config', () => {
 })
 
 describe('extends', () => {
-  test('default', () => {
+  test('default', async () => {
     const client = createClient({
       chain: localhost,
       transport: http(),
     }).extend((config) => ({
-      getChainId: () => config.chain.id,
+      getChainId: async () => config.chain.id,
     }))
 
-    expect(client.getChainId()).toEqual(client.chain.id)
+    expect(await client.getChainId()).toEqual(client.chain.id)
   })
 
   test('public actions', () => {

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -1,8 +1,9 @@
 import type { Address } from 'abitype'
 
-import type { Account, JsonRpcAccount } from '../accounts/types.js'
+import type { JsonRpcAccount } from '../accounts/types.js'
 import type { ParseAccountErrorType } from '../accounts/utils/parseAccount.js'
 import type { ErrorType } from '../errors/utils.js'
+import type { Account } from '../types/account.js'
 import type { Chain } from '../types/chain.js'
 import type {
   EIP1193RequestFn,
@@ -12,6 +13,8 @@ import type {
 import type { Prettify } from '../types/utils.js'
 import { parseAccount } from '../utils/accounts.js'
 import { uid } from '../utils/uid.js'
+import type { PublicActions } from './decorators/public.js'
+import type { WalletActions } from './decorators/wallet.js'
 import type { Transport } from './transports/createTransport.js'
 
 export type ClientConfig<
@@ -53,6 +56,34 @@ export type ClientConfig<
   type?: string | undefined
 }
 
+type ProtectedActions = Pick<
+  PublicActions,
+  | 'call'
+  | 'createContractEventFilter'
+  | 'createEventFilter'
+  | 'estimateContractGas'
+  | 'estimateGas'
+  | 'getBlock'
+  | 'getBlockNumber'
+  | 'getChainId'
+  | 'getContractEvents'
+  | 'getEnsText'
+  | 'getFilterChanges'
+  | 'getGasPrice'
+  | 'getLogs'
+  | 'getTransaction'
+  | 'getTransactionCount'
+  | 'getTransactionReceipt'
+  | 'prepareTransactionRequest'
+  | 'readContract'
+  | 'sendRawTransaction'
+  | 'simulateContract'
+  | 'uninstallFilter'
+  | 'watchBlockNumber'
+  | 'watchContractEvent'
+> &
+  Pick<WalletActions, 'sendTransaction' | 'writeContract'>
+
 // TODO: Move `transport` to slot index 2 since `chain` and `account` used more frequently.
 // Otherwise, we end up with a lot of `Client<Transport, chain, account>` in actions.
 export type Client<
@@ -63,7 +94,7 @@ export type Client<
   extended extends Extended | undefined = Extended | undefined,
 > = Client_Base<transport, chain, account, rpcSchema> &
   (extended extends Extended ? extended : unknown) & {
-    extend: <const client extends Extended>(
+    extend: <const client extends Extended & Partial<ProtectedActions>>(
       fn: (
         client: Client<transport, chain, account, rpcSchema, extended>,
       ) => client,

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -56,7 +56,11 @@ export type ClientConfig<
   type?: string | undefined
 }
 
-type ProtectedActions = Pick<
+// Actions that are used internally by other Actions (ie. `call` is used by `readContract`).
+// They are allowed to be extended, but must conform to their parameter & return type interfaces.
+// Example: an extended `call` action must accept `CallParameters` as parameters,
+// and conform to the `CallReturnType` return type.
+type ExtendableProtectedActions = Pick<
   PublicActions,
   | 'call'
   | 'createContractEventFilter'
@@ -94,7 +98,9 @@ export type Client<
   extended extends Extended | undefined = Extended | undefined,
 > = Client_Base<transport, chain, account, rpcSchema> &
   (extended extends Extended ? extended : unknown) & {
-    extend: <const client extends Extended & Partial<ProtectedActions>>(
+    extend: <
+      const client extends Extended & Partial<ExtendableProtectedActions>,
+    >(
       fn: (
         client: Client<transport, chain, account, rpcSchema, extended>,
       ) => client,

--- a/src/utils/getAction.test.ts
+++ b/src/utils/getAction.test.ts
@@ -1,0 +1,46 @@
+import { expect, test, vi } from 'vitest'
+
+import { wagmiContractConfig } from '../../test/src/abis.js'
+import { anvilChain, publicClient } from '../../test/src/utils.js'
+import * as getChainId from '../actions/public/getChainId.js'
+import { readContract } from '../actions/public/readContract.js'
+import { createClient } from '../clients/createClient.js'
+import { http } from '../clients/transports/http.js'
+import { getAction } from './getAction.js'
+
+test('uses tree-shakable action', async () => {
+  const client = createClient({ chain: anvilChain, transport: http() })
+  const actionSpy = vi.spyOn(getChainId, 'getChainId')
+  await getAction(client, getChainId.getChainId)({})
+  expect(actionSpy).toBeCalledWith(client, {})
+})
+
+test('uses client action', async () => {
+  const client = createClient({ chain: anvilChain, transport: http() }).extend(
+    () => ({
+      async getChainId() {
+        return 69
+      },
+    }),
+  )
+  const clientSpy = vi.spyOn(client, 'getChainId')
+  await getAction(client, getChainId.getChainId)({})
+  expect(clientSpy).toBeCalledWith({})
+})
+
+test('e2e', async () => {
+  const client = publicClient.extend(() => ({
+    async call() {
+      return {
+        data: '0x0000000000000000000000000000000000000000000000000000000000000045',
+      }
+    },
+  }))
+  expect(
+    await readContract(client, {
+      ...wagmiContractConfig,
+      functionName: 'balanceOf',
+      args: ['0xa5cc3c03994DB5b0d9A5eEdD10CabaB0813678AC'],
+    }),
+  ).toEqual(69n)
+})

--- a/src/utils/getAction.ts
+++ b/src/utils/getAction.ts
@@ -1,0 +1,13 @@
+import type { Client } from '../clients/createClient.js'
+
+export function getAction<params extends {}, returnType extends {}>(
+  client: Client,
+  action: (_: any, params: params) => returnType,
+) {
+  return (params: params): returnType =>
+    (
+      client as Client & {
+        [key: string]: (params: params) => returnType
+      }
+    )[action.name]?.(params) ?? action(client, params)
+}


### PR DESCRIPTION
Added internal `getAction` utility which allows the ability for Actions (i.e. `readContract`) to infer their internal/dependant Actions (i.e. `call`) from the optionally extended Client.

For instance, if an extended Client has overridden the `call` Action, then the `readContract` Action will use that instead of Viem's internal `call` Action.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding the ability for Actions to infer their internal/dependent Actions from the extended Client. 

### Detailed summary
- Added ability for Actions to infer their internal/dependent Actions from the extended Client.
- Updated `getAction.ts` to include the new functionality.
- Updated multiple action files to use the `getAction` function instead of the previous implementation.

> The following files were skipped due to too many changes: `src/actions/public/estimateFeesPerGas.ts`, `src/actions/public/watchBlocks.ts`, `src/actions/wallet/prepareTransactionRequest.ts`, `src/actions/public/watchPendingTransactions.ts`, `src/actions/wallet/sendTransaction.ts`, `src/actions/public/estimateMaxPriorityFeePerGas.ts`, `src/utils/getAction.test.ts`, `src/actions/public/watchEvent.ts`, `src/actions/public/watchContractEvent.ts`, `src/actions/getContract.ts`, `src/actions/public/waitForTransactionReceipt.ts`, `src/clients/createClient.ts`, `src/clients/createClient.test-d.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->