### PR TITLE
Fix the public URL for holesky

### DIFF
--- a/.changeset/lovely-kings-sparkle.md
+++ b/.changeset/lovely-kings-sparkle.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed Holesky public RPC URL.

--- a/src/chains/definitions/holesky.ts
+++ b/src/chains/definitions/holesky.ts
@@ -10,7 +10,7 @@ export const holesky = /*#__PURE__*/ defineChain({
       http: ['https://ethereum-holesky.publicnode.com'],
     },
     public: {
-      http: ['wss://ethereum-holesky.publicnode.com'],
+      http: ['https://ethereum-holesky.publicnode.com'],
     },
   },
   contracts: {


### PR DESCRIPTION
The http URL should be `https://...`, not `wss://...`. Otherwise it doesn't work.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR fixes the public RPC URL for the Holesky chain. 

### Detailed summary:
- Updated the public RPC URL from `wss://ethereum-holesky.publicnode.com` to `https://ethereum-holesky.publicnode.com`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->