### PR TITLE
Fix batch scheduler sort results

### DIFF
--- a/.changeset/stupid-news-wink.md
+++ b/.changeset/stupid-news-wink.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Added sorting mechanism to batch scheduler.

--- a/src/clients/transports/http.ts
+++ b/src/clients/transports/http.ts
@@ -98,6 +98,7 @@ export function http(
                 fetchOptions,
                 timeout,
               }),
+            sort: (a, b) => a.id - b.id,
           })
 
           const fn = async (body: RpcRequest) =>

--- a/src/utils/promise/createBatchScheduler.ts
+++ b/src/utils/promise/createBatchScheduler.ts
@@ -12,6 +12,11 @@ type PendingPromise<TReturnType extends readonly unknown[] = any> = {
 
 type SchedulerItem = { args: unknown; pendingPromise: PendingPromise }
 
+type BatchResultsCompareFn<TResult = unknown> = (
+  a: TResult,
+  b: TResult,
+) => number
+
 export type CreateBatchSchedulerArguments<
   TParameters = unknown,
   TReturnType extends readonly unknown[] = readonly unknown[],
@@ -20,6 +25,7 @@ export type CreateBatchSchedulerArguments<
   id: number | string
   shouldSplitBatch?: (args: TParameters[]) => boolean
   wait?: number
+  sort?: BatchResultsCompareFn<TReturnType[number]>
 }
 
 export type CreateBatchSchedulerReturnType<
@@ -44,6 +50,7 @@ export function createBatchScheduler<
   id,
   shouldSplitBatch,
   wait = 0,
+  sort,
 }: CreateBatchSchedulerArguments<
   TParameters,
   TReturnType
@@ -58,6 +65,7 @@ export function createBatchScheduler<
 
     fn(args as TParameters[])
       .then((data) => {
+        if (sort && Array.isArray(data)) data.sort(sort)
         scheduler.forEach(({ pendingPromise }, i) =>
           pendingPromise.resolve?.([data[i], data]),
         )


### PR DESCRIPTION
**Focus of the PR** : sort batched rpc responses in http() transport, for cases where the RPC provides them in an unexpected order

**Context of the PR** : migrating Talisman browser extension wallet from ethers to viem

When batching rpc requests, some RPCs do not return responses in the same order as requests.
Viem expects them to be in the same order, which causes a bunch of random bugs in the wallet.

In the example below, `client.getGasPrice()` breaks as it tries to parse the rpc response of `client.getBlock()`.
It can be reproduced once out of 10 batches, approximately, when using https://rpc.ankr.com/bsc

Batch requests
![image](https://github.com/wagmi-dev/viem/assets/26880866/c76ecaca-762e-4acf-bf28-cc2033aac34c)

Batch responses (first 2 responses aren't in the wrong order)
![image](https://github.com/wagmi-dev/viem/assets/26880866/de695770-8a96-41aa-8ffb-bab5a7bf4bc2)

Fixed it by adding a an optional sort method to the `createBatchScheduler` method
I hope you'll like it, please let me know if anything needs to be changed.

Note : I couldn't get `bun run test` to run on my machine, getting a "Anvil failed to start in time" error systematically.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to add a sorting mechanism to the batch scheduler.

### Detailed summary:
- Added a `sort` parameter to the `createBatchScheduler` function.
- Added a `BatchResultsCompareFn` type.
- Modified the `createBatchScheduler` function to sort the data if the `sort` parameter is provided.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->