### PR TITLE
fix: make concat args readonly arrays

### DIFF
--- a/.changeset/moody-lizards-live.md
+++ b/.changeset/moody-lizards-live.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed `concat` parameter type.

--- a/src/utils/data/concat.ts
+++ b/src/utils/data/concat.ts
@@ -10,16 +10,16 @@ export type ConcatErrorType =
   | ErrorType
 
 export function concat<TValue extends Hex | ByteArray>(
-  values: TValue[],
+  values: readonly TValue[],
 ): ConcatReturnType<TValue> {
   if (typeof values[0] === 'string')
-    return concatHex(values as Hex[]) as ConcatReturnType<TValue>
-  return concatBytes(values as ByteArray[]) as ConcatReturnType<TValue>
+    return concatHex(values as readonly Hex[]) as ConcatReturnType<TValue>
+  return concatBytes(values as readonly ByteArray[]) as ConcatReturnType<TValue>
 }
 
 export type ConcatBytesErrorType = ErrorType
 
-export function concatBytes(values: ByteArray[]): ByteArray {
+export function concatBytes(values: readonly ByteArray[]): ByteArray {
   let length = 0
   for (const arr of values) {
     length += arr.length
@@ -35,7 +35,7 @@ export function concatBytes(values: ByteArray[]): ByteArray {
 
 export type ConcatHexErrorType = ErrorType
 
-export function concatHex(values: Hex[]): Hex {
+export function concatHex(values: readonly Hex[]): Hex {
   return `0x${(values as Hex[]).reduce(
     (acc, x) => acc + x.replace('0x', ''),
     '',


### PR DESCRIPTION
Attempts to fix this kind of error:

<img width="614" alt="image" src="https://github.com/wagmi-dev/viem/assets/508855/c9becf87-ee55-49f1-be2f-ab0fc513a628">

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Fixed `concat` parameter type in `src/utils/data/concat.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->