### PR TITLE
feat: add WebSocket RPC for Gnosis Chain

### DIFF
--- a/.changeset/green-gorillas-shop.md
+++ b/.changeset/green-gorillas-shop.md
@@ -1,0 +1,5 @@
+---
+"viem": minor
+---
+
+Added a WebSocket RPC for Gnosis Chain

--- a/.changeset/green-gorillas-shop.md
+++ b/.changeset/green-gorillas-shop.md
@@ -2,4 +2,4 @@
 "viem": minor
 ---
 
-Added a WebSocket RPC for Gnosis Chain
+Added WebSocket RPCs for Gnosis Chain and Chiado

--- a/src/chains/definitions/gnosis.ts
+++ b/src/chains/definitions/gnosis.ts
@@ -10,8 +10,14 @@ export const gnosis = /*#__PURE__*/ defineChain({
     symbol: 'xDAI',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.gnosischain.com'] },
-    public: { http: ['https://rpc.gnosischain.com'] },
+    default: {
+      http: ['https://rpc.gnosischain.com'],
+      webSocket: ['wss://rpc.gnosischain.com/wss'],
+    },
+    public: {
+      http: ['https://rpc.gnosischain.com'],
+      webSocket: ['wss://rpc.gnosischain.com/wss'],
+    },
   },
   blockExplorers: {
     etherscan: {

--- a/src/chains/definitions/gnosisChiado.ts
+++ b/src/chains/definitions/gnosisChiado.ts
@@ -10,8 +10,14 @@ export const gnosisChiado = /*#__PURE__*/ defineChain({
     symbol: 'xDAI',
   },
   rpcUrls: {
-    default: { http: ['https://rpc.chiadochain.net'] },
-    public: { http: ['https://rpc.chiadochain.net'] },
+    default: {
+      http: ['https://rpc.chiadochain.net'],
+      webSocket: ['wss://rpc.chiadochain.net/wss'],
+    },
+    public: {
+      http: ['https://rpc.chiadochain.net'],
+      webSocket: ['wss://rpc.chiadochain.net/wss'],
+    },
   },
   blockExplorers: {
     default: {


### PR DESCRIPTION
Gnosis Chain offers public WebSocket RPCs, so might as well include them by default.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding WebSocket RPCs for Gnosis Chain and Chiado. 

### Detailed summary
- Added WebSocket RPCs for Gnosis Chain
- Added WebSocket RPCs for Chiado Chain

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->