### PR TITLE
fix(scroll-sepolia): remove unavailable WebSocket RPC

### DIFF
--- a/.changeset/rich-crabs-fry.md
+++ b/.changeset/rich-crabs-fry.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Removed Scroll Sepolia WebSocket URLs.

--- a/src/chains/definitions/scrollSepolia.ts
+++ b/src/chains/definitions/scrollSepolia.ts
@@ -8,11 +8,9 @@ export const scrollSepolia = /*#__PURE__*/ defineChain({
   rpcUrls: {
     default: {
       http: ['https://sepolia-rpc.scroll.io'],
-      webSocket: ['wss://sepolia-rpc.scroll.io/ws'],
     },
     public: {
       http: ['https://sepolia-rpc.scroll.io'],
-      webSocket: ['wss://sepolia-rpc.scroll.io/ws'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
Due to the unavailability of WebSocket services for Scroll Sepolia, this commit removes the WebSocket configuration from the `scrollSepolia.ts` file.

Presently, WebSocket RPCs are only operational for the mainnet and alpha testnet.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing Scroll Sepolia WebSocket URLs. 

### Detailed summary
- Removed Scroll Sepolia WebSocket URLs in `scrollSepolia.ts` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->