### PR TITLE
Added Kava Testnet and edited Kava Mainnet RPC

### DIFF
--- a/src/chains/definitions/kava.ts
+++ b/src/chains/definitions/kava.ts
@@ -1,26 +1,26 @@
-import { defineChain } from '../../utils/chain/defineChain.js'
+import { defineChain } from "../../utils/chain/defineChain.js";
 
 export const kava = /*#__PURE__*/ defineChain({
   id: 2222,
-  name: 'Kava EVM',
-  network: 'kava-mainnet',
+  name: "Kava EVM",
+  network: "kava-mainnet",
   nativeCurrency: {
-    name: 'Kava',
-    symbol: 'KAVA',
+    name: "Kava",
+    symbol: "KAVA",
     decimals: 18,
   },
   rpcUrls: {
-    public: { http: ['https://kava-evm.publicnode.com'] },
-    default: { http: ['https://kava-evm.publicnode.com'] },
+    public: { http: ["https://evm.kava.io"] },
+    default: { http: ["https://evm.kava.io"] },
   },
   blockExplorers: {
-    default: { name: 'Kava EVM Explorer', url: 'https://kavascan.com' },
+    default: { name: "Kava EVM Explorer", url: "https://kavascan.com" },
   },
   contracts: {
     multicall3: {
-      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
       blockCreated: 3661165,
     },
   },
   testnet: false,
-})
+});

--- a/src/chains/definitions/kavaTestnet.ts
+++ b/src/chains/definitions/kavaTestnet.ts
@@ -1,0 +1,29 @@
+import { defineChain } from "../../utils/chain/defineChain.js";
+
+export const kava = /*#__PURE__*/ defineChain({
+  id: 2221,
+  name: "Kava EVM Testnet",
+  network: "kava-testnet",
+  nativeCurrency: {
+    name: "Kava",
+    symbol: "KAVA",
+    decimals: 18,
+  },
+  rpcUrls: {
+    public: { http: ["https://evm.testnet.kava.io"] },
+    default: { http: ["https://evm.testnet.kava.io"] },
+  },
+  blockExplorers: {
+    default: {
+      name: "Kava EVM Testnet Explorer",
+      url: "https://testnet.kavascan.com/",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xDf1D724A7166261eEB015418fe8c7679BBEa7fd6",
+      blockCreated: 7242179,
+    },
+  },
+  testnet: true,
+});


### PR DESCRIPTION
Added a new network:
Name: Kava EVM Testnet
Chain ID: 2221

Edited the public RPC endpoints of Kava Mainnet (Chain 2222)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the Kava EVM testnet and mainnet configurations. 

### Detailed summary
- Added a new file `kavaTestnet.ts` to define the Kava EVM testnet configuration.
- Updated the `kava.ts` file to reflect changes in the Kava EVM mainnet configuration.
- Updated the network names, RPC URLs, block explorers, and contract addresses for both testnet and mainnet configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->