### PR TITLE
add chiliz and spicy chains

### DIFF
--- a/src/chains/definitions/chiliz.ts
+++ b/src/chains/definitions/chiliz.ts
@@ -1,0 +1,34 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const chiliz = /*#__PURE__*/ defineChain(
+  {
+    id: 88_888,
+    name: 'Chiliz Chain',
+    network: 'chiliz-chain',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'CHZ',
+      symbol: 'CHZ',
+    },
+    rpcUrls: {
+      default: {
+        http: [
+          'https://rpc.ankr.com/chiliz',
+          'https://chiliz.publicnode.com'
+        ],
+      },
+      public: {
+        http: [
+          'https://rpc.ankr.com/chiliz',
+          'https://chiliz.publicnode.com'
+        ],
+      },
+    },
+    blockExplorers: {
+      default: {
+        name: 'Chiliz Explorer',
+        url: 'https://scan.chiliz.com',
+      },
+    },
+  },
+)

--- a/src/chains/definitions/spicy.ts
+++ b/src/chains/definitions/spicy.ts
@@ -1,0 +1,42 @@
+import { defineChain } from '../../utils/chain/defineChain.js'
+
+export const spicy = /*#__PURE__*/ defineChain(
+  {
+    id: 88_882,
+    name: 'Chiliz Spicy Testnet',
+    network: 'chiliz-spicy-Testnet',
+    nativeCurrency: {
+      decimals: 18,
+      name: 'CHZ',
+      symbol: 'CHZ',
+    },
+    rpcUrls: {
+      default: {
+        http: [
+          'https://spicy-rpc.chiliz.com',
+          'https://chiliz-spicy.publicnode.com'
+        ],
+        webSocket:[
+          'wss://spicy-rpc-ws.chiliz.com',
+          'wss://chiliz-spicy.publicnode.com'
+        ]
+      },
+      public: {
+        http: [
+          'https://spicy-rpc.chiliz.com',
+          'https://chiliz-spicy.publicnode.com'
+        ],
+        webSocket:[
+          'wss://spicy-rpc-ws.chiliz.com',
+          'wss://chiliz-spicy.publicnode.com'
+        ]
+      },
+    },
+    blockExplorers: {
+      default: {
+        name: 'Chiliz Explorer',
+        url: 'http://spicy-explorer.chiliz.com',
+      },
+    },
+  },
+)


### PR DESCRIPTION
- Add Chiliz and Spicy Testnet - [Official Website](https://www.chiliz.com/)

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding definitions for the Chiliz Chain and Chiliz Spicy Testnet. 

### Detailed summary
- Added `chiliz.ts` defining the Chiliz Chain with its ID, name, network, native currency, RPC URLs, and block explorer.
- Added `spicy.ts` defining the Chiliz Spicy Testnet with its ID, name, network, native currency, RPC URLs, and block explorer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->