### PR TITLE
fix: signature normalization

### DIFF
--- a/.changeset/slow-rings-impress.md
+++ b/.changeset/slow-rings-impress.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed issue where `getFunctionSignature`/`getFunctionSelector` would not parse nested tuples in string-based signatures.

--- a/src/utils/contract/extractFunctionParts.ts
+++ b/src/utils/contract/extractFunctionParts.ts
@@ -4,6 +4,7 @@ const paramsRegex = /((function|event)\s)?(.*)(\((.*)\))/
 
 export type ExtractFunctionPartsErrorType = ErrorType
 
+/** @deprecated – use `parseAbiItem` from `abitype`. */
 export function extractFunctionParts(def: string) {
   const parts = def.match(paramsRegex)
   const type = parts?.[2] || undefined
@@ -14,12 +15,14 @@ export function extractFunctionParts(def: string) {
 
 export type ExtractFunctionNameErrorType = ErrorType
 
+/** @deprecated – use `parseAbiItem` from `abitype`. */
 export function extractFunctionName(def: string) {
   return extractFunctionParts(def).name
 }
 
 export type ExtractFunctionParamsErrorType = ErrorType
 
+/** @deprecated – use `parseAbiItem` from `abitype`. */
 export function extractFunctionParams(def: string) {
   const params = extractFunctionParts(def).params
   const splitParams = params?.split(',').map((x) => x.trim().split(' '))
@@ -32,6 +35,7 @@ export function extractFunctionParams(def: string) {
 
 export type ExtractFunctionTypeErrorType = ErrorType
 
+/** @deprecated – use `parseAbiItem` from `abitype`. */
 export function extractFunctionType(def: string) {
   return extractFunctionParts(def).type
 }

--- a/src/utils/hash/getFunctionSignature.ts
+++ b/src/utils/hash/getFunctionSignature.ts
@@ -1,29 +1,19 @@
-import type { AbiFunction } from 'abitype'
+import { type AbiFunction, formatAbiItem } from 'abitype'
 
 import type { ErrorType } from '../../errors/utils.js'
 import {
-  type FormatAbiItemErrorType,
-  formatAbiItem,
-} from '../abi/formatAbiItem.js'
-import {
-  type ExtractFunctionNameErrorType,
-  type ExtractFunctionParamsErrorType,
-  extractFunctionName,
-  extractFunctionParams,
-} from '../contract/extractFunctionParts.js'
+  type NormalizeSignatureErrorType,
+  normalizeSignature,
+} from './normalizeSignature.js'
 
 export type GetFunctionSignatureErrorType =
-  | ExtractFunctionNameErrorType
-  | ExtractFunctionParamsErrorType
-  | FormatAbiItemErrorType
+  | NormalizeSignatureErrorType
   | ErrorType
 
-export const getFunctionSignature = (fn: string | AbiFunction) => {
-  if (typeof fn === 'string') {
-    const name = extractFunctionName(fn)
-    const params = extractFunctionParams(fn) || []
-    return `${name}(${params.map(({ type }) => type).join(',')})`
-  }
-
-  return formatAbiItem(fn)
+export const getFunctionSignature = (fn_: string | AbiFunction) => {
+  const fn = (() => {
+    if (typeof fn_ === 'string') return fn_
+    return formatAbiItem(fn_)
+  })()
+  return normalizeSignature(fn)
 }

--- a/src/utils/hash/normalizeSignature.test.ts
+++ b/src/utils/hash/normalizeSignature.test.ts
@@ -1,0 +1,158 @@
+import { expect, test } from 'vitest'
+import { normalizeSignature } from './normalizeSignature.js'
+
+test('foo()', () => {
+  expect(normalizeSignature('foo()')).toBe('foo()')
+})
+
+test('bar(uint foo)', () => {
+  expect(normalizeSignature('bar(uint foo)')).toBe('bar(uint)')
+})
+
+test('processAccount(uint256 , address )', () => {
+  expect(normalizeSignature('processAccount(uint256 , address )')).toBe(
+    'processAccount(uint256,address)',
+  )
+})
+
+test('function bar()', () => {
+  expect(normalizeSignature('function bar()')).toBe('bar()')
+})
+
+test('function bar()', () => {
+  expect(normalizeSignature('function  bar( )')).toBe('bar()')
+})
+
+test('event Bar()', () => {
+  expect(normalizeSignature('event Bar()')).toBe('Bar()')
+})
+
+test('function bar(uint foo)', () => {
+  expect(normalizeSignature('function bar(uint foo)')).toBe('bar(uint)')
+})
+
+test('function bar(uint foo, address baz)', () => {
+  expect(normalizeSignature('function bar(uint foo, address baz)')).toBe(
+    'bar(uint,address)',
+  )
+})
+
+test('event Barry(uint foo)', () => {
+  expect(normalizeSignature('event Barry(uint foo)')).toBe('Barry(uint)')
+})
+
+test('Barry(uint indexed foo)', () => {
+  expect(normalizeSignature('Barry(uint indexed foo)')).toBe('Barry(uint)')
+})
+
+test('event Barry(uint indexed foo)', () => {
+  expect(normalizeSignature('event Barry(uint indexed foo)')).toBe(
+    'Barry(uint)',
+  )
+})
+
+test('function _compound(uint256 a, uint256 b, uint256 c)', () => {
+  expect(
+    normalizeSignature('function _compound(uint256 a, uint256 b, uint256 c)'),
+  ).toBe('_compound(uint256,uint256,uint256)')
+})
+
+test('bar(uint foo, (uint baz))', () => {
+  expect(normalizeSignature('bar(uint foo, (uint baz))')).toBe(
+    'bar(uint,(uint))',
+  )
+})
+
+test('bar(uint foo, (uint baz, bool x))', () => {
+  expect(normalizeSignature('bar(uint foo, (uint baz, bool x))')).toBe(
+    'bar(uint,(uint,bool))',
+  )
+})
+
+test('bar(uint foo, (uint baz, bool x) foo)', () => {
+  expect(normalizeSignature('bar(uint foo, (uint baz, bool x) foo)')).toBe(
+    'bar(uint,(uint,bool))',
+  )
+})
+
+test('bar(uint[] foo, (uint baz, bool x))', () => {
+  expect(normalizeSignature('bar(uint[] foo, (uint baz, bool x))')).toBe(
+    'bar(uint[],(uint,bool))',
+  )
+})
+
+test('bar(uint[] foo, (uint baz, bool x)[])', () => {
+  expect(normalizeSignature('bar(uint[] foo, (uint baz, bool x)[])')).toBe(
+    'bar(uint[],(uint,bool)[])',
+  )
+})
+
+test('foo(uint bar)', () => {
+  expect(normalizeSignature('foo(uint bar) payable returns (uint)')).toBe(
+    'foo(uint)',
+  )
+})
+
+test('function submitBlocksWithCallbacks(bool isDataCompressed, bytes calldata data, ((uint16,(uint16,uint16,uint16,bytes)[])[], address[])  calldata config)', () => {
+  expect(
+    normalizeSignature(
+      'function submitBlocksWithCallbacks(bool isDataCompressed, bytes calldata data, ((uint16,(uint16,uint16,uint16,bytes)[])[], address[])  calldata config)',
+    ),
+  ).toBe(
+    'submitBlocksWithCallbacks(bool,bytes,((uint16,(uint16,uint16,uint16,bytes)[])[],address[]))',
+  )
+})
+
+test('function createEdition(string name, string symbol, uint64 editionSize, uint16 royaltyBPS, address fundsRecipient, address defaultAdmin, (uint104 publicSalePrice, uint32 maxSalePurchasePerAddress, uint64 publicSaleStart, uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig, string description, string animationURI, string imageURI) returns (address)', () => {
+  expect(
+    normalizeSignature(
+      'function createEdition(string name, string symbol, uint64 editionSize, uint16 royaltyBPS, address fundsRecipient, address defaultAdmin, (uint104 publicSalePrice, uint32 maxSalePurchasePerAddress, uint64 publicSaleStart, uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig, string description, string animationURI, string imageURI) returns (address)',
+    ),
+  ).toBe(
+    'createEdition(string,string,uint64,uint16,address,address,(uint104,uint32,uint64,uint64,uint64,uint64,bytes32),string,string,string)',
+  )
+})
+
+test('trim spaces', () => {
+  expect(
+    normalizeSignature(
+      'function  createEdition(string  name,string symbol,   uint64 editionSize  , uint16   royaltyBPS,     address     fundsRecipient,   address    defaultAdmin, ( uint104   publicSalePrice  ,   uint32 maxSalePurchasePerAddress, uint64 publicSaleStart,   uint64 publicSaleEnd, uint64 presaleStart, uint64 presaleEnd, bytes32 presaleMerkleRoot) saleConfig , string description, string animationURI, string imageURI ) returns (address)',
+    ),
+  ).toBe(
+    'createEdition(string,string,uint64,uint16,address,address,(uint104,uint32,uint64,uint64,uint64,uint64,bytes32),string,string,string)',
+  )
+})
+
+test('error: invalid signatures', () => {
+  expect(() => normalizeSignature('bar')).toThrowErrorMatchingInlineSnapshot(
+    `
+    "Unable to normalize signature.
+
+    Version: viem@1.0.2"
+  `,
+  )
+
+  expect(() =>
+    normalizeSignature('bar(uint foo'),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Unable to normalize signature.
+
+    Version: viem@1.0.2"
+  `)
+
+  expect(() =>
+    normalizeSignature('baruint foo)'),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Unable to normalize signature.
+
+    Version: viem@1.0.2"
+  `)
+
+  expect(() =>
+    normalizeSignature('bar(uint foo, (uint baz)'),
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "Unable to normalize signature.
+
+    Version: viem@1.0.2"
+  `)
+})

--- a/src/utils/hash/normalizeSignature.ts
+++ b/src/utils/hash/normalizeSignature.ts
@@ -1,0 +1,64 @@
+import { BaseError } from '../../errors/base.js'
+import type { ErrorType } from '../../errors/utils.js'
+
+export type NormalizeSignatureParameters = string
+export type NormalizeSignatureReturnType = string
+export type NormalizeSignatureErrorType = ErrorType
+
+export function normalizeSignature(
+  signature: NormalizeSignatureParameters,
+): NormalizeSignatureReturnType {
+  let active = true
+  let current = ''
+  let level = 0
+  let result = ''
+  let valid = false
+
+  for (let i = 0; i < signature.length; i++) {
+    const char = signature[i]
+
+    // If the character is a separator, we want to reactivate.
+    if (['(', ')', ','].includes(char)) active = true
+
+    // If the character is a "level" token, we want to increment/decrement.
+    if (char === '(') level++
+    if (char === ')') level--
+
+    // If we aren't active, we don't want to mutate the result.
+    if (!active) continue
+
+    // If level === 0, we are at the definition level.
+    if (level === 0) {
+      if (char === ' ' && ['event', 'function', ''].includes(result))
+        result = ''
+      else {
+        result += char
+
+        // If we are at the end of the definition, we must be finished.
+        if (char === ')') {
+          valid = true
+          break
+        }
+      }
+
+      continue
+    }
+
+    // Ignore spaces
+    if (char === ' ') {
+      // If the previous character is a separator, and the current section isn't empty, we want to deactivate.
+      if (signature[i - 1] !== ',' && current !== ',' && current !== ',(') {
+        current = ''
+        active = false
+      }
+      continue
+    }
+
+    result += char
+    current += char
+  }
+
+  if (!valid) throw new BaseError('Unable to normalize signature.')
+
+  return result
+}


### PR DESCRIPTION
Fixes #1460. 

Refactored `getFunctionSignature` to use `normalizeSignature` instead of `extractFunctionName`/`extractFunctionParams` which didn't handle tuples correctly.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing an issue in the `getFunctionSignature` and related functions where they were unable to parse nested tuples in string-based signatures.

### Detailed summary:
- Added `normalizeSignature` function to handle parsing of complex function signatures.
- Updated `getFunctionSignature` function to use `normalizeSignature` for parsing signatures.
- Deprecated `extractFunctionParts`, `extractFunctionName`, `extractFunctionParams`, and `extractFunctionType` functions in favor of `parseAbiItem` from `abitype`.
- Added tests for the `normalizeSignature` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->