### PR TITLE
Fix documentation link in README

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -81,7 +81,7 @@ const blockNumber = await client.getBlockNumber();
 
 ## Documentation
 
-[Head to the documentation](https://viem.sh/docs) to read and learn more about viem.
+[Head to the documentation](https://viem.sh/docs/getting-started.html) to read and learn more about viem.
 
 ## Community
 


### PR DESCRIPTION
Current link (https://viem.sh/docs/) redirects to a 404.

I replaced the 404 url with https://viem.sh/docs/getting-started.html since that is what the "Docs" link points to on viem.sh.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the link to the documentation in the README.md file. 

### Detailed summary:
- Updated the link to the documentation in the README.md file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->