### PR TITLE
Allow old extended functions access to new extended functions

### DIFF
--- a/.changeset/little-fans-try.md
+++ b/.changeset/little-fans-try.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed client decorators assignment.

--- a/src/clients/createClient.ts
+++ b/src/clients/createClient.ts
@@ -219,8 +219,8 @@ export function createClient(parameters: ClientConfig): Client {
     return (extendFn: ExtendFn) => {
       const extended = extendFn(base) as Extended
       for (const key in client) delete extended[key]
-      const combined = { ...base, ...extended }
-      return Object.assign(combined, { extend: extend(combined) })
+      Object.assign(base, extended)
+      return Object.assign(base, { extend: extend(base) })
     }
   }
 

--- a/src/clients/createPublicClient.test.ts
+++ b/src/clients/createPublicClient.test.ts
@@ -505,6 +505,7 @@ test('extend', () => {
       "inspectTxpool": [Function],
       "key": "public",
       "mine": [Function],
+      "mode": "anvil",
       "multicall": [Function],
       "name": "Public Client",
       "pollingInterval": 4000,

--- a/src/clients/createWalletClient.test.ts
+++ b/src/clients/createWalletClient.test.ts
@@ -445,6 +445,7 @@ test('extend', () => {
       "inspectTxpool": [Function],
       "key": "wallet",
       "mine": [Function],
+      "mode": "anvil",
       "multicall": [Function],
       "name": "Wallet Client",
       "pollingInterval": 4000,


### PR DESCRIPTION
Fixing the bottom scenario. 

```typescript

let client = createClient({
    ...parameters,
    key,
    name,
    transport: (opts) => transport({ ...opts, retryCount: 0 }),
    type: "smartAccountClient"
})

client = client.extend((client) => ({
    myFirstFunction: (args) => {
        // this wont have access to mySecondFunction
        if(client.mySecondFunction) return client.mySecondFunction()
        return null;
    }
}))

client.extend((client) => ({
    mySecondFunction: (args) => {
        // some computation
        return 5
    }
}))

```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on fixing client decorators assignment. 

### Detailed summary
- Fixed client decorators assignment in `createClient.ts`.
- Added `mode` property with value "anvil" in `createPublicClient.test.ts` and `createWalletClient.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->