### PR TITLE
Link directly to CHANGELOG.md

### DIFF
--- a/site/.vitepress/config.ts
+++ b/site/.vitepress/config.ts
@@ -90,7 +90,7 @@ export default defineConfig({
           },
           {
             text: 'Changelog',
-            link: 'https://github.com/wagmi-dev/viem/blob/main/CHANGELOG.md',
+            link: 'https://github.com/wagmi-dev/viem/blob/main/src/CHANGELOG.md',
           },
           {
             text: 'Contributing',


### PR DESCRIPTION
Previously, the header link to CHANGELOG.md went to a symlink which did not resolve, requiring users to click through to the actual document.

This links directly to the doc itself.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the link to the Changelog in the Vitepress configuration file. 

### Detailed summary:
- Updated the link to the Changelog in the Vitepress configuration file from `'https://github.com/wagmi-dev/viem/blob/main/CHANGELOG.md'` to `'https://github.com/wagmi-dev/viem/blob/main/src/CHANGELOG.md'`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->