### PR TITLE
feat: support `0` and `1` values in `serializeTransaction`

### DIFF
--- a/.changeset/wise-dingos-flash.md
+++ b/.changeset/wise-dingos-flash.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Support `v` values of 0 or 1 in `serializeTransaction`.

--- a/src/utils/transaction/serializeTransaction.test.ts
+++ b/src/utils/transaction/serializeTransaction.test.ts
@@ -174,6 +174,32 @@ describe('eip1559', () => {
     ).toEqual(
       '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
     )
+    expect(
+      serializeTransaction(
+        baseEip1559,
+
+        {
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          v: 0n,
+        },
+      ),
+    ).toEqual(
+      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c080a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(
+      serializeTransaction(
+        baseEip1559,
+
+        {
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          v: 1n,
+        },
+      ),
+    ).toEqual(
+      '0x02f8720182031184773594008477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080c001a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
   })
 
   describe('errors', () => {
@@ -368,6 +394,32 @@ describe('eip2930', () => {
       ),
     ).toEqual(
       '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(
+      serializeTransaction(
+        baseEip2930,
+
+        {
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          v: 0n,
+        },
+      ),
+    ).toEqual(
+      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe80a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+    )
+    expect(
+      serializeTransaction(
+        baseEip2930,
+
+        {
+          r: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          s: '0x60fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
+          v: 1n,
+        },
+      ),
+    ).toEqual(
+      '0x01f8a6018203118477359400809470997970c51812dc3a010c7d01b50e0d17dc79c8880de0b6b3a764000080f838f7941234512345123451234512345123451234512345e1a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe01a060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fea060fdd29ff912ce880cd3edaf9f932dc61d3dae823ea77e0323f94adb9f6a72fe',
     )
   })
 

--- a/src/utils/transaction/serializeTransaction.ts
+++ b/src/utils/transaction/serializeTransaction.ts
@@ -121,12 +121,15 @@ function serializeTransactionEIP1559(
     serializedAccessList,
   ]
 
-  if (signature)
-    serializedTransaction.push(
-      signature.v === 27n ? '0x' : toHex(1), // yParity
-      trim(signature.r),
-      trim(signature.s),
-    )
+  if (signature) {
+    const yParity = (() => {
+      if (signature.v === 0n) return '0x'
+      if (signature.v === 1n) return toHex(1)
+
+      return signature.v === 27n ? '0x' : toHex(1)
+    })()
+    serializedTransaction.push(yParity, trim(signature.r), trim(signature.s))
+  }
 
   return concatHex([
     '0x02',
@@ -165,12 +168,15 @@ function serializeTransactionEIP2930(
     serializedAccessList,
   ]
 
-  if (signature)
-    serializedTransaction.push(
-      signature.v === 27n ? '0x' : toHex(1), // yParity
-      signature.r,
-      signature.s,
-    )
+  if (signature) {
+    const yParity = (() => {
+      if (signature.v === 0n) return '0x'
+      if (signature.v === 1n) return toHex(1)
+
+      return signature.v === 27n ? '0x' : toHex(1)
+    })()
+    serializedTransaction.push(yParity, trim(signature.r), trim(signature.s))
+  }
 
   return concatHex([
     '0x01',


### PR DESCRIPTION
Fixes #1481

<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Added support for `v` values of 0 or 1 in the `serializeTransaction` function.
- Refactored code to handle different `v` values using a conditional statement.
- Updated tests to cover the new functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->