### PR TITLE
fix: `getAction` name 

### DIFF
--- a/.changeset/rare-coats-grow.md
+++ b/.changeset/rare-coats-grow.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Fixed an issue where some consumer minifiers (ie. Terser, SWC) would drop `Function.prototype.name` causing client action overrides to be ignored.

--- a/src/actions/ens/getEnsAddress.ts
+++ b/src/actions/ens/getEnsAddress.ts
@@ -122,6 +122,7 @@ export async function getEnsAddress<TChain extends Chain | undefined,>(
     const res = await getAction(
       client,
       readContract,
+      'readContract',
     )({
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,

--- a/src/actions/ens/getEnsAvatar.ts
+++ b/src/actions/ens/getEnsAvatar.ts
@@ -71,6 +71,7 @@ export async function getEnsAvatar<TChain extends Chain | undefined>(
   const record = await getAction(
     client,
     getEnsText,
+    'getEnsText',
   )({
     blockNumber,
     blockTag,

--- a/src/actions/ens/getEnsName.ts
+++ b/src/actions/ens/getEnsName.ts
@@ -95,6 +95,7 @@ export async function getEnsName<TChain extends Chain | undefined>(
     const res = await getAction(
       client,
       readContract,
+      'readContract',
     )({
       address: universalResolverAddress,
       abi: universalResolverReverseAbi,

--- a/src/actions/ens/getEnsResolver.ts
+++ b/src/actions/ens/getEnsResolver.ts
@@ -91,6 +91,7 @@ export async function getEnsResolver<TChain extends Chain | undefined>(
   const [resolverAddress] = await getAction(
     client,
     readContract,
+    'readContract',
   )({
     address: universalResolverAddress,
     abi: [

--- a/src/actions/ens/getEnsText.ts
+++ b/src/actions/ens/getEnsText.ts
@@ -113,6 +113,7 @@ export async function getEnsText<TChain extends Chain | undefined>(
     const res = await getAction(
       client,
       readContract,
+      'readContract',
     )({
       address: universalResolverAddress,
       abi: universalResolverResolveAbi,

--- a/src/actions/getContract.ts
+++ b/src/actions/getContract.ts
@@ -489,6 +489,7 @@ export function getContract<
               return getAction(
                 publicClient,
                 readContract,
+                'readContract',
               )({
                 abi,
                 address,
@@ -519,6 +520,7 @@ export function getContract<
               return getAction(
                 publicClient,
                 simulateContract,
+                'simulateContract',
               )({
                 abi,
                 address,
@@ -555,6 +557,7 @@ export function getContract<
               return getAction(
                 publicClient,
                 createContractEventFilter,
+                'createContractEventFilter',
               )({
                 abi,
                 address,
@@ -589,6 +592,7 @@ export function getContract<
               return getAction(
                 publicClient,
                 getContractEvents,
+                'getContractEvents',
               )({
                 abi,
                 address,
@@ -623,6 +627,7 @@ export function getContract<
               return getAction(
                 publicClient,
                 watchContractEvent,
+                'watchContractEvent',
               )({
                 abi,
                 address,
@@ -656,6 +661,7 @@ export function getContract<
               return getAction(
                 walletClient,
                 writeContract,
+                'writeContract',
               )({
                 abi,
                 address,
@@ -694,6 +700,7 @@ export function getContract<
               return getAction(
                 client,
                 estimateContractGas,
+                'estimateContractGas',
               )({
                 abi,
                 address,

--- a/src/actions/public/estimateContractGas.ts
+++ b/src/actions/public/estimateContractGas.ts
@@ -99,6 +99,7 @@ export async function estimateContractGas<
     const gas = await getAction(
       client,
       estimateGas,
+      'estimateGas',
     )({
       data,
       to: address,

--- a/src/actions/public/estimateFeesPerGas.ts
+++ b/src/actions/public/estimateFeesPerGas.ts
@@ -126,7 +126,9 @@ export async function internal_estimateFeesPerGas<
     (base * BigInt(Math.ceil(baseFeeMultiplier * denominator))) /
     BigInt(denominator)
 
-  const block = block_ ? block_ : await getAction(client, getBlock)({})
+  const block = block_
+    ? block_
+    : await getAction(client, getBlock, 'getBlock')({})
 
   if (typeof chain?.fees?.estimateFeesPerGas === 'function')
     return chain.fees.estimateFeesPerGas({
@@ -163,7 +165,8 @@ export async function internal_estimateFeesPerGas<
   }
 
   const gasPrice =
-    request?.gasPrice ?? multiply(await getAction(client, getGasPrice)({}))
+    request?.gasPrice ??
+    multiply(await getAction(client, getGasPrice, 'getGasPrice')({}))
   return {
     gasPrice,
   } as EstimateFeesPerGasReturnType<type>

--- a/src/actions/public/estimateMaxPriorityFeePerGas.ts
+++ b/src/actions/public/estimateMaxPriorityFeePerGas.ts
@@ -83,7 +83,7 @@ export async function internal_estimateMaxPriorityFeePerGas<
 ): Promise<EstimateMaxPriorityFeePerGasReturnType> {
   const { block: block_, chain = client.chain, request } = args || {}
   if (typeof chain?.fees?.defaultPriorityFee === 'function') {
-    const block = block_ || (await getAction(client, getBlock)({}))
+    const block = block_ || (await getAction(client, getBlock, 'getBlock')({}))
     return chain.fees.defaultPriorityFee({
       block,
       client,
@@ -102,8 +102,10 @@ export async function internal_estimateMaxPriorityFeePerGas<
     // fall back to calculating it manually via `gasPrice - baseFeePerGas`.
     // See: https://github.com/ethereum/pm/issues/328#:~:text=eth_maxPriorityFeePerGas%20after%20London%20will%20effectively%20return%20eth_gasPrice%20%2D%20baseFee
     const [block, gasPrice] = await Promise.all([
-      block_ ? Promise.resolve(block_) : getAction(client, getBlock)({}),
-      getAction(client, getGasPrice)({}),
+      block_
+        ? Promise.resolve(block_)
+        : getAction(client, getBlock, 'getBlock')({}),
+      getAction(client, getGasPrice, 'getGasPrice')({}),
     ])
 
     if (typeof block.baseFeePerGas !== 'bigint')

--- a/src/actions/public/getContractEvents.ts
+++ b/src/actions/public/getContractEvents.ts
@@ -134,6 +134,7 @@ export async function getContractEvents<
   return getAction(
     client,
     getLogs,
+    'getLogs',
   )({
     address,
     args,

--- a/src/actions/public/getTransactionConfirmations.ts
+++ b/src/actions/public/getTransactionConfirmations.ts
@@ -67,8 +67,10 @@ export async function getTransactionConfirmations<
   { hash, transactionReceipt }: GetTransactionConfirmationsParameters<TChain>,
 ): Promise<GetTransactionConfirmationsReturnType> {
   const [blockNumber, transaction] = await Promise.all([
-    getAction(client, getBlockNumber)({}),
-    hash ? getAction(client, getTransaction)({ hash }) : undefined,
+    getAction(client, getBlockNumber, 'getBlockNumber')({}),
+    hash
+      ? getAction(client, getTransaction, 'getBlockNumber')({ hash })
+      : undefined,
   ])
   const transactionBlockNumber =
     transactionReceipt?.blockNumber || transaction?.blockNumber

--- a/src/actions/public/multicall.ts
+++ b/src/actions/public/multicall.ts
@@ -204,6 +204,7 @@ export async function multicall<
       getAction(
         client,
         readContract,
+        'readContract',
       )({
         abi: multicall3Abi,
         address: multicallAddress!,

--- a/src/actions/public/readContract.ts
+++ b/src/actions/public/readContract.ts
@@ -95,6 +95,7 @@ export async function readContract<
     const { data } = await getAction(
       client,
       call,
+      'call',
     )({
       data: calldata,
       to: address,

--- a/src/actions/public/simulateContract.ts
+++ b/src/actions/public/simulateContract.ts
@@ -146,6 +146,7 @@ export async function simulateContract<
     const { data } = await getAction(
       client,
       call,
+      'call',
     )({
       batch: false,
       data: `${calldata}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,

--- a/src/actions/public/verifyHash.ts
+++ b/src/actions/public/verifyHash.ts
@@ -58,6 +58,7 @@ export async function verifyHash<TChain extends Chain | undefined,>(
     const { data } = await getAction(
       client,
       call,
+      'call',
     )({
       data: encodeDeployData({
         abi: universalSignatureValidatorAbi,

--- a/src/actions/public/waitForTransactionReceipt.ts
+++ b/src/actions/public/waitForTransactionReceipt.ts
@@ -144,6 +144,7 @@ export async function waitForTransactionReceipt<
         const _unwatch = getAction(
           client,
           watchBlockNumber,
+          'watchBlockNumber',
         )({
           emitMissed: true,
           emitOnBegin: true,
@@ -185,6 +186,7 @@ export async function waitForTransactionReceipt<
                     transaction = (await getAction(
                       client,
                       getTransaction,
+                      'getTransaction',
                     )({ hash })) as GetTransactionReturnType<TChain>
                     if (transaction.blockNumber)
                       blockNumber = transaction.blockNumber
@@ -199,7 +201,11 @@ export async function waitForTransactionReceipt<
               }
 
               // Get the receipt to check if it's been processed.
-              receipt = await getAction(client, getTransactionReceipt)({ hash })
+              receipt = await getAction(
+                client,
+                getTransactionReceipt,
+                'getTransactionReceipt',
+              )({ hash })
 
               // Check if we have enough confirmations. If not, continue polling.
               if (
@@ -225,6 +231,7 @@ export async function waitForTransactionReceipt<
                   const block = await getAction(
                     client,
                     getBlock,
+                    'getBlock',
                   )({
                     blockNumber,
                     includeTransactions: true,
@@ -245,6 +252,7 @@ export async function waitForTransactionReceipt<
                   receipt = await getAction(
                     client,
                     getTransactionReceipt,
+                    'getTransactionReceipt',
                   )({
                     hash: replacementTransaction.hash,
                   })

--- a/src/actions/public/watchBlockNumber.ts
+++ b/src/actions/public/watchBlockNumber.ts
@@ -112,6 +112,7 @@ export function watchBlockNumber<
             const blockNumber = await getAction(
               client,
               getBlockNumber,
+              'getBlockNumber',
             )({ cacheTime: 0 })
 
             if (prevBlockNumber) {

--- a/src/actions/public/watchBlocks.ts
+++ b/src/actions/public/watchBlocks.ts
@@ -144,6 +144,7 @@ export function watchBlocks<
             const block = await getAction(
               client,
               getBlock,
+              'getBlock',
             )({
               blockTag,
               includeTransactions,
@@ -160,6 +161,7 @@ export function watchBlocks<
                   const block = (await getAction(
                     client,
                     getBlock,
+                    'getBlock',
                   )({
                     blockNumber: i,
                     includeTransactions,

--- a/src/actions/public/watchContractEvent.ts
+++ b/src/actions/public/watchContractEvent.ts
@@ -191,6 +191,7 @@ export function watchContractEvent<
               filter = (await getAction(
                 client,
                 createContractEventFilter,
+                'createContractEventFilter',
               )({
                 abi,
                 address,
@@ -210,13 +211,21 @@ export function watchContractEvent<
           try {
             let logs: Log[]
             if (filter) {
-              logs = await getAction(client, getFilterChanges)({ filter })
+              logs = await getAction(
+                client,
+                getFilterChanges,
+                'getFilterChanges',
+              )({ filter })
             } else {
               // If the filter doesn't exist, we will fall back to use `getLogs`.
               // The fall back exists because some RPC Providers do not support filters.
 
               // Fetch the block number to use for `getLogs`.
-              const blockNumber = await getAction(client, getBlockNumber)({})
+              const blockNumber = await getAction(
+                client,
+                getBlockNumber,
+                'getBlockNumber',
+              )({})
 
               // If the block number has changed, we will need to fetch the logs.
               // If the block number doesn't exist, we are yet to reach the first poll interval,
@@ -225,6 +234,7 @@ export function watchContractEvent<
                 logs = await getAction(
                   client,
                   getContractEvents,
+                  'getContractEvents',
                 )({
                   abi,
                   address,
@@ -258,7 +268,12 @@ export function watchContractEvent<
       )
 
       return async () => {
-        if (filter) await getAction(client, uninstallFilter)({ filter })
+        if (filter)
+          await getAction(
+            client,
+            uninstallFilter,
+            'uninstallFilter',
+          )({ filter })
         unwatch()
       }
     })

--- a/src/actions/public/watchEvent.ts
+++ b/src/actions/public/watchEvent.ts
@@ -226,6 +226,7 @@ export function watchEvent<
               filter = (await getAction(
                 client,
                 createEventFilter as any,
+                'createEventFilter',
               )({
                 address,
                 args,
@@ -245,13 +246,21 @@ export function watchEvent<
           try {
             let logs: Log[]
             if (filter) {
-              logs = await getAction(client, getFilterChanges)({ filter })
+              logs = await getAction(
+                client,
+                getFilterChanges,
+                'getFilterChanges',
+              )({ filter })
             } else {
               // If the filter doesn't exist, we will fall back to use `getLogs`.
               // The fall back exists because some RPC Providers do not support filters.
 
               // Fetch the block number to use for `getLogs`.
-              const blockNumber = await getAction(client, getBlockNumber)({})
+              const blockNumber = await getAction(
+                client,
+                getBlockNumber,
+                'getBlockNumber',
+              )({})
 
               // If the block number has changed, we will need to fetch the logs.
               // If the block number doesn't exist, we are yet to reach the first poll interval,
@@ -260,6 +269,7 @@ export function watchEvent<
                 logs = await getAction(
                   client,
                   getLogs,
+                  'getLogs',
                 )({
                   address,
                   args,
@@ -292,7 +302,12 @@ export function watchEvent<
       )
 
       return async () => {
-        if (filter) await getAction(client, uninstallFilter)({ filter })
+        if (filter)
+          await getAction(
+            client,
+            uninstallFilter,
+            'uninstallFilter',
+          )({ filter })
         unwatch()
       }
     })

--- a/src/actions/public/watchPendingTransactions.ts
+++ b/src/actions/public/watchPendingTransactions.ts
@@ -129,6 +129,7 @@ export function watchPendingTransactions<
                 filter = await getAction(
                   client,
                   createPendingTransactionFilter,
+                  'createPendingTransactionFilter',
                 )({})
                 return
               } catch (err) {
@@ -137,7 +138,11 @@ export function watchPendingTransactions<
               }
             }
 
-            const hashes = await getAction(client, getFilterChanges)({ filter })
+            const hashes = await getAction(
+              client,
+              getFilterChanges,
+              'getFilterChanges',
+            )({ filter })
             if (hashes.length === 0) return
             if (batch) emit.onTransactions(hashes)
             else for (const hash of hashes) emit.onTransactions([hash])
@@ -152,7 +157,12 @@ export function watchPendingTransactions<
       )
 
       return async () => {
-        if (filter) await getAction(client, uninstallFilter)({ filter })
+        if (filter)
+          await getAction(
+            client,
+            uninstallFilter,
+            'uninstallFilter',
+          )({ filter })
         unwatch()
       }
     })

--- a/src/actions/wallet/prepareTransactionRequest.ts
+++ b/src/actions/wallet/prepareTransactionRequest.ts
@@ -130,7 +130,11 @@ export async function prepareTransactionRequest<
   if (!account_) throw new AccountNotFoundError()
   const account = parseAccount(account_)
 
-  const block = await getAction(client, getBlock)({ blockTag: 'latest' })
+  const block = await getAction(
+    client,
+    getBlock,
+    'getBlock',
+  )({ blockTag: 'latest' })
 
   const request = { ...args, from: account.address }
 
@@ -138,6 +142,7 @@ export async function prepareTransactionRequest<
     request.nonce = await getAction(
       client,
       getTransactionCount,
+      'getTransactionCount',
     )({
       address: account.address,
       blockTag: 'pending',
@@ -196,6 +201,7 @@ export async function prepareTransactionRequest<
     request.gas = await getAction(
       client,
       estimateGas,
+      'estimateGas',
     )({
       ...request,
       account: { address: account.address, type: 'json-rpc' },

--- a/src/actions/wallet/sendTransaction.ts
+++ b/src/actions/wallet/sendTransaction.ts
@@ -155,7 +155,7 @@ export async function sendTransaction<
 
     let chainId
     if (chain !== null) {
-      chainId = await getAction(client, getChainId)({})
+      chainId = await getAction(client, getChainId, 'getChainId')({})
       assertCurrentChain({
         currentChainId: chainId,
         chain,
@@ -167,6 +167,7 @@ export async function sendTransaction<
       const request = await getAction(
         client,
         prepareTransactionRequest,
+        'prepareTransactionRequest',
       )({
         account,
         accessList,
@@ -182,7 +183,8 @@ export async function sendTransaction<
         ...rest,
       } as any)
 
-      if (!chainId) chainId = await getAction(client, getChainId)({})
+      if (!chainId)
+        chainId = await getAction(client, getChainId, 'getChainId')({})
 
       const serializer = chain?.serializers?.transaction
       const serializedTransaction = (await account.signTransaction(
@@ -195,6 +197,7 @@ export async function sendTransaction<
       return await getAction(
         client,
         sendRawTransaction,
+        'sendRawTransaction',
       )({
         serializedTransaction,
       })

--- a/src/actions/wallet/signTransaction.ts
+++ b/src/actions/wallet/signTransaction.ts
@@ -128,7 +128,7 @@ export async function signTransaction<
     ...args,
   })
 
-  const chainId = await getAction(client, getChainId)({})
+  const chainId = await getAction(client, getChainId, 'getChainId')({})
   if (chain !== null)
     assertCurrentChain({
       currentChainId: chainId,

--- a/src/actions/wallet/writeContract.ts
+++ b/src/actions/wallet/writeContract.ts
@@ -138,6 +138,7 @@ export async function writeContract<
   const hash = await getAction(
     client,
     sendTransaction,
+    'sendTransaction',
   )({
     data: `${data}${dataSuffix ? dataSuffix.replace('0x', '') : ''}`,
     to: address,

--- a/src/utils/getAction.test.ts
+++ b/src/utils/getAction.test.ts
@@ -11,7 +11,7 @@ import { getAction } from './getAction.js'
 test('uses tree-shakable action', async () => {
   const client = createClient({ chain: anvilChain, transport: http() })
   const actionSpy = vi.spyOn(getChainId, 'getChainId')
-  await getAction(client, getChainId.getChainId)({})
+  await getAction(client, getChainId.getChainId, 'getChainId')({})
   expect(actionSpy).toBeCalledWith(client, {})
 })
 
@@ -24,7 +24,7 @@ test('uses client action', async () => {
     }),
   )
   const clientSpy = vi.spyOn(client, 'getChainId')
-  await getAction(client, getChainId.getChainId)({})
+  await getAction(client, getChainId.getChainId, 'getChainId')({})
   expect(clientSpy).toBeCalledWith({})
 })
 

--- a/src/utils/getAction.ts
+++ b/src/utils/getAction.ts
@@ -1,13 +1,23 @@
 import type { Client } from '../clients/createClient.js'
 
+/**
+ * Retrieves and returns an action from the client (if exists), and falls
+ * back to the tree-shakable action.
+ *
+ * Useful for extracting overridden actions from a client (ie. if a consumer
+ * wants to override the `sendTransaction` implementation).
+ */
 export function getAction<params extends {}, returnType extends {}>(
   client: Client,
   action: (_: any, params: params) => returnType,
+  // Some minifiers drop `Function.prototype.name`, meaning that `action.name`
+  // will not work. For that case, the consumer needs to pass the name explicitly.
+  name: string,
 ) {
   return (params: params): returnType =>
     (
       client as Client & {
         [key: string]: (params: params) => returnType
       }
-    )[action.name]?.(params) ?? action(client, params)
+    )[action.name || name]?.(params) ?? action(client, params)
 }


### PR DESCRIPTION
Fixes #1502.

Fixed an issue where some consumer minifiers (ie. Terser, SWC) would drop Function.prototype.name causing client action overrides to be ignored.

<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary

- This PR introduces a new utility function `getAction` that retrieves an action from the client or falls back to the tree-shakable action.
- The `getAction` function accepts an explicit `name` parameter to handle cases where minifiers drop `Function.prototype.name`.
- The `getAction` function is used to replace direct calls to client actions in various files.
- The PR also includes other changes such as adding missing imports, fixing typos, and updating function calls with the appropriate arguments.

> The following files were skipped due to too many changes: `src/actions/public/watchEvent.ts`, `src/actions/public/watchContractEvent.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->