### PR TITLE
Patch ccipFetch method when URL includes {sender}

### DIFF
--- a/.changeset/slow-chicken-leave.md
+++ b/.changeset/slow-chicken-leave.md
@@ -2,4 +2,4 @@
 "viem": patch
 ---
 
-Patch ccipFetch method when URL includes {sender}
+Patched `ccipFetch` method to use POST by default when URL includes `{sender}`.

--- a/.changeset/slow-chicken-leave.md
+++ b/.changeset/slow-chicken-leave.md
@@ -1,0 +1,5 @@
+---
+"viem": patch
+---
+
+Patch ccipFetch method when URL includes {sender}

--- a/src/utils/ccip.ts
+++ b/src/utils/ccip.ts
@@ -116,8 +116,7 @@ export async function ccipFetch({
 
   for (let i = 0; i < urls.length; i++) {
     const url = urls[i]
-    const method =
-      url.includes('{sender}') || url.includes('{data}') ? 'GET' : 'POST'
+    const method = url.includes('{data}') ? 'GET' : 'POST'
     const body = method === 'POST' ? { data, sender } : undefined
 
     try {


### PR DESCRIPTION
As specified in [EIP-3668 # Gateway Interface](https://eips.ethereum.org/EIPS/eip-3668#gateway-interface), if the URL template contains the {data} substitution parameter, the client MUST send a GET request after replacing the substitution parameters.

![image](https://github.com/wagmi-dev/viem/assets/10339043/359de208-9cc6-46de-be1d-5fc05140c59d)

This should not however include the `{sender}` parameter as its safe to use in `POST` requests (see example below)

![image](https://github.com/wagmi-dev/viem/assets/10339043/e9dfa4f5-bbe6-410e-8a8d-6babd1f7a974)

This PR updates the `ccipFetch` method such that URLs with `{sender}` execute as `POST` instead of `GET` in accordance with spec.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of the PR:
The focus of this PR is to patch the `ccipFetch` method in order to use POST by default when the URL includes `{sender}`.

### Detailed summary:
- Patched the `ccipFetch` method in `ccip.ts` to use POST by default when the URL includes `{sender}`.
- Updated the logic in the `for` loop in `ccip.ts` to determine the method based on whether the URL includes `{data}` or not.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->