### PR TITLE
docs: fix example for decodeEventLog strict param

### DIFF
--- a/site/docs/contract/decodeEventLog.md
+++ b/site/docs/contract/decodeEventLog.md
@@ -221,7 +221,7 @@ If `false`, `decodeEventLog` will try and [partially decode](#partial-decode).
 ```ts
 const topics = decodeEventLog({
   abi: wagmiAbi,
-  eventName: 'Transfer', // [!code focus]
+  strict: false, // [!code focus]
   topics: [
     '0x406dade31f7ae4b5dbc276258c28dde5ae6d5c2773c5745802c493a2360e55e0', 
     '0x00000000000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266', 


### PR DESCRIPTION
Fixes the code example for the `decodeEventLog` `strict` param in the docs. Previously it was copied and pasted from the `eventName` param.

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- The focus of this PR is to add a new parameter `strict` to the `decodeEventLog` function in the `decodeEventLog.md` file.
- The notable changes include:
  - Adding the `strict` parameter with a value of `false` to the `decodeEventLog` function call.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->